### PR TITLE
Latex issue dollar signs

### DIFF
--- a/src/components/assistant-ui/markdown-text.tsx
+++ b/src/components/assistant-ui/markdown-text.tsx
@@ -153,15 +153,14 @@ function normalizeCustomMathTags(input: string): string {
       (_, content) => `$$\n${content.trim()}\n$$`
     )
     // Convert single $ ... $ to $$...$$ (inline math), but avoid currency like $10 or $5.50
-    // We use (^|[^\$]) to ensure it's not preceded by match (ignoring $$)
-    // and (?!\$) to ensure it's not followed by $ (ignoring $$)
-    .replace(/(^|[^\$])\$([^\$\n]+?)\$(?!\$)/g, (match, prefix, content) => {
-      // If content is purely numeric (with optional commas/periods), treat as currency
-      if (/^[\d,\.]+$/.test(content.trim())) {
+    // Use lookbehind to avoid consuming characters and handle consecutive expressions
+    // Exclude escaped dollar signs (prefixed with \)
+    .replace(/(?<!\\)(?<!\$)\$(?!\$)([^$\n]+?)(?<!\\)(?<!\$)\$(?!\$)/g, (match, content) => {
+      // More precise currency pattern: matches numbers like 10, 1,000, 10.50, 1,000.50
+      if (/^\d{1,3}(?:,\d{3})*(?:\.\d{1,2})?$/.test(content.trim())) {
         return match; // Keep as-is (currency)
       }
-      // Otherwise, convert to math.
-      // prefix is the character before the first $ (or empty string)
-      return `${prefix}$$${content.trim()}$$`;
+      // Otherwise, convert to math
+      return `$$${content.trim()}$$`;
     }));
 }

--- a/src/components/assistant-ui/standalone-markdown.tsx
+++ b/src/components/assistant-ui/standalone-markdown.tsx
@@ -61,21 +61,14 @@ function normalizeCustomMathTags(input: string): string {
     input
       // Convert [/math]...[/math] to $$...$$ (legacy block math format)
       .replace(/\[\/math\]([\s\S]*?)\[\/math\]/g, (_, content) => `$$${content.trim()}$$`)
-      // Convert [/inline]...[/inline] to $$...$$ (legacy inline format - Streamdown uses $$ for all)
-      .replace(/\[\/inline\]([\s\S]*?)\[\/inline\]/g, (_, content) => `$$${content.trim()}$$`)
-      // Convert \( ... \) to $$...$$ (LaTeX inline math - Streamdown uses $$ for all)
-      .replace(/\\{1,2}\(([\s\S]*?)\\{1,2}\)/g, (_, content) => `$$${content.trim()}$$`)
+      // Convert [/inline]...[/inline] to $...$ (legacy inline format - ReactMarkdown uses $ for inline)
+      .replace(/\[\/inline\]([\s\S]*?)\[\/inline\]/g, (_, content) => `$${content.trim()}$`)
+      // Convert \( ... \) to $...$ (LaTeX inline math - ReactMarkdown uses $ for inline)
+      .replace(/\\{1,2}\(([\s\S]*?)\\{1,2}\)/g, (_, content) => `$${content.trim()}$`)
       // Convert \[ ... \] to $$...$$ (LaTeX block math)
       .replace(/\\{1,2}\[([\s\S]*?)\\{1,2}\]/g, (_, content) => `$$${content.trim()}$$`)
-      // Convert single $ ... $ to $$...$$ (inline math), but avoid currency like $10 or $5.50
-      .replace(/(^|[^\$])\$([^\$\n]+?)\$(?!\$)/g, (match, prefix, content) => {
-        // If content is purely numeric (with optional commas/periods), treat as currency
-        if (/^[\d,\.]+$/.test(content.trim())) {
-          return match; // Keep as-is (currency)
-        }
-        // Otherwise, convert to math
-        return `${prefix}$$${content.trim()}$$`;
-      })
+      // Note: We DON'T convert $...$ to $$ here because ReactMarkdown with remark-math expects
+      // single dollar signs for inline math and double dollar signs for block math
   );
 }
 

--- a/src/components/workspace-canvas/QuizContent.tsx
+++ b/src/components/workspace-canvas/QuizContent.tsx
@@ -299,11 +299,11 @@ export function QuizContent({ item, onUpdateData, isScrollLocked = false }: Quiz
                                     )}>
                                         {String.fromCharCode(65 + index)}
                                     </span>
-                                    <span className="text-sm text-white/90 flex-1 prose prose-invert prose-sm max-w-none">
+                                    <div className="text-sm text-white/90 flex-1 prose prose-invert prose-sm max-w-none">
                                         <ReactMarkdown remarkPlugins={[remarkMath]} rehypePlugins={[rehypeKatex]}>
                                             {option}
                                         </ReactMarkdown>
-                                    </span>
+                                    </div>
                                     {showCorrectness && isCorrect && <CheckCircle2 className="w-5 h-5 text-green-400" />}
                                     {showCorrectness && isSelected && !isCorrect && <XCircle className="w-5 h-5 text-red-400" />}
                                 </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improved LaTeX math expression handling in markdown content, ensuring correct rendering and differentiation from currency values in `markdown-text.tsx`, `standalone-markdown.tsx`, and `QuizContent.tsx`.
> 
>   - **Behavior**:
>     - Enhanced inline math notation processing in `normalizeCustomMathTags()` in `markdown-text.tsx` and `standalone-markdown.tsx` to avoid converting currency values like `$10` to math expressions.
>     - Updated `QuizContent.tsx` to render quiz options and questions using `ReactMarkdown` with `remarkMath` and `rehypeKatex` for LaTeX support.
>   - **Components**:
>     - `normalizeCustomMathTags()` in `markdown-text.tsx` and `standalone-markdown.tsx` now uses regex to differentiate between math expressions and currency.
>     - `QuizContent.tsx` now supports rich markdown formatting for quiz questions and options, including mathematical expressions.
>   - **Misc**:
>     - Added `remarkMath` and `rehypeKatex` plugins to `ReactMarkdown` in `QuizContent.tsx` for LaTeX rendering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ThinkEx-OSS%2Fthinkex&utm_source=github&utm_medium=referral)<sup> for 047d18f2270d977f7bae74973fed20ec92c331e1. You can [customize](https://app.ellipsis.dev/ThinkEx-OSS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quiz options now render rich Markdown with math support, allowing inline LaTeX and formatted content in choices.

* **Improvements**
  * Inline math handling normalized for consistent rendering; block math remains as block delimiters.
  * Currency-like expressions are preserved and not treated as math to avoid false conversions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->