### PR TITLE
feat: apply note card resize logic to PDF cards

### DIFF
--- a/src/components/workspace-canvas/WorkspaceGrid.tsx
+++ b/src/components/workspace-canvas/WorkspaceGrid.tsx
@@ -404,20 +404,22 @@ export function WorkspaceGrid({
         if (newItem.w === 4) newItem.h = 10;
         else if (newItem.w === 3) newItem.h = 8;
         else if (newItem.w === 2) newItem.h = 5;
-      } else if (itemData.type === 'folder' || itemData.type === 'pdf' || itemData.type === 'flashcard') {
-        // Folders, PDFs, and flashcards don't need minimum height enforcement - skip
-      } else if (currentBreakpointRef.current !== 'xxs') {
-        // Note cards: handle transitions between compact and expanded modes
-        // Compact mode: w=1, h=4 | Expanded mode: w>=2, h>=9
+      } else if (itemData.type === 'folder' || itemData.type === 'flashcard') {
+        // Folders and flashcards don't need minimum height enforcement - skip
+      } else if (currentBreakpointRef.current !== 'xxs' && (itemData.type === 'note' || itemData.type === 'pdf')) {
+        // Note and PDF cards: handle transitions between compact and expanded modes
+        // Note cards: Compact mode: w=1, h=4 | Expanded mode: w>=2, h>=9
+        // PDF cards: Compact mode: w=1, h=4 | Expanded mode: w>=2, h>=6
         const wasCompact = oldItem.w === 1;
         const widthChanged = oldItem.w !== newItem.w;
+        const minExpandedHeight = itemData.type === 'pdf' ? 6 : 9;
 
         // Check for mode transitions triggered by height-only resize
         if (!widthChanged) {
           if (wasCompact && newItem.h > 4) {
             // Growing a compact card taller → expand to wide mode
             newItem.w = 2;
-          } else if (!wasCompact && newItem.h < 9) {
+          } else if (!wasCompact && newItem.h < minExpandedHeight) {
             // Shrinking a wide card shorter → collapse to compact mode
             newItem.w = 1;
           }
@@ -425,7 +427,7 @@ export function WorkspaceGrid({
 
         // Apply constraints based on final width
         if (newItem.w >= 2) {
-          newItem.h = Math.max(newItem.h, 9);
+          newItem.h = Math.max(newItem.h, minExpandedHeight);
         } else {
           newItem.h = 4;
         }


### PR DESCRIPTION
Closes #92
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Apply note card resize logic to PDF cards in `WorkspaceGrid`, adjusting height constraints and mode transitions.
> 
>   - **Behavior**:
>     - Apply note card resize logic to PDF cards in `WorkspaceGrid`.
>     - PDF cards now have compact mode (w=1, h=4) and expanded mode (w>=2, h>=6).
>     - Adjusts height constraints and mode transitions for PDF cards during resizing.
>   - **Code Changes**:
>     - Modify `handleResize` in `WorkspaceGrid.tsx` to include PDF cards in resize logic.
>     - Introduce `minExpandedHeight` for PDF cards set to 6.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ThinkEx-OSS%2Fthinkex&utm_source=github&utm_medium=referral)<sup> for 0fc2250c167d8bda14d30d3130ca6671657b8d08. You can [customize](https://app.ellipsis.dev/ThinkEx-OSS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined resize handling for workspace cards with type-specific minimum height enforcement for note and PDF items.
  * Improved transitions between compact and expanded states, with cards now respecting type-specific minimum dimensions during resizing.
  * Enhanced height constraint logic to apply appropriately based on card type during expand and collapse operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->