### PR TITLE
fix: add scroll lock/unlock button to flashcard hover menu

### DIFF
--- a/src/components/workspace-canvas/FlashcardWorkspaceCard.tsx
+++ b/src/components/workspace-canvas/FlashcardWorkspaceCard.tsx
@@ -110,18 +110,22 @@ const FlashcardSideContent = memo(function FlashcardSideContent({
     return (
         <div
             ref={scrollContainerRef}
-            className={`workspace-card-readonly-editor size-full min-h-0 ${isScrollLocked ? 'overflow-hidden' : 'overflow-y-auto overflow-x-hidden'} ${className}`}
+            className={`workspace-card-readonly-editor size-full min-h-0 ${isScrollLocked ? 'overflow-hidden' : 'overflow-auto'} ${className}`}
             style={{
                 // Ensure white text cascades to BlockNote default styles where possible
                 color: 'white',
                 // Explicitly contain scroll chaining
                 overscrollBehaviorY: 'contain',
+                overscrollBehaviorX: 'contain',
                 // Center text within the flashcard
                 textAlign: 'center',
                 // Match ItemHeader note card title styling: text-base (1rem) font-medium (500)
                 fontSize: '1rem',
                 fontWeight: 500,
-                padding: '1rem',
+                paddingTop: '1.5rem',
+                paddingBottom: '1.5rem',
+                paddingLeft: '1.5rem',
+                paddingRight: '1.5rem',
                 // Text rendering optimization - NO transforms here to avoid 3D context conflicts
                 WebkitFontSmoothing: 'antialiased',
                 MozOsxFontSmoothing: 'grayscale' as any,
@@ -137,8 +141,8 @@ const FlashcardSideContent = memo(function FlashcardSideContent({
                 }
             }}
         >
-            <div className="size-full flex flex-col justify-center items-center px-6">
-                <div className="w-full">
+            <div className={`flex flex-col items-center min-w-0 w-full ${isScrollLocked ? 'justify-center min-h-full' : ''}`}>
+                <div className="w-full max-w-full min-w-0">
                     {displayContent.map((block, index) => (
                         <PreviewBlock
                             key={block.id || index}


### PR DESCRIPTION
Fixes #62 
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a scroll lock/unlock button to the flashcard hover menu in `FlashcardWorkspaceCard.tsx`, allowing users to toggle scroll behavior with visual feedback.
> 
>   - **Behavior**:
>     - Adds a scroll lock/unlock button to the flashcard hover menu in `FlashcardWorkspaceCard.tsx`.
>     - Button toggles scroll lock state using `toggleItemScrollLocked` from Zustand store.
>     - Button appearance changes based on `isScrollLocked` state.
>   - **UI Changes**:
>     - Updates `FlashcardSideContent` to handle `overflow-auto` when scroll is unlocked.
>     - Adjusts padding in `FlashcardSideContent` for better layout.
>   - **Icons**:
>     - Uses `PiMouseScrollFill` and `PiMouseScrollBold` from `react-icons/pi` for button icons.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ThinkEx-OSS%2Fthinkex&utm_source=github&utm_medium=referral)<sup> for 05b3f982d0cee8f0d6548dfd99d1afb30ad1c04c. You can [customize](https://app.ellipsis.dev/ThinkEx-OSS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->