### PR TITLE
fix(assistant-ui): prevent gray screen during transient runtime errors

### DIFF
--- a/src/components/assistant-ui/SafeAssistantRuntimeProvider.tsx
+++ b/src/components/assistant-ui/SafeAssistantRuntimeProvider.tsx
@@ -12,12 +12,13 @@ interface Props {
 
 interface State {
     hasError: boolean;
+    remountKey: number;
 }
 
 export class SafeAssistantRuntimeProvider extends Component<Props, State> {
     constructor(props: Props) {
         super(props);
-        this.state = { hasError: false };
+        this.state = { hasError: false, remountKey: 0 };
     }
 
     static getDerivedStateFromError(error: unknown) {
@@ -30,11 +31,14 @@ export class SafeAssistantRuntimeProvider extends Component<Props, State> {
 
         if (errorMessage.includes("tapLookupResources") || errorMessage.includes("Resource not found")) {
             console.warn("[SafeAssistantRuntimeProvider] Caught transient runtime error, attempting graceful recovery:", error);
-            // Attempt to recover by resetting error state after a short delay
-            // This allows the tree to re-mount, hopefully after the race condition passes
+            // Attempt to recover by resetting error state and incrementing remount key after a short delay
+            // This allows the tree to re-mount with a fresh key, hopefully after the race condition passes
             setTimeout(() => {
                 if (this.state.hasError) {
-                    this.setState({ hasError: false });
+                    this.setState({ 
+                        hasError: false,
+                        remountKey: this.state.remountKey + 1
+                    });
                 }
             }, 50);
         } else {
@@ -45,19 +49,27 @@ export class SafeAssistantRuntimeProvider extends Component<Props, State> {
     componentDidUpdate(prevProps: Props) {
         // If runtime changed, try to recover from error state
         if (prevProps.runtime !== this.props.runtime && this.state.hasError) {
-            this.setState({ hasError: false });
+            this.setState({ 
+                hasError: false,
+                remountKey: this.state.remountKey + 1
+            });
         }
     }
 
     render() {
+        // During error state, render children without AssistantRuntimeProvider to avoid gray screen
+        // Assistant features will be temporarily unavailable, but UI remains visible
         if (this.state.hasError) {
-            // Return null to unmount the failed tree.
-            // The componentDidCatch timeout will trigger a re-mount.
-            return null;
+            return <>{this.props.children}</>;
         }
 
+        // Use remountKey to force complete remount of AssistantRuntimeProvider on recovery
+        // This ensures a clean state after error recovery
         return (
-            <AssistantRuntimeProvider runtime={this.props.runtime}>
+            <AssistantRuntimeProvider 
+                key={this.state.remountKey}
+                runtime={this.props.runtime}
+            >
                 {this.props.children}
             </AssistantRuntimeProvider>
         );


### PR DESCRIPTION
- Render children without AssistantRuntimeProvider during error state to keep UI visible
- Add remount key mechanism to force clean remount after recovery
- Maintain UI visibility while assistant features temporarily unavailable
- Auto-recover after 50ms delay or when runtime prop changes