### PR TITLE
fix: focus composer input after dropdown/dialog interactions; create shared util

### DIFF
--- a/src/components/assistant-ui/AssistantTextSelectionManager.tsx
+++ b/src/components/assistant-ui/AssistantTextSelectionManager.tsx
@@ -5,6 +5,7 @@ import { X, FileText, Highlighter, CheckIcon, Plus } from "lucide-react";
 import { FaQuoteRight } from "react-icons/fa6";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { focusComposerInput } from "@/lib/utils/composer-utils";
 import { HighlightTooltip, TooltipAction } from "@/components/ui/highlight-tooltip";
 import SelectableText, {
   TextHighlight,
@@ -551,12 +552,7 @@ export default function AssistantTextSelectionManager({
     setTooltipVisible(false);
 
     // Focus the composer input after adding reply
-    setTimeout(() => {
-      const composerInput = document.querySelector('.aui-composer-input') as HTMLTextAreaElement | null;
-      if (composerInput) {
-        composerInput.focus();
-      }
-    }, 100);
+    focusComposerInput();
   }, [currentSelection, inMultiMode, highlights, addReplySelection, extractMessageContext, extractUserPrompt, exitMultiSelectMode, setTooltipVisible, removeMarkerElement]);
 
   // Handle trash/negative feedback action - opens dialog

--- a/src/components/assistant-ui/attachment.tsx
+++ b/src/components/assistant-ui/attachment.tsx
@@ -41,6 +41,7 @@ import { cn } from "@/lib/utils";
 import { createUrlFile } from "@/lib/attachments/url-utils";
 import { useUIStore } from "@/lib/stores/ui-store";
 import { FaCheck } from "react-icons/fa";
+import { focusComposerInput } from "@/lib/utils/composer-utils";
 
 const useFileSrc = (file: File | undefined) => {
   const [src, setSrc] = useState<string | undefined>(undefined);
@@ -537,6 +538,7 @@ export const ComposerAddAttachment: FC = () => {
         api.composer().addAttachment(urlFile);
         setUrlInput("");
         setShowUrlDialog(false);
+        focusComposerInput();
       } catch (error) {
         console.error("Failed to add URL attachment:", error);
       }
@@ -549,7 +551,12 @@ export const ComposerAddAttachment: FC = () => {
         ref={containerRef}
         className="relative flex items-center gap-2 pt-6 pb-6 pl-6 pr-10 -mt-6 -mb-6 -ml-6 -mr-10 pointer-events-none"
       >
-        <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen} modal={false}>
+        <DropdownMenu open={isDropdownOpen} onOpenChange={(open) => {
+          setIsDropdownOpen(open);
+          if (!open) {
+            focusComposerInput();
+          }
+        }} modal={false}>
           <div className="flex items-center gap-2 pointer-events-auto">
             <DropdownMenuTrigger asChild>
               <button
@@ -594,7 +601,12 @@ export const ComposerAddAttachment: FC = () => {
       </div>
 
       {/* URL Input Dialog */}
-      <Dialog open={showUrlDialog} onOpenChange={setShowUrlDialog}>
+      <Dialog open={showUrlDialog} onOpenChange={(open) => {
+        setShowUrlDialog(open);
+        if (!open) {
+          focusComposerInput();
+        }
+      }}>
         <DialogContent className="sm:max-w-md">
           <DialogTitle>Add URL</DialogTitle>
           <form onSubmit={handleUrlSubmit} className="space-y-4">

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -93,6 +93,7 @@ import { extractUrls, createUrlFile } from "@/lib/attachments/url-utils";
 import { filterItems } from "@/lib/workspace-state/search";
 import { useSession } from "@/lib/auth-client";
 import { formatSelectedCardsContext } from "@/lib/utils/format-workspace-context";
+import { focusComposerInput } from "@/lib/utils/composer-utils";
 import {
   ModelSelector,
   ModelSelectorTrigger,
@@ -781,12 +782,7 @@ const ComposerAction: FC<ComposerActionProps> = ({ items }) => {
     item?.onClick?.();
 
     // Focus the composer input after action selection
-    setTimeout(() => {
-      const composerInput = document.querySelector('.aui-composer-input') as HTMLTextAreaElement | null;
-      if (composerInput) {
-        composerInput.focus();
-      }
-    }, 100);
+    focusComposerInput();
   };
 
   const isActionSelected = (itemId: string) => selectedIds.includes(itemId);
@@ -802,7 +798,11 @@ const ComposerAction: FC<ComposerActionProps> = ({ items }) => {
           <ComposerAddAttachment />
         </div>
         {/* Actions Button */}
-        <DropdownMenu>
+        <DropdownMenu onOpenChange={(open) => {
+          if (!open) {
+            focusComposerInput();
+          }
+        }}>
           <DropdownMenuTrigger asChild>
             <button
               type="button"
@@ -843,7 +843,12 @@ const ComposerAction: FC<ComposerActionProps> = ({ items }) => {
           </DropdownMenuContent>
         </DropdownMenu>
         {/* Model Selector Button */}
-        <ModelSelector open={isModelSelectorOpen} onOpenChange={setIsModelSelectorOpen}>
+        <ModelSelector open={isModelSelectorOpen} onOpenChange={(open) => {
+          setIsModelSelectorOpen(open);
+          if (!open) {
+            focusComposerInput();
+          }
+        }}>
           <ModelSelectorTrigger asChild>
             <button
               type="button"
@@ -882,7 +887,12 @@ const ComposerAction: FC<ComposerActionProps> = ({ items }) => {
         {/* Warning icon for anonymous users */}
         {isAnonymous && (
 
-          <Popover open={isWarningPopoverOpen} onOpenChange={setIsWarningPopoverOpen}>
+          <Popover open={isWarningPopoverOpen} onOpenChange={(open) => {
+            setIsWarningPopoverOpen(open);
+            if (!open) {
+              focusComposerInput();
+            }
+          }}>
             <PopoverTrigger asChild>
               <button
                 type="button"

--- a/src/lib/utils/composer-utils.ts
+++ b/src/lib/utils/composer-utils.ts
@@ -1,0 +1,12 @@
+/**
+ * Focuses the composer input field.
+ * Uses the existing pattern with a timeout to ensure the DOM is ready.
+ */
+export function focusComposerInput(): void {
+  setTimeout(() => {
+    const composerInput = document.querySelector('.aui-composer-input') as HTMLTextAreaElement | null;
+    if (composerInput) {
+      composerInput.focus();
+    }
+  }, 100);
+}


### PR DESCRIPTION
Fixes #77 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces `focusComposerInput()` utility to standardize focusing the composer input across components.
> 
>   - **Behavior**:
>     - Introduces `focusComposerInput()` in `composer-utils.ts` to focus the composer input field with a delay.
>     - Replaces inline focus logic with `focusComposerInput()` in `AssistantTextSelectionManager.tsx`, `attachment.tsx`, and `thread.tsx`.
>   - **Files**:
>     - `AssistantTextSelectionManager.tsx`: Replaces inline focus logic after adding reply.
>     - `attachment.tsx`: Uses `focusComposerInput()` after adding URL attachment and closing dropdown.
>     - `thread.tsx`: Utilizes `focusComposerInput()` after action selection and closing dropdowns/dialogs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ThinkEx-OSS%2Fthinkex&utm_source=github&utm_medium=referral)<sup> for fdbeef704d08c1afa5b2ea7ebaa6b5ff0125228e. You can [customize](https://app.ellipsis.dev/ThinkEx-OSS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Composer input now automatically regains focus after interactions such as attaching files, selecting models, and closing dialogs, streamlining your workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->