### PR TITLE
fix: open panel when viewing create note tool ui

### DIFF
--- a/src/components/assistant-ui/CreateNoteToolUI.tsx
+++ b/src/components/assistant-ui/CreateNoteToolUI.tsx
@@ -76,6 +76,7 @@ const CreateNoteReceipt = ({
   const workspaceId = useWorkspaceStore((state) => state.currentWorkspaceId);
   const { state: workspaceState } = useWorkspaceState(workspaceId);
   const navigateToItem = useNavigateToItem();
+  const setOpenModalItemId = useUIStore((state) => state.setOpenModalItemId);
 
   // State for MoveToDialog
   const [showMoveDialog, setShowMoveDialog] = useState(false);
@@ -107,6 +108,8 @@ const CreateNoteReceipt = ({
   const handleViewCard = () => {
     if (!result.itemId) return;
     navigateToItem(result.itemId);
+    // Open the panel in addition to scrolling
+    setOpenModalItemId(result.itemId);
   };
 
   const handleMoveToFolder = (folderId: string | null) => {


### PR DESCRIPTION
Fixes #70 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> In `CreateNoteToolUI.tsx`, `handleViewCard` now opens the panel when viewing a created note or flashcard by calling `setOpenModalItemId`.
> 
>   - **Behavior**:
>     - In `CreateNoteToolUI.tsx`, `handleViewCard` now calls `setOpenModalItemId` with `result.itemId` to open the panel when viewing a created note or flashcard.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ThinkEx-OSS%2Fthinkex&utm_source=github&utm_medium=referral)<sup> for f0fbcc071aec58f8a99fe47ddd90af660cba5cf5. You can [customize](https://app.ellipsis.dev/ThinkEx-OSS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notes now automatically open in a modal panel when viewed, enabling simultaneous navigation and content display for an improved viewing experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->