### PR TITLE
feat: add Open Graph metadata for share links; show Shared Workspace …

### DIFF
--- a/src/app/invite/link/[token]/layout.tsx
+++ b/src/app/invite/link/[token]/layout.tsx
@@ -1,0 +1,90 @@
+import { Metadata } from "next";
+import { db } from "@/lib/db/client";
+import { workspaceShareLinks, workspaces } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import { seoConfig, getPageTitle, getFullImageUrl } from "@/lib/seo-config";
+
+type Props = {
+    params: Promise<{ token: string }>;
+    children: React.ReactNode;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+    const { token } = await params;
+
+    const [shareLink] = await db
+        .select({
+            workspaceId: workspaceShareLinks.workspaceId,
+            expiresAt: workspaceShareLinks.expiresAt,
+            workspaceName: workspaces.name,
+        })
+        .from(workspaceShareLinks)
+        .innerJoin(workspaces, eq(workspaces.id, workspaceShareLinks.workspaceId))
+        .where(eq(workspaceShareLinks.token, token))
+        .limit(1);
+
+    if (!shareLink) {
+        const notFoundTitle = "Invite Link Not Found";
+        const notFoundDesc = "This invite link is invalid or has been removed.";
+        return {
+            title: getPageTitle(notFoundTitle),
+            description: notFoundDesc,
+            openGraph: {
+                title: getPageTitle(notFoundTitle),
+                description: notFoundDesc,
+                url: `${seoConfig.siteUrl}/invite/link/${token}`,
+                siteName: seoConfig.siteName,
+                images: [{ url: getFullImageUrl(), width: 1200, height: 630, alt: notFoundTitle }],
+                type: "website",
+            },
+            twitter: { card: "summary_large_image", title: getPageTitle(notFoundTitle), description: notFoundDesc },
+        };
+    }
+
+    if (new Date(shareLink.expiresAt) < new Date()) {
+        const expiredTitle = "Invite Link Expired";
+        const expiredDesc = "This workspace invite link has expired.";
+        return {
+            title: getPageTitle(expiredTitle),
+            description: expiredDesc,
+            openGraph: {
+                title: getPageTitle(expiredTitle),
+                description: expiredDesc,
+                url: `${seoConfig.siteUrl}/invite/link/${token}`,
+                siteName: seoConfig.siteName,
+                images: [{ url: getFullImageUrl(), width: 1200, height: 630, alt: expiredTitle }],
+                type: "website",
+            },
+            twitter: { card: "summary_large_image", title: getPageTitle(expiredTitle), description: expiredDesc },
+        };
+    }
+
+    const workspaceName = shareLink.workspaceName || "Workspace";
+    const sharedTitle = `Shared Workspace: ${workspaceName}`;
+    const description = `Join "${workspaceName}" on ThinkEx. Collaborate on notes and build knowledge together.`;
+    const fullTitle = getPageTitle(sharedTitle);
+    const url = `${seoConfig.siteUrl}/invite/link/${token}`;
+
+    return {
+        title: fullTitle,
+        description,
+        openGraph: {
+            title: fullTitle,
+            description,
+            url,
+            siteName: seoConfig.siteName,
+            images: [{ url: getFullImageUrl(), width: 1200, height: 630, alt: sharedTitle }],
+            type: "website",
+        },
+        twitter: {
+            card: "summary_large_image",
+            title: fullTitle,
+            description,
+            images: [getFullImageUrl()],
+        },
+    };
+}
+
+export default function InviteLinkLayout({ children }: { children: React.ReactNode }) {
+    return <>{children}</>;
+}


### PR DESCRIPTION
…in link previews

Made-with: Cursor
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Open Graph metadata for share links in `layout.tsx` to enhance link previews for shared workspaces.
> 
>   - **Metadata Generation**:
>     - `generateMetadata` in `layout.tsx` for `/invite/link/[token]` and `/share-copy/[id]` now includes Open Graph and Twitter metadata.
>     - Handles cases for not found, expired, and valid links with appropriate titles and descriptions.
>   - **SEO Enhancements**:
>     - Uses `getPageTitle` and `getFullImageUrl` from `seo-config` to construct metadata.
>     - Constructs URLs using `seoConfig.siteUrl` for consistency.
>   - **Misc**:
>     - Adds `InviteLinkLayout` and `ShareLayout` components to wrap children.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ThinkEx-OSS%2Fthinkex&utm_source=github&utm_medium=referral)<sup> for 0dee0bc6a5c4da5785dddf0e7eb36a8050fcb6b5. You can [customize](https://app.ellipsis.dev/ThinkEx-OSS/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic metadata generation for invite links with support for expired link detection.
  * Enhanced shared workspace previews with improved Open Graph and Twitter card metadata for better social media appearance when sharing links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->