### PR TITLE
fix: preserve workspaces when linking anonymous account

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -126,6 +126,8 @@ export const auth = betterAuth({
                   .update(workspaces)
                   .set({ slug: newSlug })
                   .where(eq(workspaces.id, workspace.id));
+
+                existingSlugs.add(newSlug);
               }
             }
 


### PR DESCRIPTION
Fixes #147 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes account linking to transfer workspaces and handle slug conflicts when connecting an anonymous account to an existing account in `src/lib/auth.ts`.
> 
>   - **Bug Fix**:
>     - In `src/lib/auth.ts`, fixed account linking to transfer workspaces when connecting an anonymous account to an existing account.
>     - Handles slug conflicts by renaming conflicting slugs with a counter.
>     - Migrates workspaces and workspace events to the new user ID.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ThinkEx-OSS%2Fthinkex&utm_source=github&utm_medium=referral)<sup> for bacec7d0bde1fe3da5703889e6e61cc16f5abae6. You can [customize](https://app.ellipsis.dev/ThinkEx-OSS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed account linking to transfer workspaces and associated events from anonymous to existing accounts.
  * Avoided name/slug collisions by automatically renaming conflicting anonymous workspaces with numeric suffixes.
  * Migration errors are now logged but won’t interrupt the account-linking process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->