### PR TITLE
Keyword Search MCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ bun.lockb
 # One-off / local scripts (keep on disk, not versioned)
 /scripts/
 
+
+
+.cursorrules

--- a/drizzle/0006_add_api_keys.sql
+++ b/drizzle/0006_add_api_keys.sql
@@ -1,0 +1,16 @@
+-- API keys for MCP server authentication
+CREATE TABLE "api_keys" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"key_hash" text NOT NULL,
+	"key_prefix" text NOT NULL,
+	"label" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_used_at" timestamp with time zone,
+	"revoked_at" timestamp with time zone,
+	CONSTRAINT "api_keys_key_hash_key" UNIQUE("key_hash")
+);
+--> statement-breakpoint
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "api_keys_user_id_idx" ON "api_keys" USING btree ("user_id" text_ops);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1771800001000,
       "tag": "0005_add_chat_messages_thread_message_unique",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1744156800000,
+      "tag": "0006_add_api_keys",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@ai-sdk/devtools": "^0.0.15",
     "@ai-sdk/google": "^3.0.58",
+    "@modelcontextprotocol/sdk": "^1.0.4",
     "@assistant-ui/react": "^0.12.23",
     "@assistant-ui/react-ai-sdk": "^1.3.17",
     "@assistant-ui/react-devtools": "^1.0.4",

--- a/src/app/api/mcp-keys/[id]/route.ts
+++ b/src/app/api/mcp-keys/[id]/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db/client";
+import { apiKeys } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import { requireAuth, withErrorHandling } from "@/lib/api/workspace-helpers";
+
+async function handleDELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const userId = await requireAuth();
+  const { id } = await params;
+
+  const [key] = await db
+    .select({ userId: apiKeys.userId })
+    .from(apiKeys)
+    .where(eq(apiKeys.id, id))
+    .limit(1);
+
+  if (!key) {
+    return NextResponse.json({ error: "API key not found" }, { status: 404 });
+  }
+
+  if (key.userId !== userId) {
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+  }
+
+  await db
+    .update(apiKeys)
+    .set({ revokedAt: new Date().toISOString() })
+    .where(eq(apiKeys.id, id));
+
+  return NextResponse.json({ success: true });
+}
+
+export const DELETE = withErrorHandling(handleDELETE, "DELETE /api/mcp-keys/[id]");

--- a/src/app/api/mcp-keys/route.ts
+++ b/src/app/api/mcp-keys/route.ts
@@ -2,13 +2,27 @@ import { NextResponse } from "next/server";
 import { createHash, randomBytes } from "crypto";
 import { db } from "@/lib/db/client";
 import { apiKeys } from "@/lib/db/schema";
-import { eq, and, isNull } from "drizzle-orm";
+import { eq, and, isNull, count } from "drizzle-orm";
 import { requireAuth, withErrorHandling } from "@/lib/api/workspace-helpers";
+
+const MAX_KEYS_PER_USER = 10;
 
 async function handlePOST(req: Request) {
   const userId = await requireAuth();
   const body = await req.json().catch(() => ({}));
-  const label = body?.label || null;
+  const label = typeof body?.label === "string" ? body.label.slice(0, 100) : null;
+
+  const [{ total }] = await db
+    .select({ total: count() })
+    .from(apiKeys)
+    .where(and(eq(apiKeys.userId, userId), isNull(apiKeys.revokedAt)));
+
+  if (total >= MAX_KEYS_PER_USER) {
+    return NextResponse.json(
+      { error: `You can have at most ${MAX_KEYS_PER_USER} active API keys. Revoke an existing key first.` },
+      { status: 422 }
+    );
+  }
 
   const rawKey = `tx_${randomBytes(32).toString("base64url")}`;
   const keyHash = createHash("sha256").update(rawKey).digest("hex");

--- a/src/app/api/mcp-keys/route.ts
+++ b/src/app/api/mcp-keys/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { createHash, randomBytes } from "crypto";
+import { db } from "@/lib/db/client";
+import { apiKeys } from "@/lib/db/schema";
+import { eq, and, isNull } from "drizzle-orm";
+import { requireAuth, withErrorHandling } from "@/lib/api/workspace-helpers";
+
+async function handlePOST(req: Request) {
+  const userId = await requireAuth();
+  const body = await req.json().catch(() => ({}));
+  const label = body?.label || null;
+
+  const rawKey = `tx_${randomBytes(32).toString("base64url")}`;
+  const keyHash = createHash("sha256").update(rawKey).digest("hex");
+  const keyPrefix = rawKey.substring(0, 8);
+
+  const [result] = await db
+    .insert(apiKeys)
+    .values({
+      userId,
+      keyHash,
+      keyPrefix,
+      label,
+      createdAt: new Date().toISOString(),
+      revokedAt: null,
+      lastUsedAt: null,
+    })
+    .returning({ id: apiKeys.id, prefix: apiKeys.keyPrefix });
+
+  return NextResponse.json({
+    id: result.id,
+    rawKey,
+    prefix: result.prefix,
+  });
+}
+
+async function handleGET() {
+  const userId = await requireAuth();
+
+  const keys = await db
+    .select({
+      id: apiKeys.id,
+      prefix: apiKeys.keyPrefix,
+      label: apiKeys.label,
+      createdAt: apiKeys.createdAt,
+      lastUsedAt: apiKeys.lastUsedAt,
+    })
+    .from(apiKeys)
+    .where(and(eq(apiKeys.userId, userId), isNull(apiKeys.revokedAt)))
+    .orderBy(apiKeys.createdAt);
+
+  return NextResponse.json({ keys });
+}
+
+export const POST = withErrorHandling(handlePOST, "POST /api/mcp-keys");
+export const GET = withErrorHandling(handleGET, "GET /api/mcp-keys");

--- a/src/app/api/mcp-keys/route.ts
+++ b/src/app/api/mcp-keys/route.ts
@@ -2,44 +2,70 @@ import { NextResponse } from "next/server";
 import { createHash, randomBytes } from "crypto";
 import { db } from "@/lib/db/client";
 import { apiKeys } from "@/lib/db/schema";
-import { eq, and, isNull, count } from "drizzle-orm";
+import { eq, and, isNull, count, sql } from "drizzle-orm";
 import { requireAuth, withErrorHandling } from "@/lib/api/workspace-helpers";
 
 const MAX_KEYS_PER_USER = 10;
+
+// Deterministic i64 from a userId string — used as the advisory lock key.
+// XOR-folds the SHA-256 bytes into 8 bytes so the result fits in a pg bigint.
+function userIdToLockKey(userId: string): bigint {
+  const hash = createHash("sha256").update(userId).digest();
+  let lo = 0n;
+  for (let i = 0; i < 32; i++) {
+    lo ^= BigInt(hash[i]) << BigInt((i % 8) * 8);
+  }
+  // Clamp to signed int64 range so Postgres accepts it
+  const MAX_I64 = 9223372036854775807n;
+  return lo > MAX_I64 ? lo - (MAX_I64 + 1n) * 2n : lo;
+}
 
 async function handlePOST(req: Request) {
   const userId = await requireAuth();
   const body = await req.json().catch(() => ({}));
   const label = typeof body?.label === "string" ? body.label.slice(0, 100) : null;
 
-  const [{ total }] = await db
-    .select({ total: count() })
-    .from(apiKeys)
-    .where(and(eq(apiKeys.userId, userId), isNull(apiKeys.revokedAt)));
+  const rawKey = `tx_${randomBytes(32).toString("base64url")}`;
+  const keyHash = createHash("sha256").update(rawKey).digest("hex");
+  const keyPrefix = rawKey.substring(0, 8);
+  const lockKey = userIdToLockKey(userId);
 
-  if (total >= MAX_KEYS_PER_USER) {
+  const result = await db.transaction(async (tx) => {
+    // Acquire a per-user advisory lock that is automatically released when
+    // the transaction ends, serialising concurrent key-creation requests.
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(${lockKey}::bigint)`);
+
+    const [{ total }] = await tx
+      .select({ total: count() })
+      .from(apiKeys)
+      .where(and(eq(apiKeys.userId, userId), isNull(apiKeys.revokedAt)));
+
+    if (total >= MAX_KEYS_PER_USER) {
+      return null;
+    }
+
+    const [inserted] = await tx
+      .insert(apiKeys)
+      .values({
+        userId,
+        keyHash,
+        keyPrefix,
+        label,
+        createdAt: new Date().toISOString(),
+        revokedAt: null,
+        lastUsedAt: null,
+      })
+      .returning({ id: apiKeys.id, prefix: apiKeys.keyPrefix });
+
+    return inserted;
+  });
+
+  if (!result) {
     return NextResponse.json(
       { error: `You can have at most ${MAX_KEYS_PER_USER} active API keys. Revoke an existing key first.` },
       { status: 422 }
     );
   }
-
-  const rawKey = `tx_${randomBytes(32).toString("base64url")}`;
-  const keyHash = createHash("sha256").update(rawKey).digest("hex");
-  const keyPrefix = rawKey.substring(0, 8);
-
-  const [result] = await db
-    .insert(apiKeys)
-    .values({
-      userId,
-      keyHash,
-      keyPrefix,
-      label,
-      createdAt: new Date().toISOString(),
-      revokedAt: null,
-      lastUsedAt: null,
-    })
-    .returning({ id: apiKeys.id, prefix: apiKeys.keyPrefix });
 
   return NextResponse.json({
     id: result.id,

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -8,23 +8,35 @@ import { createHash } from "crypto";
 import { db, workspaces } from "@/lib/db/client";
 import { apiKeys } from "@/lib/db/schema";
 import { eq, and, isNull } from "drizzle-orm";
-import { loadWorkspaceState } from "@/lib/workspace/state-loader";
-import type { AgentState, Item } from "@/lib/workspace-state/types";
+import { getCachedState } from "@/lib/mcp/workspace-cache";
+import type { Item } from "@/lib/workspace-state/types";
 
-const stateCache = new Map<string, { state: AgentState; expiresAt: number }>();
-const CACHE_TTL_MS = 30_000;
+const MAX_BODY_BYTES = 64 * 1024; // 64 KB — more than enough for any MCP request
+const MAX_REGEX_LENGTH = 300;
+const MAX_ID_LENGTH = 256;
+const MAX_NAME_LENGTH = 500;
 
-async function getCachedState(workspaceId: string): Promise<AgentState> {
-  const cached = stateCache.get(workspaceId);
-  if (cached && cached.expiresAt > Date.now()) return cached.state;
-
-  const state = await loadWorkspaceState(workspaceId);
-  stateCache.set(workspaceId, { state, expiresAt: Date.now() + CACHE_TTL_MS });
-  return state;
+// Throws if the workspace does not belong to userId — prevents cross-user data access.
+async function assertOwnsWorkspace(workspaceId: string, userId: string): Promise<void> {
+  const [ws] = await db
+    .select({ id: workspaces.id })
+    .from(workspaces)
+    .where(and(eq(workspaces.id, workspaceId), eq(workspaces.userId, userId)))
+    .limit(1);
+  if (!ws) throw new McpAuthError("Workspace not found or access denied");
 }
 
-export function invalidateWorkspaceCache(workspaceId: string) {
-  stateCache.delete(workspaceId);
+class McpAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "McpAuthError";
+  }
+}
+
+// Sanitise errors before sending to the caller — never leak raw DB messages.
+function safeErrorMessage(error: unknown): string {
+  if (error instanceof McpAuthError) return error.message;
+  return "Internal server error";
 }
 
 function extractText(item: Item): string | null {
@@ -123,24 +135,13 @@ async function authenticateRequest(req: NextRequest): Promise<string | null> {
   return key.userId;
 }
 
-let mcpServer: Server | null = null;
-
-function getOrCreateServer(userId: string): Server {
-  if (!mcpServer) {
-    mcpServer = new Server(
-      {
-        name: "thinkex",
-        version: "1.0.0",
-      },
-      {
-        capabilities: {
-          tools: {},
-        },
-      }
-    );
-    registerTools(mcpServer, userId);
-  }
-  return mcpServer;
+function createServer(userId: string): Server {
+  const server = new Server(
+    { name: "thinkex", version: "1.0.0" },
+    { capabilities: { tools: {} } }
+  );
+  registerTools(server, userId);
+  return server;
 }
 
 function registerTools(server: Server, userId: string) {
@@ -265,6 +266,7 @@ function registerTools(server: Server, userId: string) {
 
         case "list_workspace": {
           const { workspaceId, folderId } = args as { workspaceId: string; folderId?: string };
+          await assertOwnsWorkspace(workspaceId, userId);
           const state = await getCachedState(workspaceId);
           let items = state.items;
 
@@ -291,6 +293,7 @@ function registerTools(server: Server, userId: string) {
 
         case "get_recent": {
           const { workspaceId, limit } = args as { workspaceId: string; limit?: number };
+          await assertOwnsWorkspace(workspaceId, userId);
           const state = await getCachedState(workspaceId);
           const recentLimit = Math.min(limit ?? 5, 20);
 
@@ -323,6 +326,15 @@ function registerTools(server: Server, userId: string) {
             type?: string;
             limit?: number;
           };
+          await assertOwnsWorkspace(workspaceId, userId);
+
+          if (typeof query !== "string" || query.length > MAX_REGEX_LENGTH) {
+            return {
+              content: [{ type: "text", text: JSON.stringify({ error: `Query must be a string of at most ${MAX_REGEX_LENGTH} characters` }, null, 2) }],
+              isError: true,
+            };
+          }
+
           const state = await getCachedState(workspaceId);
           let items = state.items;
 
@@ -416,6 +428,15 @@ function registerTools(server: Server, userId: string) {
             pageStart?: number;
             pageEnd?: number;
           };
+          await assertOwnsWorkspace(workspaceId, userId);
+
+          if (typeof name !== "string" || name.length === 0 || name.length > MAX_NAME_LENGTH) {
+            return {
+              content: [{ type: "text", text: JSON.stringify({ error: `name must be a non-empty string of at most ${MAX_NAME_LENGTH} characters` }, null, 2) }],
+              isError: true,
+            };
+          }
+
           const state = await getCachedState(workspaceId);
 
           const nameLower = name.toLowerCase();
@@ -552,16 +573,12 @@ function registerTools(server: Server, userId: string) {
             isError: true,
           };
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify(
-              { error: error.message || "Internal server error" },
-              null,
-              2
-            ),
+            text: JSON.stringify({ error: safeErrorMessage(error) }, null, 2),
           },
         ],
         isError: true,
@@ -571,63 +588,74 @@ function registerTools(server: Server, userId: string) {
 }
 
 async function handleMCP(req: NextRequest) {
+  // Enforce body size limit before doing anything else
+  const contentLength = Number(req.headers.get("content-length") ?? 0);
+  if (contentLength > MAX_BODY_BYTES) {
+    return NextResponse.json({ error: "Request body too large" }, { status: 413 });
+  }
+
   const userId = await authenticateRequest(req);
-
   if (!userId) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401 }
-    );
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const server = getOrCreateServer(userId);
+  const server = createServer(userId);
 
-  if (req.method !== "POST") {
-    return NextResponse.json(
-      { error: "Only POST method is supported for MCP" },
-      { status: 405 }
-    );
+  let body: unknown;
+  try {
+    const text = await req.text();
+    if (text.length > MAX_BODY_BYTES) {
+      return NextResponse.json({ error: "Request body too large" }, { status: 413 });
+    }
+    body = JSON.parse(text);
+  } catch {
+    return NextResponse.json({
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: -32700, message: "Parse error" },
+    }, { status: 400 });
   }
+
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return NextResponse.json({
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: -32600, message: "Invalid request" },
+    }, { status: 400 });
+  }
+
+  const { method, params, id: rawId } = body as Record<string, unknown>;
+
+  // JSON-RPC id must be a string, number, or null — never reflect arbitrary values
+  const id: string | number | null =
+    typeof rawId === "string" && rawId.length <= MAX_ID_LENGTH ? rawId
+    : typeof rawId === "number" && Number.isFinite(rawId) ? rawId
+    : null;
 
   try {
-    const body = await req.json();
-    
-    const { method, params, id } = body;
-
     if (method === "tools/list") {
-      const response = await server.request({ method: "tools/list", params }, ListToolsRequestSchema);
-      return NextResponse.json({
-        jsonrpc: "2.0",
-        id,
-        result: response,
-      });
+      const response = await server.request({ method: "tools/list", params: params as any }, ListToolsRequestSchema);
+      return NextResponse.json({ jsonrpc: "2.0", id, result: response });
     } else if (method === "tools/call") {
-      const response = await server.request({ method: "tools/call", params }, CallToolRequestSchema);
-      return NextResponse.json({
-        jsonrpc: "2.0",
-        id,
-        result: response,
-      });
+      const response = await server.request({ method: "tools/call", params: params as any }, CallToolRequestSchema);
+      return NextResponse.json({ jsonrpc: "2.0", id, result: response });
     } else {
       return NextResponse.json({
         jsonrpc: "2.0",
         id,
-        error: {
-          code: -32601,
-          message: `Method not found: ${method}`,
-        },
+        error: { code: -32601, message: "Method not found" },
       });
     }
-  } catch (error: any) {
+  } catch {
     return NextResponse.json({
       jsonrpc: "2.0",
-      id: null,
-      error: {
-        code: -32603,
-        message: error.message || "Internal error",
-      },
+      id,
+      error: { code: -32603, message: "Internal error" },
     }, { status: 500 });
   }
 }
 
 export const POST = handleMCP;
+
+// Allow up to 30s for workspace state loading on large workspaces
+export const maxDuration = 30;

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -81,7 +81,7 @@ function extractText(item: Item): string | null {
       const transcript: string | null =
         data.transcript ??
         ((data.segments as any[] | undefined)
-          ?.map((s: any) => s.text)
+          ?.map((s: any) => s.content)
           .filter(Boolean)
           .join(" ") || null);
       const summary: string | null = data.summary ?? null;
@@ -201,12 +201,12 @@ function registerTools(server: Server, userId: string) {
         },
         {
           name: "search_workspace",
-          description: "Search item content by keyword or pattern. Returns matching snippets with item names and line numbers. Use this before read_item to locate the right section — it is far more token-efficient than loading full documents to scan manually.",
+          description: "Search item content by literal keyword. Returns matching snippets with item names and line numbers. Use this before read_item to locate the right section — it is far more token-efficient than loading full documents to scan manually.",
           inputSchema: {
             type: "object",
             properties: {
               workspaceId: { type: "string", description: "Workspace ID" },
-              query: { type: "string", description: "Search keyword or regex pattern" },
+              query: { type: "string", description: "Literal substring to search for (case-insensitive; special characters are matched literally, not as regex)" },
               folderId: { type: "string", description: "Restrict to a folder (optional)" },
               type: { type: "string", description: "Restrict to an item type: document, pdf, flashcard, quiz, audio, image (optional)" },
               limit: { type: "number", description: "Snippets to return (default 5, max 10)" },
@@ -286,7 +286,7 @@ function registerTools(server: Server, userId: string) {
           const { workspaceId, limit } = args as { workspaceId: string; limit?: number };
           await assertOwnsWorkspace(workspaceId, userId);
           const state = await getCachedState(workspaceId);
-          const recentLimit = Math.min(limit ?? 5, 20);
+          const recentLimit = Math.max(1, Math.min(Math.floor(limit ?? 5), 20));
 
           const recent = [...state.items]
             .filter((i) => i.lastModified)
@@ -563,11 +563,37 @@ async function handleMCP(req: NextRequest) {
 
   let body: unknown;
   try {
-    const text = await req.text();
-    if (text.length > MAX_BODY_BYTES) {
-      return NextResponse.json({ error: "Request body too large" }, { status: 413 });
+    const reader = req.body?.getReader();
+    if (!reader) {
+      return NextResponse.json({
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32700, message: "Parse error" },
+      }, { status: 400 });
     }
-    body = JSON.parse(text);
+    let totalBytes = 0;
+    const chunks: Uint8Array[] = [];
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        totalBytes += value.byteLength;
+        if (totalBytes > MAX_BODY_BYTES) {
+          await reader.cancel();
+          return NextResponse.json({ error: "Request body too large" }, { status: 413 });
+        }
+        chunks.push(value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    const combined = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+      combined.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    body = JSON.parse(new TextDecoder().decode(combined));
   } catch {
     return NextResponse.json({
       jsonrpc: "2.0",

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -3,6 +3,8 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
+  InitializeRequestSchema,
+  LATEST_PROTOCOL_VERSION,
 } from "@modelcontextprotocol/sdk/types.js";
 import { createHash } from "crypto";
 import { db, workspaces } from "@/lib/db/client";
@@ -22,6 +24,12 @@ const DEFAULT_LINE_LIMIT = 500; // enough for a full section without requiring a
 const LIST_MAX_ITEMS = 200;  // items returned per list_workspace call; use search_workspace for larger workspaces
 
 const VALID_ITEM_TYPES = new Set(["document", "pdf", "flashcard", "quiz", "audio", "image", "website", "youtube", "folder"]);
+
+// Escapes all regex metacharacters so user-supplied query strings are always
+// treated as literal substrings rather than patterns, preventing ReDoS.
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 // Throws if the workspace does not belong to userId — prevents cross-user data access.
 async function assertOwnsWorkspace(workspaceId: string, userId: string): Promise<void> {
@@ -69,8 +77,14 @@ function extractText(item: Item): string | null {
         .join("\n\n") || null;
     }
     case "audio": {
-      const transcript = (item.data as any).transcript;
-      const summary = (item.data as any).summary;
+      const data = item.data as any;
+      const transcript: string | null =
+        data.transcript ??
+        ((data.segments as any[] | undefined)
+          ?.map((s: any) => s.text)
+          .filter(Boolean)
+          .join(" ") || null);
+      const summary: string | null = data.summary ?? null;
       return [transcript, summary].filter(Boolean).join("\n\n") || null;
     }
     case "image": {
@@ -319,22 +333,11 @@ function registerTools(server: Server, userId: string) {
             items = items.filter((i) => i.type === type);
           }
 
-          // Use case-insensitive flag only (no `g`) to avoid lastIndex state bleeding
-          // between test() calls on separate lines, which causes matches to be skipped.
-          let regex: RegExp;
-          try {
-            regex = new RegExp(query, "i");
-          } catch {
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: JSON.stringify({ error: "Invalid regex pattern" }),
-                },
-              ],
-              isError: true,
-            };
-          }
+          // Treat the query as a literal substring (metacharacters are escaped)
+          // to eliminate ReDoS exposure from untrusted input.
+          // Use case-insensitive flag only (no `g`) to avoid lastIndex state
+          // bleeding between test() calls on separate lines.
+          const regex = new RegExp(escapeRegex(query), "i");
 
           const matches: Array<{
             itemName: string;
@@ -590,7 +593,26 @@ async function handleMCP(req: NextRequest) {
     : null;
 
   try {
-    if (method === "tools/list") {
+    if (method === "initialize") {
+      // Respond to the MCP initialization handshake.
+      // The client sends its capabilities; we reply with ours.
+      await server.request(
+        { method: "initialize", params: params as any },
+        InitializeRequestSchema,
+      );
+      return NextResponse.json({
+        jsonrpc: "2.0",
+        id,
+        result: {
+          protocolVersion: LATEST_PROTOCOL_VERSION,
+          capabilities: { tools: {} },
+          serverInfo: { name: "thinkex", version: "1.0.0" },
+        },
+      });
+    } else if (method === "notifications/initialized") {
+      // Notification — no response body required by the MCP spec.
+      return new NextResponse(null, { status: 204 });
+    } else if (method === "tools/list") {
       const response = await server.request({ method: "tools/list", params: params as any }, ListToolsRequestSchema);
       return NextResponse.json({ jsonrpc: "2.0", id, result: response });
     } else if (method === "tools/call") {

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -11,10 +11,17 @@ import { eq, and, isNull } from "drizzle-orm";
 import { getCachedState } from "@/lib/mcp/workspace-cache";
 import type { Item } from "@/lib/workspace-state/types";
 
-const MAX_BODY_BYTES = 64 * 1024; // 64 KB — more than enough for any MCP request
+const MAX_BODY_BYTES = 64 * 1024;
 const MAX_REGEX_LENGTH = 300;
 const MAX_ID_LENGTH = 256;
 const MAX_NAME_LENGTH = 500;
+const MAX_PDF_PAGES = 50;    // ~25k words per call — fits comfortably in any modern model context window
+const MAX_LINE_LIMIT = 2000; // ~20k words at typical prose density
+const MIN_LINE_LIMIT = 1;
+const DEFAULT_LINE_LIMIT = 500; // enough for a full section without requiring a follow-up call
+const LIST_MAX_ITEMS = 200;  // items returned per list_workspace call; use search_workspace for larger workspaces
+
+const VALID_ITEM_TYPES = new Set(["document", "pdf", "flashcard", "quiz", "audio", "image", "website", "youtube", "folder"]);
 
 // Throws if the workspace does not belong to userId — prevents cross-user data access.
 async function assertOwnsWorkspace(workspaceId: string, userId: string): Promise<void> {
@@ -151,90 +158,60 @@ function registerTools(server: Server, userId: string) {
       tools: [
         {
           name: "list_workspaces",
-          description: "List all workspaces for the authenticated user",
-          inputSchema: {
-            type: "object",
-            properties: {},
-          },
+          description: "List all workspaces for the authenticated user. Call this first if you don't know the workspaceId.",
+          inputSchema: { type: "object", properties: {} },
         },
         {
           name: "list_workspace",
-          description: "List all items in a workspace (or in a specific folder)",
+          description: "List items in a workspace (metadata only — no content). Returns up to 200 most-recently-modified items. If totalItems exceeds returned, use search_workspace to find specific items instead of calling list_workspace repeatedly.",
           inputSchema: {
             type: "object",
             properties: {
               workspaceId: { type: "string", description: "Workspace ID" },
-              folderId: {
-                type: "string",
-                description: "Optional folder ID to filter items",
-              },
+              folderId: { type: "string", description: "Restrict to a specific folder (optional)" },
             },
             required: ["workspaceId"],
           },
         },
         {
           name: "get_recent",
-          description: "Get the N most recently modified items in a workspace",
+          description: "Get the N most recently modified items in a workspace. Use this to orient yourself quickly before deciding what to read.",
           inputSchema: {
             type: "object",
             properties: {
               workspaceId: { type: "string", description: "Workspace ID" },
-              limit: {
-                type: "number",
-                description: "Number of items to return (default 5, max 20)",
-              },
+              limit: { type: "number", description: "Items to return (default 5, max 20)" },
             },
             required: ["workspaceId"],
           },
         },
         {
           name: "search_workspace",
-          description: "Search for items in a workspace using regex",
+          description: "Search item content by keyword or pattern. Returns matching snippets with item names and line numbers. Use this before read_item to locate the right section — it is far more token-efficient than loading full documents to scan manually.",
           inputSchema: {
             type: "object",
             properties: {
               workspaceId: { type: "string", description: "Workspace ID" },
-              query: { type: "string", description: "Regex search pattern" },
-              folderId: {
-                type: "string",
-                description: "Optional folder ID to filter search",
-              },
-              type: {
-                type: "string",
-                description: "Optional item type to filter search",
-              },
-              limit: {
-                type: "number",
-                description: "Number of results to return (default 5, max 10)",
-              },
+              query: { type: "string", description: "Search keyword or regex pattern" },
+              folderId: { type: "string", description: "Restrict to a folder (optional)" },
+              type: { type: "string", description: "Restrict to an item type: document, pdf, flashcard, quiz, audio, image (optional)" },
+              limit: { type: "number", description: "Snippets to return (default 5, max 10)" },
             },
             required: ["workspaceId", "query"],
           },
         },
         {
           name: "read_item",
-          description: "Read the full content of an item (with pagination support)",
+          description: "Read the content of a named item. Fuzzy-matches the name. For text items use lineStart+limit; for PDFs use pageStart+pageEnd. The response includes hasMore and a note with the exact next call when the document continues beyond the current window.",
           inputSchema: {
             type: "object",
             properties: {
               workspaceId: { type: "string", description: "Workspace ID" },
               name: { type: "string", description: "Item name (fuzzy matched)" },
-              lineStart: {
-                type: "number",
-                description: "Line number to start from (1-indexed, for text items)",
-              },
-              limit: {
-                type: "number",
-                description: "Number of lines to return (default 100, max 500)",
-              },
-              pageStart: {
-                type: "number",
-                description: "Page number to start from (1-indexed, for PDFs)",
-              },
-              pageEnd: {
-                type: "number",
-                description: "Page number to end at (for PDFs)",
-              },
+              lineStart: { type: "number", description: "Start line, 1-indexed (text items only, default 1)" },
+              limit: { type: "number", description: "Lines to return (default 500, max 2000)" },
+              pageStart: { type: "number", description: "Start page, 1-indexed (PDFs only, default 1)" },
+              pageEnd: { type: "number", description: "End page inclusive (PDFs only, max 50 pages per call)" },
             },
             required: ["workspaceId", "name"],
           },
@@ -255,12 +232,7 @@ function registerTools(server: Server, userId: string) {
             .where(eq(workspaces.userId, userId));
 
           return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(workspacesList, null, 2),
-              },
-            ],
+            content: [{ type: "text", text: JSON.stringify(workspacesList) }],
           };
         }
 
@@ -274,20 +246,25 @@ function registerTools(server: Server, userId: string) {
             items = items.filter((i) => i.folderId === folderId);
           }
 
-          const itemsList = items.map((i) => ({
-            name: i.name,
-            type: i.type,
-            folderId: i.folderId,
-            lastModified: i.lastModified,
-          }));
+          const totalItems = items.length;
+
+          // Sort most-recently-modified first so the cap preserves the most relevant items
+          const sorted = [...items]
+            .sort((a, b) => (b.lastModified ?? 0) - (a.lastModified ?? 0))
+            .slice(0, LIST_MAX_ITEMS)
+            .map((i) => ({ name: i.name, type: i.type, folderId: i.folderId ?? null, lastModified: i.lastModified }));
+
+          const result: Record<string, unknown> = {
+            items: sorted,
+            returned: sorted.length,
+            totalItems,
+          };
+          if (totalItems > LIST_MAX_ITEMS) {
+            result.hint = `Showing ${LIST_MAX_ITEMS} most-recent of ${totalItems} items. Use search_workspace() to find specific items by name or content.`;
+          }
 
           return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(itemsList, null, 2),
-              },
-            ],
+            content: [{ type: "text", text: JSON.stringify(result) }],
           };
         }
 
@@ -301,20 +278,10 @@ function registerTools(server: Server, userId: string) {
             .filter((i) => i.lastModified)
             .sort((a, b) => (b.lastModified ?? 0) - (a.lastModified ?? 0))
             .slice(0, recentLimit)
-            .map((i) => ({
-              name: i.name,
-              type: i.type,
-              folderId: i.folderId,
-              lastModified: i.lastModified,
-            }));
+            .map((i) => ({ name: i.name, type: i.type, folderId: i.folderId ?? null, lastModified: i.lastModified }));
 
           return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(recent, null, 2),
-              },
-            ],
+            content: [{ type: "text", text: JSON.stringify(recent) }],
           };
         }
 
@@ -328,9 +295,16 @@ function registerTools(server: Server, userId: string) {
           };
           await assertOwnsWorkspace(workspaceId, userId);
 
-          if (typeof query !== "string" || query.length > MAX_REGEX_LENGTH) {
+          if (typeof query !== "string" || query.length === 0 || query.length > MAX_REGEX_LENGTH) {
             return {
-              content: [{ type: "text", text: JSON.stringify({ error: `Query must be a string of at most ${MAX_REGEX_LENGTH} characters` }, null, 2) }],
+              content: [{ type: "text", text: JSON.stringify({ error: `Query must be a non-empty string of at most ${MAX_REGEX_LENGTH} characters` }) }],
+              isError: true,
+            };
+          }
+
+          if (type !== undefined && !VALID_ITEM_TYPES.has(type)) {
+            return {
+              content: [{ type: "text", text: JSON.stringify({ error: `Unknown item type "${type}". Valid types: ${[...VALID_ITEM_TYPES].join(", ")}` }) }],
               isError: true,
             };
           }
@@ -345,15 +319,17 @@ function registerTools(server: Server, userId: string) {
             items = items.filter((i) => i.type === type);
           }
 
+          // Use case-insensitive flag only (no `g`) to avoid lastIndex state bleeding
+          // between test() calls on separate lines, which causes matches to be skipped.
           let regex: RegExp;
           try {
-            regex = new RegExp(query, "gi");
+            regex = new RegExp(query, "i");
           } catch {
             return {
               content: [
                 {
                   type: "text",
-                  text: JSON.stringify({ error: "Invalid regex pattern" }, null, 2),
+                  text: JSON.stringify({ error: "Invalid regex pattern" }),
                 },
               ],
               isError: true,
@@ -363,7 +339,7 @@ function registerTools(server: Server, userId: string) {
           const matches: Array<{
             itemName: string;
             itemType: string;
-            folderId?: string;
+            folderId: string | null;
             lineStart: number;
             content: string;
           }> = [];
@@ -379,7 +355,7 @@ function registerTools(server: Server, userId: string) {
                 matches.push({
                   itemName: item.name,
                   itemType: item.type,
-                  folderId: item.folderId,
+                  folderId: item.folderId ?? null,
                   lineStart: i + 1,
                   content: lines[i].trim(),
                 });
@@ -391,31 +367,16 @@ function registerTools(server: Server, userId: string) {
 
           if (matches.length === 0) {
             return {
-              content: [
-                {
-                  type: "text",
-                  text: JSON.stringify(
-                    {
-                      results: [],
-                      suggestion:
-                        "No matches found. Try list_workspace() to browse available items or broaden your query.",
-                    },
-                    null,
-                    2
-                  ),
-                },
-              ],
+              content: [{
+                type: "text",
+                text: JSON.stringify({ results: [], suggestion: "No matches found. Try list_workspace() to browse available items or broaden your query." }),
+              }],
             };
           }
 
-          const resultLimit = Math.min(limit ?? 5, 10);
+          const resultLimit = Math.min(Math.max(limit ?? 5, 1), 10);
           return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(matches.slice(0, resultLimit), null, 2),
-              },
-            ],
+            content: [{ type: "text", text: JSON.stringify(matches.slice(0, resultLimit)) }],
           };
         }
 
@@ -432,7 +393,7 @@ function registerTools(server: Server, userId: string) {
 
           if (typeof name !== "string" || name.length === 0 || name.length > MAX_NAME_LENGTH) {
             return {
-              content: [{ type: "text", text: JSON.stringify({ error: `name must be a non-empty string of at most ${MAX_NAME_LENGTH} characters` }, null, 2) }],
+              content: [{ type: "text", text: JSON.stringify({ error: `name must be a non-empty string of at most ${MAX_NAME_LENGTH} characters` }) }],
               isError: true,
             };
           }
@@ -467,99 +428,95 @@ function registerTools(server: Server, userId: string) {
 
           if (!matchedItem) {
             return {
-              content: [
-                {
-                  type: "text",
-                  text: JSON.stringify(
-                    {
-                      error: "Item not found. Try list_workspace() to see available items.",
-                    },
-                    null,
-                    2
-                  ),
-                },
-              ],
+              content: [{ type: "text", text: JSON.stringify({ error: "Item not found. Try list_workspace() to see available items." }) }],
               isError: true,
             };
           }
 
           if (matchedItem.type === "pdf") {
-            const pages = ((matchedItem.data as any).ocrPages ?? []) as Array<{
-              markdown: string;
-            }>;
-            const start = (pageStart ?? 1) - 1;
-            const end = (pageEnd ?? pages.length) - 1;
+            const pages = ((matchedItem.data as any).ocrPages ?? []) as Array<{ markdown: string }>;
+            const totalPages = pages.length;
+
+            // Clamp pageStart to a valid 1-based page number
+            const clampedStart = Math.max(1, Math.floor(pageStart ?? 1));
+            if (clampedStart > totalPages) {
+              return {
+                content: [{ type: "text", text: JSON.stringify({ error: `pageStart (${clampedStart}) exceeds total pages (${totalPages})` }) }],
+                isError: true,
+              };
+            }
+
+            // Cap the window: if pageEnd is supplied, honour it but never exceed MAX_PDF_PAGES per request
+            const requestedEnd = pageEnd !== undefined ? Math.floor(pageEnd) : clampedStart + MAX_PDF_PAGES - 1;
+            if (requestedEnd < clampedStart) {
+              return {
+                content: [{ type: "text", text: JSON.stringify({ error: "pageEnd must be >= pageStart" }) }],
+                isError: true,
+              };
+            }
+            const clampedEnd = Math.min(requestedEnd, clampedStart + MAX_PDF_PAGES - 1, totalPages);
+
             const content = pages
-              .slice(start, end + 1)
+              .slice(clampedStart - 1, clampedEnd)
               .map((p) => p.markdown)
               .join("\n\n---\n\n");
 
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: JSON.stringify(
-                    {
-                      itemName: matchedItem.name,
-                      itemType: matchedItem.type,
-                      content,
-                      estimatedTokens: Math.ceil(content.length / 4),
-                      totalPages: pages.length,
-                      pageStart: start + 1,
-                    },
-                    null,
-                    2
-                  ),
-                },
-              ],
+            const pdfResult: Record<string, unknown> = {
+              itemName: matchedItem.name,
+              itemType: matchedItem.type,
+              content,
+              estimatedTokens: Math.ceil(content.length / 4),
+              pageStart: clampedStart,
+              pageEnd: clampedEnd,
+              totalPages,
+              hasMore: clampedEnd < totalPages,
             };
+            if (clampedEnd < totalPages) {
+              pdfResult.note = `Showing pages ${clampedStart}–${clampedEnd} of ${totalPages}. Call read_item again with pageStart=${clampedEnd + 1} for the next section.`;
+            }
+
+            return { content: [{ type: "text", text: JSON.stringify(pdfResult) }] };
           }
 
           const text = extractText(matchedItem);
           if (!text) {
             const url = (matchedItem.data as any).url;
             return {
-              content: [
-                {
-                  type: "text",
-                  text: JSON.stringify(
-                    {
-                      content: null,
-                      note: `This item has no stored body text. URL: ${url ?? "N/A"}`,
-                    },
-                    null,
-                    2
-                  ),
-                },
-              ],
+              content: [{ type: "text", text: JSON.stringify({ content: null, note: `This item has no stored body text. URL: ${url ?? "N/A"}` }) }],
             };
           }
 
           const lines = text.split("\n");
-          const start = (lineStart ?? 1) - 1;
-          const lineLimit = Math.min(limit ?? 100, 500);
-          const slice = lines.slice(start, start + lineLimit);
-          const content = slice.join("\n");
+          const totalLines = lines.length;
 
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(
-                  {
-                    itemName: matchedItem.name,
-                    itemType: matchedItem.type,
-                    content,
-                    estimatedTokens: Math.ceil(content.length / 4),
-                    totalLines: lines.length,
-                    lineStart: start + 1,
-                  },
-                  null,
-                  2
-                ),
-              },
-            ],
+          const clampedLineStart = Math.max(1, Math.floor(lineStart ?? 1));
+          if (clampedLineStart > totalLines) {
+            return {
+              content: [{ type: "text", text: JSON.stringify({ error: `lineStart (${clampedLineStart}) exceeds total lines (${totalLines})` }) }],
+              isError: true,
+            };
+          }
+
+          const lineLimit = Math.min(Math.max(Math.floor(limit ?? DEFAULT_LINE_LIMIT), MIN_LINE_LIMIT), MAX_LINE_LIMIT);
+          const slice = lines.slice(clampedLineStart - 1, clampedLineStart - 1 + lineLimit);
+          const content = slice.join("\n");
+          const returnedEnd = clampedLineStart - 1 + slice.length;
+
+          const textResult: Record<string, unknown> = {
+            itemName: matchedItem.name,
+            itemType: matchedItem.type,
+            content,
+            estimatedTokens: Math.ceil(content.length / 4),
+            lineStart: clampedLineStart,
+            lineEnd: returnedEnd,
+            totalLines,
+            hasMore: returnedEnd < totalLines,
           };
+          if (returnedEnd < totalLines) {
+            textResult.note = `Showing lines ${clampedLineStart}–${returnedEnd} of ${totalLines}. Call read_item again with lineStart=${returnedEnd + 1} for the next section.`;
+          }
+
+          return { content: [{ type: "text", text: JSON.stringify(textResult) }] };
         }
 
         default:
@@ -567,7 +524,7 @@ function registerTools(server: Server, userId: string) {
             content: [
               {
                 type: "text",
-                text: JSON.stringify({ error: `Unknown tool: ${name}` }, null, 2),
+                text: JSON.stringify({ error: `Unknown tool: ${name}` }),
               },
             ],
             isError: true,
@@ -578,7 +535,7 @@ function registerTools(server: Server, userId: string) {
         content: [
           {
             type: "text",
-            text: JSON.stringify({ error: safeErrorMessage(error) }, null, 2),
+            text: JSON.stringify({ error: safeErrorMessage(error) }),
           },
         ],
         isError: true,

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,0 +1,633 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { createHash } from "crypto";
+import { db, workspaces } from "@/lib/db/client";
+import { apiKeys } from "@/lib/db/schema";
+import { eq, and, isNull } from "drizzle-orm";
+import { loadWorkspaceState } from "@/lib/workspace/state-loader";
+import type { AgentState, Item } from "@/lib/workspace-state/types";
+
+const stateCache = new Map<string, { state: AgentState; expiresAt: number }>();
+const CACHE_TTL_MS = 30_000;
+
+async function getCachedState(workspaceId: string): Promise<AgentState> {
+  const cached = stateCache.get(workspaceId);
+  if (cached && cached.expiresAt > Date.now()) return cached.state;
+
+  const state = await loadWorkspaceState(workspaceId);
+  stateCache.set(workspaceId, { state, expiresAt: Date.now() + CACHE_TTL_MS });
+  return state;
+}
+
+export function invalidateWorkspaceCache(workspaceId: string) {
+  stateCache.delete(workspaceId);
+}
+
+function extractText(item: Item): string | null {
+  switch (item.type) {
+    case "document":
+      return (item.data as any).markdown ?? null;
+    case "pdf": {
+      const pages = (item.data as any).ocrPages;
+      return pages?.map((p: any) => p.markdown).join("\n\n") ?? null;
+    }
+    case "flashcard": {
+      const cards = (item.data as any).cards ?? [];
+      return cards.map((c: any) => `Q: ${c.front}\nA: ${c.back}`).join("\n\n");
+    }
+    case "quiz": {
+      const questions = (item.data as any).questions ?? [];
+      return questions
+        .map((q: any) =>
+          [q.questionText, ...(q.options ?? []), q.explanation]
+            .filter(Boolean)
+            .join("\n")
+        )
+        .join("\n\n") || null;
+    }
+    case "audio": {
+      const transcript = (item.data as any).transcript;
+      const summary = (item.data as any).summary;
+      return [transcript, summary].filter(Boolean).join("\n\n") || null;
+    }
+    case "image": {
+      const pages = (item.data as any).ocrPages;
+      return pages?.map((p: any) => p.markdown).join("\n\n") ?? null;
+    }
+    case "website":
+    case "youtube":
+    case "folder":
+    default:
+      return null;
+  }
+}
+
+function levenshteinDistance(a: string, b: string): number {
+  const matrix: number[][] = [];
+  for (let i = 0; i <= b.length; i++) {
+    matrix[i] = [i];
+  }
+  for (let j = 0; j <= a.length; j++) {
+    matrix[0][j] = j;
+  }
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      if (b.charAt(i - 1) === a.charAt(j - 1)) {
+        matrix[i][j] = matrix[i - 1][j - 1];
+      } else {
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j - 1] + 1,
+          matrix[i][j - 1] + 1,
+          matrix[i - 1][j] + 1
+        );
+      }
+    }
+  }
+  return matrix[b.length][a.length];
+}
+
+async function authenticateRequest(req: NextRequest): Promise<string | null> {
+  const authHeader = req.headers.get("Authorization");
+  
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return null;
+  }
+
+  const rawKey = authHeader.substring(7);
+  if (!rawKey.startsWith("tx_")) {
+    return null;
+  }
+
+  const keyHash = createHash("sha256").update(rawKey).digest("hex");
+
+  const [key] = await db
+    .select({ userId: apiKeys.userId, id: apiKeys.id })
+    .from(apiKeys)
+    .where(and(eq(apiKeys.keyHash, keyHash), isNull(apiKeys.revokedAt)))
+    .limit(1);
+
+  if (!key) {
+    return null;
+  }
+
+  db.update(apiKeys)
+    .set({ lastUsedAt: new Date().toISOString() })
+    .where(eq(apiKeys.id, key.id))
+    .execute()
+    .catch(() => {});
+
+  return key.userId;
+}
+
+let mcpServer: Server | null = null;
+
+function getOrCreateServer(userId: string): Server {
+  if (!mcpServer) {
+    mcpServer = new Server(
+      {
+        name: "thinkex",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {
+          tools: {},
+        },
+      }
+    );
+    registerTools(mcpServer, userId);
+  }
+  return mcpServer;
+}
+
+function registerTools(server: Server, userId: string) {
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return {
+      tools: [
+        {
+          name: "list_workspaces",
+          description: "List all workspaces for the authenticated user",
+          inputSchema: {
+            type: "object",
+            properties: {},
+          },
+        },
+        {
+          name: "list_workspace",
+          description: "List all items in a workspace (or in a specific folder)",
+          inputSchema: {
+            type: "object",
+            properties: {
+              workspaceId: { type: "string", description: "Workspace ID" },
+              folderId: {
+                type: "string",
+                description: "Optional folder ID to filter items",
+              },
+            },
+            required: ["workspaceId"],
+          },
+        },
+        {
+          name: "get_recent",
+          description: "Get the N most recently modified items in a workspace",
+          inputSchema: {
+            type: "object",
+            properties: {
+              workspaceId: { type: "string", description: "Workspace ID" },
+              limit: {
+                type: "number",
+                description: "Number of items to return (default 5, max 20)",
+              },
+            },
+            required: ["workspaceId"],
+          },
+        },
+        {
+          name: "search_workspace",
+          description: "Search for items in a workspace using regex",
+          inputSchema: {
+            type: "object",
+            properties: {
+              workspaceId: { type: "string", description: "Workspace ID" },
+              query: { type: "string", description: "Regex search pattern" },
+              folderId: {
+                type: "string",
+                description: "Optional folder ID to filter search",
+              },
+              type: {
+                type: "string",
+                description: "Optional item type to filter search",
+              },
+              limit: {
+                type: "number",
+                description: "Number of results to return (default 5, max 10)",
+              },
+            },
+            required: ["workspaceId", "query"],
+          },
+        },
+        {
+          name: "read_item",
+          description: "Read the full content of an item (with pagination support)",
+          inputSchema: {
+            type: "object",
+            properties: {
+              workspaceId: { type: "string", description: "Workspace ID" },
+              name: { type: "string", description: "Item name (fuzzy matched)" },
+              lineStart: {
+                type: "number",
+                description: "Line number to start from (1-indexed, for text items)",
+              },
+              limit: {
+                type: "number",
+                description: "Number of lines to return (default 100, max 500)",
+              },
+              pageStart: {
+                type: "number",
+                description: "Page number to start from (1-indexed, for PDFs)",
+              },
+              pageEnd: {
+                type: "number",
+                description: "Page number to end at (for PDFs)",
+              },
+            },
+            required: ["workspaceId", "name"],
+          },
+        },
+      ],
+    };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+
+    try {
+      switch (name) {
+        case "list_workspaces": {
+          const workspacesList = await db
+            .select({ id: workspaces.id, slug: workspaces.slug, name: workspaces.name })
+            .from(workspaces)
+            .where(eq(workspaces.userId, userId));
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(workspacesList, null, 2),
+              },
+            ],
+          };
+        }
+
+        case "list_workspace": {
+          const { workspaceId, folderId } = args as { workspaceId: string; folderId?: string };
+          const state = await getCachedState(workspaceId);
+          let items = state.items;
+
+          if (folderId !== undefined) {
+            items = items.filter((i) => i.folderId === folderId);
+          }
+
+          const itemsList = items.map((i) => ({
+            name: i.name,
+            type: i.type,
+            folderId: i.folderId,
+            lastModified: i.lastModified,
+          }));
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(itemsList, null, 2),
+              },
+            ],
+          };
+        }
+
+        case "get_recent": {
+          const { workspaceId, limit } = args as { workspaceId: string; limit?: number };
+          const state = await getCachedState(workspaceId);
+          const recentLimit = Math.min(limit ?? 5, 20);
+
+          const recent = [...state.items]
+            .filter((i) => i.lastModified)
+            .sort((a, b) => (b.lastModified ?? 0) - (a.lastModified ?? 0))
+            .slice(0, recentLimit)
+            .map((i) => ({
+              name: i.name,
+              type: i.type,
+              folderId: i.folderId,
+              lastModified: i.lastModified,
+            }));
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(recent, null, 2),
+              },
+            ],
+          };
+        }
+
+        case "search_workspace": {
+          const { workspaceId, query, folderId, type, limit } = args as {
+            workspaceId: string;
+            query: string;
+            folderId?: string;
+            type?: string;
+            limit?: number;
+          };
+          const state = await getCachedState(workspaceId);
+          let items = state.items;
+
+          if (folderId !== undefined) {
+            items = items.filter((i) => i.folderId === folderId);
+          }
+          if (type !== undefined) {
+            items = items.filter((i) => i.type === type);
+          }
+
+          let regex: RegExp;
+          try {
+            regex = new RegExp(query, "gi");
+          } catch {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({ error: "Invalid regex pattern" }, null, 2),
+                },
+              ],
+              isError: true,
+            };
+          }
+
+          const matches: Array<{
+            itemName: string;
+            itemType: string;
+            folderId?: string;
+            lineStart: number;
+            content: string;
+          }> = [];
+          const INTERNAL_CAP = 100;
+
+          for (const item of items) {
+            const text = extractText(item);
+            if (!text) continue;
+
+            const lines = text.split("\n");
+            for (let i = 0; i < lines.length; i++) {
+              if (regex.test(lines[i])) {
+                matches.push({
+                  itemName: item.name,
+                  itemType: item.type,
+                  folderId: item.folderId,
+                  lineStart: i + 1,
+                  content: lines[i].trim(),
+                });
+                if (matches.length >= INTERNAL_CAP) break;
+              }
+            }
+            if (matches.length >= INTERNAL_CAP) break;
+          }
+
+          if (matches.length === 0) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    {
+                      results: [],
+                      suggestion:
+                        "No matches found. Try list_workspace() to browse available items or broaden your query.",
+                    },
+                    null,
+                    2
+                  ),
+                },
+              ],
+            };
+          }
+
+          const resultLimit = Math.min(limit ?? 5, 10);
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(matches.slice(0, resultLimit), null, 2),
+              },
+            ],
+          };
+        }
+
+        case "read_item": {
+          const { workspaceId, name, lineStart, limit, pageStart, pageEnd } = args as {
+            workspaceId: string;
+            name: string;
+            lineStart?: number;
+            limit?: number;
+            pageStart?: number;
+            pageEnd?: number;
+          };
+          const state = await getCachedState(workspaceId);
+
+          const nameLower = name.toLowerCase();
+          let matchedItem: Item | null = null;
+
+          const exactMatch = state.items.find((i) => i.name.toLowerCase() === nameLower);
+          if (exactMatch) {
+            matchedItem = exactMatch;
+          } else {
+            const substringMatches = state.items.filter((i) =>
+              i.name.toLowerCase().includes(nameLower)
+            );
+            if (substringMatches.length === 1) {
+              matchedItem = substringMatches[0];
+            } else if (substringMatches.length > 1) {
+              let closestItem = substringMatches[0];
+              let closestDistance = levenshteinDistance(nameLower, closestItem.name.toLowerCase());
+              for (const item of substringMatches.slice(1)) {
+                const distance = levenshteinDistance(nameLower, item.name.toLowerCase());
+                if (distance < closestDistance) {
+                  closestDistance = distance;
+                  closestItem = item;
+                }
+              }
+              matchedItem = closestItem;
+            }
+          }
+
+          if (!matchedItem) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    {
+                      error: "Item not found. Try list_workspace() to see available items.",
+                    },
+                    null,
+                    2
+                  ),
+                },
+              ],
+              isError: true,
+            };
+          }
+
+          if (matchedItem.type === "pdf") {
+            const pages = ((matchedItem.data as any).ocrPages ?? []) as Array<{
+              markdown: string;
+            }>;
+            const start = (pageStart ?? 1) - 1;
+            const end = (pageEnd ?? pages.length) - 1;
+            const content = pages
+              .slice(start, end + 1)
+              .map((p) => p.markdown)
+              .join("\n\n---\n\n");
+
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    {
+                      itemName: matchedItem.name,
+                      itemType: matchedItem.type,
+                      content,
+                      estimatedTokens: Math.ceil(content.length / 4),
+                      totalPages: pages.length,
+                      pageStart: start + 1,
+                    },
+                    null,
+                    2
+                  ),
+                },
+              ],
+            };
+          }
+
+          const text = extractText(matchedItem);
+          if (!text) {
+            const url = (matchedItem.data as any).url;
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    {
+                      content: null,
+                      note: `This item has no stored body text. URL: ${url ?? "N/A"}`,
+                    },
+                    null,
+                    2
+                  ),
+                },
+              ],
+            };
+          }
+
+          const lines = text.split("\n");
+          const start = (lineStart ?? 1) - 1;
+          const lineLimit = Math.min(limit ?? 100, 500);
+          const slice = lines.slice(start, start + lineLimit);
+          const content = slice.join("\n");
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(
+                  {
+                    itemName: matchedItem.name,
+                    itemType: matchedItem.type,
+                    content,
+                    estimatedTokens: Math.ceil(content.length / 4),
+                    totalLines: lines.length,
+                    lineStart: start + 1,
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        default:
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({ error: `Unknown tool: ${name}` }, null, 2),
+              },
+            ],
+            isError: true,
+          };
+      }
+    } catch (error: any) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              { error: error.message || "Internal server error" },
+              null,
+              2
+            ),
+          },
+        ],
+        isError: true,
+      };
+    }
+  });
+}
+
+async function handleMCP(req: NextRequest) {
+  const userId = await authenticateRequest(req);
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const server = getOrCreateServer(userId);
+
+  if (req.method !== "POST") {
+    return NextResponse.json(
+      { error: "Only POST method is supported for MCP" },
+      { status: 405 }
+    );
+  }
+
+  try {
+    const body = await req.json();
+    
+    const { method, params, id } = body;
+
+    if (method === "tools/list") {
+      const response = await server.request({ method: "tools/list", params }, ListToolsRequestSchema);
+      return NextResponse.json({
+        jsonrpc: "2.0",
+        id,
+        result: response,
+      });
+    } else if (method === "tools/call") {
+      const response = await server.request({ method: "tools/call", params }, CallToolRequestSchema);
+      return NextResponse.json({
+        jsonrpc: "2.0",
+        id,
+        result: response,
+      });
+    } else {
+      return NextResponse.json({
+        jsonrpc: "2.0",
+        id,
+        error: {
+          code: -32601,
+          message: `Method not found: ${method}`,
+        },
+      });
+    }
+  } catch (error: any) {
+    return NextResponse.json({
+      jsonrpc: "2.0",
+      id: null,
+      error: {
+        code: -32603,
+        message: error.message || "Internal error",
+      },
+    }, { status: 500 });
+  }
+}
+
+export const POST = handleMCP;

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -23,7 +23,7 @@ const MIN_LINE_LIMIT = 1;
 const DEFAULT_LINE_LIMIT = 500; // enough for a full section without requiring a follow-up call
 const LIST_MAX_ITEMS = 200;  // items returned per list_workspace call; use search_workspace for larger workspaces
 
-const VALID_ITEM_TYPES = new Set(["document", "pdf", "flashcard", "quiz", "audio", "image", "website", "youtube", "folder"]);
+const VALID_ITEM_TYPES = new Set(["document", "pdf", "flashcard", "quiz", "audio", "image"]);
 
 // Escapes all regex metacharacters so user-supplied query strings are always
 // treated as literal substrings rather than patterns, preventing ReDoS.
@@ -83,7 +83,7 @@ function extractText(item: Item): string | null {
         ((data.segments as any[] | undefined)
           ?.map((s: any) => s.content)
           .filter(Boolean)
-          .join(" ") || null);
+          .join("\n") || null);
       const summary: string | null = data.summary ?? null;
       return [transcript, summary].filter(Boolean).join("\n\n") || null;
     }
@@ -344,25 +344,46 @@ function registerTools(server: Server, userId: string) {
             itemType: string;
             folderId: string | null;
             lineStart: number;
+            pageNumber?: number;
             content: string;
           }> = [];
           const INTERNAL_CAP = 100;
 
           for (const item of items) {
-            const text = extractText(item);
-            if (!text) continue;
+            if (item.type === "pdf") {
+              const pages = ((item.data as any).ocrPages ?? []) as Array<{ markdown: string }>;
+              for (let pageIdx = 0; pageIdx < pages.length && matches.length < INTERNAL_CAP; pageIdx++) {
+                const pageLines = (pages[pageIdx].markdown ?? "").split("\n");
+                for (let lineIdx = 0; lineIdx < pageLines.length; lineIdx++) {
+                  if (regex.test(pageLines[lineIdx])) {
+                    matches.push({
+                      itemName: item.name,
+                      itemType: item.type,
+                      folderId: item.folderId ?? null,
+                      pageNumber: pageIdx + 1,
+                      lineStart: lineIdx + 1,
+                      content: pageLines[lineIdx].trim(),
+                    });
+                    if (matches.length >= INTERNAL_CAP) break;
+                  }
+                }
+              }
+            } else {
+              const text = extractText(item);
+              if (!text) continue;
 
-            const lines = text.split("\n");
-            for (let i = 0; i < lines.length; i++) {
-              if (regex.test(lines[i])) {
-                matches.push({
-                  itemName: item.name,
-                  itemType: item.type,
-                  folderId: item.folderId ?? null,
-                  lineStart: i + 1,
-                  content: lines[i].trim(),
-                });
-                if (matches.length >= INTERNAL_CAP) break;
+              const lines = text.split("\n");
+              for (let i = 0; i < lines.length; i++) {
+                if (regex.test(lines[i])) {
+                  matches.push({
+                    itemName: item.name,
+                    itemType: item.type,
+                    folderId: item.folderId ?? null,
+                    lineStart: i + 1,
+                    content: lines[i].trim(),
+                  });
+                  if (matches.length >= INTERNAL_CAP) break;
+                }
               }
             }
             if (matches.length >= INTERNAL_CAP) break;

--- a/src/app/api/workspaces/[id]/events/route.ts
+++ b/src/app/api/workspaces/[id]/events/route.ts
@@ -67,7 +67,7 @@ import {
   withErrorHandling,
 } from "@/lib/api/workspace-helpers";
 import { broadcastWorkspaceEventFromServer } from "@/lib/realtime/server-broadcast";
-import { invalidateWorkspaceCache } from "@/app/api/mcp/route";
+import { invalidateWorkspaceCache } from "@/lib/mcp/workspace-cache";
 
 /**
  * GET /api/workspaces/[id]/events

--- a/src/app/api/workspaces/[id]/events/route.ts
+++ b/src/app/api/workspaces/[id]/events/route.ts
@@ -67,6 +67,7 @@ import {
   withErrorHandling,
 } from "@/lib/api/workspace-helpers";
 import { broadcastWorkspaceEventFromServer } from "@/lib/realtime/server-broadcast";
+import { invalidateWorkspaceCache } from "@/app/api/mcp/route";
 
 /**
  * GET /api/workspaces/[id]/events
@@ -458,6 +459,9 @@ async function handlePOST(
   }
 
   // Success - no conflict
+  // Invalidate MCP cache for this workspace
+  invalidateWorkspaceCache(id);
+
   // Check if we need to create a snapshot (async, non-blocking)
   checkAndCreateSnapshot(id).catch((err) => {
     console.error(

--- a/src/app/share-copy/[id]/layout.tsx
+++ b/src/app/share-copy/[id]/layout.tsx
@@ -38,9 +38,15 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     }
 
     // Fetch full state to get potentially updated title/description
-    const state = await loadWorkspaceState(id);
+    let stateTitle: string | undefined;
+    try {
+      const state = await loadWorkspaceState(id);
+      stateTitle = state.globalTitle;
+    } catch (err) {
+      console.error("[generateMetadata] loadWorkspaceState failed for workspace", id, err);
+    }
 
-    const title = state.globalTitle || workspace[0].name || "Untitled Workspace";
+    const title = stateTitle || workspace[0].name || "Untitled Workspace";
     const sharedTitle = `Shared Workspace: ${title}`;
     const description = workspace[0].description || "View and import this shared ThinkEx workspace.";
     const fullTitle = getPageTitle(sharedTitle);

--- a/src/components/auth/AccountModal.tsx
+++ b/src/components/auth/AccountModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { Fragment, useState, useEffect } from "react";
 import {
   Dialog,
   DialogContent,
@@ -370,9 +370,53 @@ function IDEConfigSection({ copyToClipboard }: { copyToClipboard: (text: string)
   }
 }`;
 
+  const claudeCodeSnippet = `// .mcp.json  (project-level)
+{
+  "mcpServers": {
+    "thinkex": {
+      "type": "http",
+      "url": "${mcpUrl}",
+      "headers": {
+        "Authorization": "Bearer <your-api-key>"
+      }
+    }
+  }
+}`;
+
   const cursorGlobal = snippet("~/.cursor/mcp.json  (global — all projects)");
   const cursorProject = snippet(".cursor/mcp.json  (project-level)");
   const vscode = snippet(".vscode/mcp.json  (project-level)");
+
+  const ideTabs = [
+    {
+      value: "cursor-global",
+      tabLabel: "Cursor — global",
+      fileLabel: "~/.cursor/mcp.json",
+      code: cursorGlobal,
+      hint: "Applies to all your Cursor projects. Create the file if it doesn't exist.",
+    },
+    {
+      value: "cursor-project",
+      tabLabel: "Cursor — project",
+      fileLabel: ".cursor/mcp.json",
+      code: cursorProject,
+      hint: "Place this inside the root of a specific project. Useful for per-project keys.",
+    },
+    {
+      value: "vscode",
+      tabLabel: "VS Code",
+      fileLabel: ".vscode/mcp.json",
+      code: vscode,
+      hint: "Requires the MCP extension for VS Code. Place in the project root.",
+    },
+    {
+      value: "claude-code",
+      tabLabel: "Claude Code",
+      fileLabel: ".mcp.json",
+      code: claudeCodeSnippet,
+      hint: 'Place .mcp.json in your project root. Claude Code requires the "type": "http" field for remote servers.',
+    },
+  ] as const;
 
   return (
     <div className="mt-6">
@@ -383,21 +427,27 @@ function IDEConfigSection({ copyToClipboard }: { copyToClipboard: (text: string)
       </p>
 
       <Tabs defaultValue="cursor-global">
-        <TabsList className="mb-3 h-8">
-          <TabsTrigger value="cursor-global" className="text-xs px-3 h-7">Cursor — global</TabsTrigger>
-          <TabsTrigger value="cursor-project" className="text-xs px-3 h-7">Cursor — project</TabsTrigger>
-          <TabsTrigger value="vscode" className="text-xs px-3 h-7">VS Code</TabsTrigger>
+        <TabsList className="mb-3 h-auto min-h-8 w-full min-w-0 flex-wrap items-center justify-start gap-0 px-1 py-1">
+          {ideTabs.map((tab, index) => (
+            <Fragment key={tab.value}>
+              {index > 0 ? (
+                <span
+                  className="pointer-events-none mx-1.5 h-5 w-px shrink-0 self-center rounded-full bg-gradient-to-b from-border/15 via-border to-border/15"
+                  aria-hidden
+                />
+              ) : null}
+              <TabsTrigger value={tab.value} className="text-xs px-3 h-7">
+                {tab.tabLabel}
+              </TabsTrigger>
+            </Fragment>
+          ))}
         </TabsList>
 
-        {[
-          { value: "cursor-global", label: "~/.cursor/mcp.json", code: cursorGlobal, hint: "Applies to all your Cursor projects. Create the file if it doesn't exist." },
-          { value: "cursor-project", label: ".cursor/mcp.json", code: cursorProject, hint: "Place this inside the root of a specific project. Useful for per-project keys." },
-          { value: "vscode", label: ".vscode/mcp.json", code: vscode, hint: "Requires the MCP extension for VS Code. Place in the project root." },
-        ].map(({ value, label, code, hint }) => (
+        {ideTabs.map(({ value, fileLabel, code, hint }) => (
           <TabsContent key={value} value={value} className="mt-0">
             <div className="rounded-lg border bg-muted/40 overflow-hidden">
               <div className="flex items-center justify-between px-3 py-2 border-b bg-muted/60">
-                <code className="text-xs font-mono text-muted-foreground">{label}</code>
+                <code className="text-xs font-mono text-muted-foreground">{fileLabel}</code>
                 <Button
                   variant="ghost"
                   size="sm"

--- a/src/components/auth/AccountModal.tsx
+++ b/src/components/auth/AccountModal.tsx
@@ -7,6 +7,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { getBaseURL } from "@/lib/base-url";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -45,14 +47,18 @@ export function AccountModal({ open, onOpenChange }: AccountModalProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
-        <DialogHeader>
-          <DialogTitle>Account Settings</DialogTitle>
-        </DialogHeader>
-        <div className="mt-4 space-y-6">
-          <ProfileForm user={session.user} />
-          <MCPAccessSection />
-          <DangerZone />
+      <DialogContent className="max-w-2xl max-h-[min(90vh,100dvh)] flex flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl">
+        <div className="shrink-0 border-b px-6 py-4 pr-14">
+          <DialogHeader className="text-left">
+            <DialogTitle>Account Settings</DialogTitle>
+          </DialogHeader>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-6 py-4">
+          <div className="space-y-6">
+            <ProfileForm user={session.user} />
+            <MCPAccessSection />
+            <DangerZone />
+          </div>
         </div>
       </DialogContent>
     </Dialog>
@@ -251,24 +257,7 @@ function MCPAccessSection() {
           Create API Key
         </Button>
 
-        <div className="mt-6">
-          <h4 className="text-sm font-medium mb-2">IDE Configuration</h4>
-          <p className="text-xs text-muted-foreground mb-2">
-            Add this to your MCP settings file:
-          </p>
-          <pre className="bg-muted p-3 rounded text-xs overflow-x-auto">
-{`{
-  "mcpServers": {
-    "thinkex": {
-      "url": "${typeof window !== 'undefined' ? window.location.origin : 'https://thinkex.app'}/api/mcp",
-      "headers": {
-        "Authorization": "Bearer <your-api-key>"
-      }
-    }
-  }
-}`}
-          </pre>
-        </div>
+        <IDEConfigSection copyToClipboard={copyToClipboard} />
       </div>
 
       <AlertDialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
@@ -363,6 +352,69 @@ function MCPAccessSection() {
         </AlertDialogContent>
       </AlertDialog>
     </>
+  );
+}
+
+function IDEConfigSection({ copyToClipboard }: { copyToClipboard: (text: string) => void }) {
+  const mcpUrl = `${getBaseURL()}/api/mcp`;
+
+  const snippet = (filePath: string) => `// ${filePath}
+{
+  "mcpServers": {
+    "thinkex": {
+      "url": "${mcpUrl}",
+      "headers": {
+        "Authorization": "Bearer <your-api-key>"
+      }
+    }
+  }
+}`;
+
+  const cursorGlobal = snippet("~/.cursor/mcp.json  (global — all projects)");
+  const cursorProject = snippet(".cursor/mcp.json  (project-level)");
+  const vscode = snippet(".vscode/mcp.json  (project-level)");
+
+  return (
+    <div className="mt-6">
+      <h4 className="text-sm font-medium mb-1">IDE Configuration</h4>
+      <p className="text-xs text-muted-foreground mb-3">
+        Create (or edit) the config file shown below and paste the snippet inside.
+        After saving, your IDE will discover the ThinkEx MCP server automatically.
+      </p>
+
+      <Tabs defaultValue="cursor-global">
+        <TabsList className="mb-3 h-8">
+          <TabsTrigger value="cursor-global" className="text-xs px-3 h-7">Cursor — global</TabsTrigger>
+          <TabsTrigger value="cursor-project" className="text-xs px-3 h-7">Cursor — project</TabsTrigger>
+          <TabsTrigger value="vscode" className="text-xs px-3 h-7">VS Code</TabsTrigger>
+        </TabsList>
+
+        {[
+          { value: "cursor-global", label: "~/.cursor/mcp.json", code: cursorGlobal, hint: "Applies to all your Cursor projects. Create the file if it doesn't exist." },
+          { value: "cursor-project", label: ".cursor/mcp.json", code: cursorProject, hint: "Place this inside the root of a specific project. Useful for per-project keys." },
+          { value: "vscode", label: ".vscode/mcp.json", code: vscode, hint: "Requires the MCP extension for VS Code. Place in the project root." },
+        ].map(({ value, label, code, hint }) => (
+          <TabsContent key={value} value={value} className="mt-0">
+            <div className="rounded-lg border bg-muted/40 overflow-hidden">
+              <div className="flex items-center justify-between px-3 py-2 border-b bg-muted/60">
+                <code className="text-xs font-mono text-muted-foreground">{label}</code>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-2 text-xs gap-1"
+                  onClick={() => copyToClipboard(code)}
+                >
+                  <Copy className="h-3 w-3" />
+                  Copy
+                </Button>
+              </div>
+              <pre className="p-3 text-xs overflow-x-auto leading-relaxed">{code}</pre>
+            </div>
+            <p className="text-xs text-muted-foreground mt-2">{hint}</p>
+          </TabsContent>
+        ))}
+      </Tabs>
+    </div>
   );
 }
 

--- a/src/components/auth/AccountModal.tsx
+++ b/src/components/auth/AccountModal.tsx
@@ -14,7 +14,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { authClient, useSession } from "@/lib/auth-client";
 import { toast } from "sonner";
-import { Loader2, Copy, Plus, Trash2 } from "lucide-react";
+import { Loader2, Copy, Plus, Trash2, ChevronDown } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   AlertDialog,
@@ -34,6 +34,11 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from "@/components/ui/collapsible";
 
 interface AccountModalProps {
   open: boolean;
@@ -126,8 +131,9 @@ interface APIKey {
 }
 
 function MCPAccessSection() {
+  const [open, setOpen] = useState(false);
   const [keys, setKeys] = useState<APIKey[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
   const [loadFailed, setLoadFailed] = useState(false);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [showKeyModal, setShowKeyModal] = useState(false);
@@ -157,8 +163,11 @@ function MCPAccessSection() {
   };
 
   useEffect(() => {
-    fetchKeys();
-  }, []);
+    if (open && keys.length === 0 && !loadFailed) {
+      setIsLoading(true);
+      fetchKeys();
+    }
+  }, [open]);
 
   const handleCreateKey = async () => {
     setIsCreating(true);
@@ -210,69 +219,80 @@ function MCPAccessSection() {
 
   return (
     <>
-      <div className="border-t pt-6">
-        <h3 className="text-lg font-medium mb-2">MCP Access</h3>
-        <p className="text-sm text-muted-foreground mb-4">
-          API keys allow external tools like IDEs to access your workspaces via the Model Context Protocol.
-        </p>
+      <Collapsible open={open} onOpenChange={setOpen} className="border-t">
+        <CollapsibleTrigger asChild>
+          <button className="flex w-full items-center justify-between text-left group cursor-pointer pt-6">
+            <div>
+              <h3 className="text-lg font-medium">MCP Access</h3>
+              <p className="text-sm text-muted-foreground mt-0.5">
+                API keys for IDE integrations via the Model Context Protocol.
+              </p>
+            </div>
+            <ChevronDown
+              className="h-5 w-5 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180"
+            />
+          </button>
+        </CollapsibleTrigger>
 
-        {isLoading ? (
-          <div className="flex items-center justify-center py-8">
-            <Loader2 className="h-6 w-6 animate-spin" />
-          </div>
-        ) : loadFailed ? (
-          <div className="text-sm text-destructive mb-4">
-            Failed to load API keys. Please try again.
-          </div>
-        ) : keys.length === 0 ? (
-          <div className="text-sm text-muted-foreground mb-4">
-            No API keys yet. Create one to get started.
-          </div>
-        ) : (
-          <div className="mb-4 border rounded-lg">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Label</TableHead>
-                  <TableHead>Key Prefix</TableHead>
-                  <TableHead>Created</TableHead>
-                  <TableHead>Last Used</TableHead>
-                  <TableHead className="w-[80px]">Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {keys.map((key) => (
-                  <TableRow key={key.id}>
-                    <TableCell>{key.label || <span className="text-muted-foreground italic">Unlabeled</span>}</TableCell>
-                    <TableCell>
-                      <code className="text-xs bg-muted px-2 py-1 rounded">{key.prefix}...</code>
-                    </TableCell>
-                    <TableCell className="text-sm">{formatDate(key.createdAt)}</TableCell>
-                    <TableCell className="text-sm">{formatDate(key.lastUsedAt)}</TableCell>
-                    <TableCell>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        aria-label={`Revoke key ${key.label || key.prefix}`}
-                        onClick={() => setKeyToRevoke(key.id)}
-                      >
-                        <Trash2 className="h-4 w-4 text-destructive" />
-                      </Button>
-                    </TableCell>
+        <CollapsibleContent className="pt-4 space-y-4">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin" />
+            </div>
+          ) : loadFailed ? (
+            <div className="text-sm text-destructive">
+              Failed to load API keys. Please try again.
+            </div>
+          ) : keys.length === 0 ? (
+            <div className="text-sm text-muted-foreground">
+              No API keys yet. Create one to get started.
+            </div>
+          ) : (
+            <div className="border rounded-lg">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Label</TableHead>
+                    <TableHead>Key Prefix</TableHead>
+                    <TableHead>Created</TableHead>
+                    <TableHead>Last Used</TableHead>
+                    <TableHead className="w-[80px]">Actions</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-        )}
+                </TableHeader>
+                <TableBody>
+                  {keys.map((key) => (
+                    <TableRow key={key.id}>
+                      <TableCell>{key.label || <span className="text-muted-foreground italic">Unlabeled</span>}</TableCell>
+                      <TableCell>
+                        <code className="text-xs bg-muted px-2 py-1 rounded">{key.prefix}...</code>
+                      </TableCell>
+                      <TableCell className="text-sm">{formatDate(key.createdAt)}</TableCell>
+                      <TableCell className="text-sm">{formatDate(key.lastUsedAt)}</TableCell>
+                      <TableCell>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          aria-label={`Revoke key ${key.label || key.prefix}`}
+                          onClick={() => setKeyToRevoke(key.id)}
+                        >
+                          <Trash2 className="h-4 w-4 text-destructive" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
 
-        <Button onClick={() => setShowCreateDialog(true)}>
-          <Plus className="mr-2 h-4 w-4" />
-          Create API Key
-        </Button>
+          <Button onClick={() => setShowCreateDialog(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            Create API Key
+          </Button>
 
-        <IDEConfigSection copyToClipboard={copyToClipboard} />
-      </div>
+          <IDEConfigSection copyToClipboard={copyToClipboard} />
+        </CollapsibleContent>
+      </Collapsible>
 
       <AlertDialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
         <AlertDialogContent>

--- a/src/components/auth/AccountModal.tsx
+++ b/src/components/auth/AccountModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, useState, useEffect } from "react";
+import { Fragment, useState, useEffect, useRef } from "react";
 import {
   Dialog,
   DialogContent,
@@ -141,10 +141,13 @@ function MCPAccessSection() {
   const [label, setLabel] = useState("");
   const [isCreating, setIsCreating] = useState(false);
   const [keyToRevoke, setKeyToRevoke] = useState<string | null>(null);
+  const latestFetchIdRef = useRef(0);
 
   const fetchKeys = async () => {
+    const fetchId = ++latestFetchIdRef.current;
     try {
       const res = await fetch("/api/mcp-keys");
+      if (fetchId !== latestFetchIdRef.current) return;
       if (!res.ok) {
         console.error("Failed to load API keys:", res.status, res.statusText);
         toast.error("Failed to load API keys");
@@ -152,22 +155,27 @@ function MCPAccessSection() {
         return;
       }
       const data = await res.json();
+      if (fetchId !== latestFetchIdRef.current) return;
       setKeys(data.keys || []);
       setLoadFailed(false);
     } catch (error) {
+      if (fetchId !== latestFetchIdRef.current) return;
       toast.error("Failed to load API keys");
       setLoadFailed(true);
     } finally {
-      setIsLoading(false);
+      if (fetchId === latestFetchIdRef.current) {
+        setIsLoading(false);
+      }
     }
   };
 
   useEffect(() => {
-    if (open && keys.length === 0 && !loadFailed) {
+    if (open && keys.length === 0) {
       setIsLoading(true);
       fetchKeys();
     }
-  }, [open]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, loadFailed, keys.length]);
 
   const handleCreateKey = async () => {
     setIsCreating(true);
@@ -178,7 +186,15 @@ function MCPAccessSection() {
         body: JSON.stringify({ label: label || null }),
       });
 
-      if (!res.ok) throw new Error("Failed to create API key");
+      if (!res.ok) {
+        let errorMessage = "Failed to create API key";
+        try {
+          const errData = await res.json();
+          errorMessage = errData.message || errData.error || errorMessage;
+        } catch {}
+        toast.error(errorMessage);
+        return;
+      }
 
       const data = await res.json();
       setNewKeyData({ rawKey: data.rawKey, prefix: data.prefix });
@@ -186,8 +202,8 @@ function MCPAccessSection() {
       setShowKeyModal(true);
       setLabel("");
       await fetchKeys();
-    } catch (error) {
-      toast.error("Failed to create API key");
+    } catch (error: any) {
+      toast.error(error?.message || "Failed to create API key");
     } finally {
       setIsCreating(false);
     }

--- a/src/components/auth/AccountModal.tsx
+++ b/src/components/auth/AccountModal.tsx
@@ -170,12 +170,19 @@ function MCPAccessSection() {
   };
 
   useEffect(() => {
-    if (open && keys.length === 0) {
+    if (open) {
+      setLoadFailed(false);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  useEffect(() => {
+    if (open && keys.length === 0 && !loadFailed) {
       setIsLoading(true);
       fetchKeys();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, loadFailed, keys.length]);
+  }, [open, keys.length]);
 
   const handleCreateKey = async () => {
     setIsCreating(true);

--- a/src/components/auth/AccountModal.tsx
+++ b/src/components/auth/AccountModal.tsx
@@ -128,6 +128,7 @@ interface APIKey {
 function MCPAccessSection() {
   const [keys, setKeys] = useState<APIKey[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [loadFailed, setLoadFailed] = useState(false);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [showKeyModal, setShowKeyModal] = useState(false);
   const [newKeyData, setNewKeyData] = useState<{ rawKey: string; prefix: string } | null>(null);
@@ -141,12 +142,15 @@ function MCPAccessSection() {
       if (!res.ok) {
         console.error("Failed to load API keys:", res.status, res.statusText);
         toast.error("Failed to load API keys");
+        setLoadFailed(true);
         return;
       }
       const data = await res.json();
       setKeys(data.keys || []);
+      setLoadFailed(false);
     } catch (error) {
       toast.error("Failed to load API keys");
+      setLoadFailed(true);
     } finally {
       setIsLoading(false);
     }
@@ -216,6 +220,10 @@ function MCPAccessSection() {
           <div className="flex items-center justify-center py-8">
             <Loader2 className="h-6 w-6 animate-spin" />
           </div>
+        ) : loadFailed ? (
+          <div className="text-sm text-destructive mb-4">
+            Failed to load API keys. Please try again.
+          </div>
         ) : keys.length === 0 ? (
           <div className="text-sm text-muted-foreground mb-4">
             No API keys yet. Create one to get started.
@@ -245,6 +253,7 @@ function MCPAccessSection() {
                       <Button
                         variant="ghost"
                         size="sm"
+                        aria-label={`Revoke key ${key.label || key.prefix}`}
                         onClick={() => setKeyToRevoke(key.id)}
                       >
                         <Trash2 className="h-4 w-4 text-destructive" />
@@ -317,6 +326,7 @@ function MCPAccessSection() {
               <Button
                 size="sm"
                 variant="outline"
+                aria-label="Copy API key"
                 onClick={() => copyToClipboard(newKeyData?.rawKey || "")}
               >
                 <Copy className="h-4 w-4" />

--- a/src/components/auth/AccountModal.tsx
+++ b/src/components/auth/AccountModal.tsx
@@ -138,6 +138,11 @@ function MCPAccessSection() {
   const fetchKeys = async () => {
     try {
       const res = await fetch("/api/mcp-keys");
+      if (!res.ok) {
+        console.error("Failed to load API keys:", res.status, res.statusText);
+        toast.error("Failed to load API keys");
+        return;
+      }
       const data = await res.json();
       setKeys(data.keys || []);
     } catch (error) {
@@ -358,8 +363,7 @@ function MCPAccessSection() {
 function IDEConfigSection({ copyToClipboard }: { copyToClipboard: (text: string) => void }) {
   const mcpUrl = `${getBaseURL()}/api/mcp`;
 
-  const snippet = (filePath: string) => `// ${filePath}
-{
+  const snippet = () => `{
   "mcpServers": {
     "thinkex": {
       "url": "${mcpUrl}",
@@ -370,8 +374,7 @@ function IDEConfigSection({ copyToClipboard }: { copyToClipboard: (text: string)
   }
 }`;
 
-  const claudeCodeSnippet = `// .mcp.json  (project-level)
-{
+  const claudeCodeSnippet = `{
   "mcpServers": {
     "thinkex": {
       "type": "http",
@@ -383,9 +386,9 @@ function IDEConfigSection({ copyToClipboard }: { copyToClipboard: (text: string)
   }
 }`;
 
-  const cursorGlobal = snippet("~/.cursor/mcp.json  (global — all projects)");
-  const cursorProject = snippet(".cursor/mcp.json  (project-level)");
-  const vscode = snippet(".vscode/mcp.json  (project-level)");
+  const cursorGlobal = snippet();
+  const cursorProject = snippet();
+  const vscode = snippet();
 
   const ideTabs = [
     {

--- a/src/components/auth/AccountModal.tsx
+++ b/src/components/auth/AccountModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Dialog,
   DialogContent,
@@ -12,7 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { authClient, useSession } from "@/lib/auth-client";
 import { toast } from "sonner";
-import { Loader2 } from "lucide-react";
+import { Loader2, Copy, Plus, Trash2 } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   AlertDialog,
@@ -24,6 +24,14 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 
 interface AccountModalProps {
   open: boolean;
@@ -43,6 +51,7 @@ export function AccountModal({ open, onOpenChange }: AccountModalProps) {
         </DialogHeader>
         <div className="mt-4 space-y-6">
           <ProfileForm user={session.user} />
+          <MCPAccessSection />
           <DangerZone />
         </div>
       </DialogContent>
@@ -99,6 +108,261 @@ function ProfileForm({ user }: { user: any }) {
         </Button>
       </div>
     </form>
+  );
+}
+
+interface APIKey {
+  id: string;
+  prefix: string;
+  label: string | null;
+  createdAt: string;
+  lastUsedAt: string | null;
+}
+
+function MCPAccessSection() {
+  const [keys, setKeys] = useState<APIKey[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [showKeyModal, setShowKeyModal] = useState(false);
+  const [newKeyData, setNewKeyData] = useState<{ rawKey: string; prefix: string } | null>(null);
+  const [label, setLabel] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+  const [keyToRevoke, setKeyToRevoke] = useState<string | null>(null);
+
+  const fetchKeys = async () => {
+    try {
+      const res = await fetch("/api/mcp-keys");
+      const data = await res.json();
+      setKeys(data.keys || []);
+    } catch (error) {
+      toast.error("Failed to load API keys");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchKeys();
+  }, []);
+
+  const handleCreateKey = async () => {
+    setIsCreating(true);
+    try {
+      const res = await fetch("/api/mcp-keys", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label: label || null }),
+      });
+
+      if (!res.ok) throw new Error("Failed to create API key");
+
+      const data = await res.json();
+      setNewKeyData({ rawKey: data.rawKey, prefix: data.prefix });
+      setShowCreateDialog(false);
+      setShowKeyModal(true);
+      setLabel("");
+      await fetchKeys();
+    } catch (error) {
+      toast.error("Failed to create API key");
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleRevokeKey = async (id: string) => {
+    try {
+      const res = await fetch(`/api/mcp-keys/${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Failed to revoke API key");
+
+      toast.success("API key revoked successfully");
+      await fetchKeys();
+    } catch (error) {
+      toast.error("Failed to revoke API key");
+    } finally {
+      setKeyToRevoke(null);
+    }
+  };
+
+  const copyToClipboard = (text: string) => {
+    navigator.clipboard.writeText(text);
+    toast.success("Copied to clipboard");
+  };
+
+  const formatDate = (dateStr: string | null) => {
+    if (!dateStr) return "—";
+    return new Date(dateStr).toLocaleDateString();
+  };
+
+  return (
+    <>
+      <div className="border-t pt-6">
+        <h3 className="text-lg font-medium mb-2">MCP Access</h3>
+        <p className="text-sm text-muted-foreground mb-4">
+          API keys allow external tools like IDEs to access your workspaces via the Model Context Protocol.
+        </p>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin" />
+          </div>
+        ) : keys.length === 0 ? (
+          <div className="text-sm text-muted-foreground mb-4">
+            No API keys yet. Create one to get started.
+          </div>
+        ) : (
+          <div className="mb-4 border rounded-lg">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Label</TableHead>
+                  <TableHead>Key Prefix</TableHead>
+                  <TableHead>Created</TableHead>
+                  <TableHead>Last Used</TableHead>
+                  <TableHead className="w-[80px]">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {keys.map((key) => (
+                  <TableRow key={key.id}>
+                    <TableCell>{key.label || <span className="text-muted-foreground italic">Unlabeled</span>}</TableCell>
+                    <TableCell>
+                      <code className="text-xs bg-muted px-2 py-1 rounded">{key.prefix}...</code>
+                    </TableCell>
+                    <TableCell className="text-sm">{formatDate(key.createdAt)}</TableCell>
+                    <TableCell className="text-sm">{formatDate(key.lastUsedAt)}</TableCell>
+                    <TableCell>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setKeyToRevoke(key.id)}
+                      >
+                        <Trash2 className="h-4 w-4 text-destructive" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+
+        <Button onClick={() => setShowCreateDialog(true)}>
+          <Plus className="mr-2 h-4 w-4" />
+          Create API Key
+        </Button>
+
+        <div className="mt-6">
+          <h4 className="text-sm font-medium mb-2">IDE Configuration</h4>
+          <p className="text-xs text-muted-foreground mb-2">
+            Add this to your MCP settings file:
+          </p>
+          <pre className="bg-muted p-3 rounded text-xs overflow-x-auto">
+{`{
+  "mcpServers": {
+    "thinkex": {
+      "url": "${typeof window !== 'undefined' ? window.location.origin : 'https://thinkex.app'}/api/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-api-key>"
+      }
+    }
+  }
+}`}
+          </pre>
+        </div>
+      </div>
+
+      <AlertDialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Create API Key</AlertDialogTitle>
+            <AlertDialogDescription>
+              Give this API key a label to help you identify it later (optional).
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="py-4">
+            <Label htmlFor="key-label">Label (optional)</Label>
+            <Input
+              id="key-label"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="e.g., My MacBook"
+              className="mt-2"
+            />
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isCreating}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                handleCreateKey();
+              }}
+              disabled={isCreating}
+            >
+              {isCreating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              Create Key
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={showKeyModal} onOpenChange={setShowKeyModal}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>API Key Created</AlertDialogTitle>
+            <AlertDialogDescription>
+              Copy this key now. You will not be able to see it again.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="py-4">
+            <div className="flex items-center gap-2">
+              <Input
+                value={newKeyData?.rawKey || ""}
+                readOnly
+                className="font-mono text-sm"
+              />
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => copyToClipboard(newKeyData?.rawKey || "")}
+              >
+                <Copy className="h-4 w-4" />
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground mt-2">
+              This key will not be shown again. Store it in a secure location.
+            </p>
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogAction onClick={() => { setShowKeyModal(false); setNewKeyData(null); }}>
+              Done
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={keyToRevoke !== null} onOpenChange={() => setKeyToRevoke(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Revoke API Key?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will immediately revoke the API key. Any applications using this key will lose access.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                if (keyToRevoke) handleRevokeKey(keyToRevoke);
+              }}
+              className="bg-red-500 hover:bg-red-600"
+            >
+              Revoke Key
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }
 

--- a/src/components/auth/AccountModal.tsx
+++ b/src/components/auth/AccountModal.tsx
@@ -182,7 +182,7 @@ function MCPAccessSection() {
       fetchKeys();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, keys.length]);
+  }, [open, keys.length, loadFailed]);
 
   const handleCreateKey = async () => {
     setIsCreating(true);

--- a/src/components/auth/AccountModal.tsx
+++ b/src/components/auth/AccountModal.tsx
@@ -207,9 +207,13 @@ function MCPAccessSection() {
     }
   };
 
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
-    toast.success("Copied to clipboard");
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success("Copied to clipboard");
+    } catch {
+      toast.error("Failed to copy to clipboard");
+    }
   };
 
   const formatDate = (dateStr: string | null) => {
@@ -328,7 +332,7 @@ function MCPAccessSection() {
         </AlertDialogContent>
       </AlertDialog>
 
-      <AlertDialog open={showKeyModal} onOpenChange={setShowKeyModal}>
+      <AlertDialog open={showKeyModal} onOpenChange={(open) => { setShowKeyModal(open); if (!open) setNewKeyData(null); }}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>API Key Created</AlertDialogTitle>

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,120 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+))
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn(
+      "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
+    )}
+    {...props}
+  />
+))
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm cursor-pointer",
       className
     )}
     {...props}

--- a/src/lib/ai/tools/tool-utils.ts
+++ b/src/lib/ai/tools/tool-utils.ts
@@ -59,8 +59,13 @@ export async function loadStateForTool(
         return { success: false, message: "No workspace context available" };
     }
 
-    const state = await loadWorkspaceState(ctx.workspaceId);
-    return { success: true, state };
+    try {
+      const state = await loadWorkspaceState(ctx.workspaceId);
+      return { success: true, state };
+    } catch (err) {
+      console.error("[loadStateForTool] loadWorkspaceState failed", err);
+      return { success: false, message: "Failed to load workspace state" };
+    }
 }
 
 /**

--- a/src/lib/ai/workers/workspace-worker.ts
+++ b/src/lib/ai/workers/workspace-worker.ts
@@ -247,6 +247,15 @@ async function broadcastPersistedWorkspaceEvent(
   });
 }
 
+async function postAppendSuccess(
+  workspaceId: string,
+  event: WorkspaceEvent,
+  version: number,
+): Promise<void> {
+  invalidateWorkspaceCache(workspaceId);
+  await broadcastPersistedWorkspaceEvent(workspaceId, event, version);
+}
+
 /**
  * WORKER 3: Workspace Management Agent
  * Manages workspace items (create, update, delete)
@@ -458,7 +467,6 @@ export async function workspaceWorker(
 
             // If no conflict, we're done
             if (!appendResult.conflict) {
-              invalidateWorkspaceCache(params.workspaceId);
               break;
             }
 
@@ -487,11 +495,7 @@ export async function workspaceWorker(
 
           logger.info(`📝 [WORKSPACE-WORKER] Created ${item.type}:`, item.name);
 
-          await broadcastPersistedWorkspaceEvent(
-            params.workspaceId,
-            event,
-            appendResult.version,
-          );
+          await postAppendSuccess(params.workspaceId, event, appendResult.version);
 
           // Include card count for flashcard decks (use created item.data.cards, not params)
           const flashcardCards =
@@ -557,16 +561,10 @@ export async function workspaceWorker(
               "Workspace was modified by another user, please try again",
             );
           }
-          invalidateWorkspaceCache(params.workspaceId);
-
           logger.info(
             `📝 [WORKSPACE-WORKER] Bulk created ${items.length} items`,
           );
-          await broadcastPersistedWorkspaceEvent(
-            params.workspaceId,
-            event,
-            appendResult.version,
-          );
+          await postAppendSuccess(params.workspaceId, event, appendResult.version);
           return {
             success: true,
             message: `Bulk created ${items.length} items successfully`,
@@ -685,8 +683,6 @@ export async function workspaceWorker(
               "Workspace was modified by another user, please try again",
             );
           }
-          invalidateWorkspaceCache(params.workspaceId);
-
           logger.info("🎴 [WORKSPACE-WORKER] Updated flashcard deck:", {
             itemId: params.itemId,
             cardsAdded: newCards.length,
@@ -694,11 +690,7 @@ export async function workspaceWorker(
             newTitle: params.title,
           });
 
-          await broadcastPersistedWorkspaceEvent(
-            params.workspaceId,
-            event,
-            appendResult.version,
-          );
+          await postAppendSuccess(params.workspaceId, event, appendResult.version);
 
           return {
             success: true,
@@ -845,19 +837,13 @@ export async function workspaceWorker(
               "Workspace was modified by another user, please try again",
             );
           }
-          invalidateWorkspaceCache(params.workspaceId);
-
           logger.info("🎯 [WORKSPACE-WORKER] Updated quiz:", {
             itemId: params.itemId,
             questionsAdded: questionsToAdd?.length ?? 0,
             totalQuestions: updatedData.questions.length,
           });
 
-          await broadcastPersistedWorkspaceEvent(
-            params.workspaceId,
-            event,
-            appendResult.version,
-          );
+          await postAppendSuccess(params.workspaceId, event, appendResult.version);
 
           return {
             success: true,
@@ -972,19 +958,13 @@ export async function workspaceWorker(
               "Workspace was modified by another user, please try again",
             );
           }
-          invalidateWorkspaceCache(params.workspaceId);
-
           const contentLen = getOcrPagesTextContent(params.pdfOcrPages).length;
           logger.info("📄 [WORKSPACE-WORKER] Updated PDF OCR content:", {
             itemId: params.itemId,
             contentLength: contentLen,
           });
 
-          await broadcastPersistedWorkspaceEvent(
-            params.workspaceId,
-            event,
-            appendResult.version,
-          );
+          await postAppendSuccess(params.workspaceId, event, appendResult.version);
 
           return {
             success: true,
@@ -1078,13 +1058,7 @@ export async function workspaceWorker(
               "Workspace was modified by another user, please try again",
             );
           }
-          invalidateWorkspaceCache(params.workspaceId);
-
-          await broadcastPersistedWorkspaceEvent(
-            params.workspaceId,
-            event,
-            appendResult.version,
-          );
+          await postAppendSuccess(params.workspaceId, event, appendResult.version);
 
           return {
             success: true,
@@ -1222,13 +1196,7 @@ export async function workspaceWorker(
               throw new Error(
                 "Workspace was modified by another user, please try again",
               );
-            invalidateWorkspaceCache(params.workspaceId);
-
-            await broadcastPersistedWorkspaceEvent(
-              params.workspaceId,
-              event,
-              appendResult.version,
-            );
+            await postAppendSuccess(params.workspaceId, event, appendResult.version);
 
             return {
               success: true,
@@ -1357,13 +1325,7 @@ export async function workspaceWorker(
               throw new Error(
                 "Workspace was modified by another user, please try again",
               );
-            invalidateWorkspaceCache(params.workspaceId);
-
-            await broadcastPersistedWorkspaceEvent(
-              params.workspaceId,
-              event,
-              appendResult.version,
-            );
+            await postAppendSuccess(params.workspaceId, event, appendResult.version);
 
             return {
               success: true,
@@ -1466,13 +1428,7 @@ export async function workspaceWorker(
               throw new Error(
                 "Workspace was modified by another user, please try again",
               );
-            invalidateWorkspaceCache(params.workspaceId);
-
-            await broadcastPersistedWorkspaceEvent(
-              params.workspaceId,
-              event,
-              appendResult.version,
-            );
+            await postAppendSuccess(params.workspaceId, event, appendResult.version);
 
             const diffOutput = trimDiff(
               createPatch(
@@ -1548,12 +1504,7 @@ export async function workspaceWorker(
               throw new Error(
                 "Workspace was modified by another user, please try again",
               );
-            invalidateWorkspaceCache(params.workspaceId);
-            await broadcastPersistedWorkspaceEvent(
-              params.workspaceId,
-              event,
-              appendResult.version,
-            );
+            await postAppendSuccess(params.workspaceId, event, appendResult.version);
             return {
               success: true,
               itemId: params.itemId,
@@ -1611,15 +1562,9 @@ export async function workspaceWorker(
               "Workspace was modified by another user, please try again",
             );
           }
-          invalidateWorkspaceCache(params.workspaceId);
-
           logger.info("📝 [WORKSPACE-WORKER] Deleted item:", params.itemId);
 
-          await broadcastPersistedWorkspaceEvent(
-            params.workspaceId,
-            event,
-            appendResult.version,
-          );
+          await postAppendSuccess(params.workspaceId, event, appendResult.version);
 
           return {
             success: true,

--- a/src/lib/ai/workers/workspace-worker.ts
+++ b/src/lib/ai/workers/workspace-worker.ts
@@ -31,6 +31,7 @@ import {
 import { parseJsonWithRepair } from "@/lib/utils/json-repair";
 import { buildPdfDataFromUpload } from "@/lib/pdf/pdf-item";
 import { broadcastWorkspaceEventFromServer } from "@/lib/realtime/server-broadcast";
+import { invalidateWorkspaceCache } from "@/app/api/mcp/route";
 
 /** Create params for a single item (used by create and bulkCreate). Exported for autogen. */
 export type CreateItemParams = {
@@ -457,6 +458,7 @@ export async function workspaceWorker(
 
             // If no conflict, we're done
             if (!appendResult.conflict) {
+              invalidateWorkspaceCache(params.workspaceId);
               break;
             }
 
@@ -555,6 +557,7 @@ export async function workspaceWorker(
               "Workspace was modified by another user, please try again",
             );
           }
+          invalidateWorkspaceCache(params.workspaceId);
 
           logger.info(
             `📝 [WORKSPACE-WORKER] Bulk created ${items.length} items`,
@@ -682,6 +685,7 @@ export async function workspaceWorker(
               "Workspace was modified by another user, please try again",
             );
           }
+          invalidateWorkspaceCache(params.workspaceId);
 
           logger.info("🎴 [WORKSPACE-WORKER] Updated flashcard deck:", {
             itemId: params.itemId,
@@ -841,6 +845,7 @@ export async function workspaceWorker(
               "Workspace was modified by another user, please try again",
             );
           }
+          invalidateWorkspaceCache(params.workspaceId);
 
           logger.info("🎯 [WORKSPACE-WORKER] Updated quiz:", {
             itemId: params.itemId,
@@ -967,6 +972,7 @@ export async function workspaceWorker(
               "Workspace was modified by another user, please try again",
             );
           }
+          invalidateWorkspaceCache(params.workspaceId);
 
           const contentLen = getOcrPagesTextContent(params.pdfOcrPages).length;
           logger.info("📄 [WORKSPACE-WORKER] Updated PDF OCR content:", {
@@ -1072,6 +1078,7 @@ export async function workspaceWorker(
               "Workspace was modified by another user, please try again",
             );
           }
+          invalidateWorkspaceCache(params.workspaceId);
 
           await broadcastPersistedWorkspaceEvent(
             params.workspaceId,
@@ -1215,6 +1222,7 @@ export async function workspaceWorker(
               throw new Error(
                 "Workspace was modified by another user, please try again",
               );
+            invalidateWorkspaceCache(params.workspaceId);
 
             await broadcastPersistedWorkspaceEvent(
               params.workspaceId,
@@ -1349,6 +1357,7 @@ export async function workspaceWorker(
               throw new Error(
                 "Workspace was modified by another user, please try again",
               );
+            invalidateWorkspaceCache(params.workspaceId);
 
             await broadcastPersistedWorkspaceEvent(
               params.workspaceId,
@@ -1457,6 +1466,7 @@ export async function workspaceWorker(
               throw new Error(
                 "Workspace was modified by another user, please try again",
               );
+            invalidateWorkspaceCache(params.workspaceId);
 
             await broadcastPersistedWorkspaceEvent(
               params.workspaceId,
@@ -1538,6 +1548,7 @@ export async function workspaceWorker(
               throw new Error(
                 "Workspace was modified by another user, please try again",
               );
+            invalidateWorkspaceCache(params.workspaceId);
             await broadcastPersistedWorkspaceEvent(
               params.workspaceId,
               event,
@@ -1600,6 +1611,7 @@ export async function workspaceWorker(
               "Workspace was modified by another user, please try again",
             );
           }
+          invalidateWorkspaceCache(params.workspaceId);
 
           logger.info("📝 [WORKSPACE-WORKER] Deleted item:", params.itemId);
 

--- a/src/lib/ai/workers/workspace-worker.ts
+++ b/src/lib/ai/workers/workspace-worker.ts
@@ -31,7 +31,7 @@ import {
 import { parseJsonWithRepair } from "@/lib/utils/json-repair";
 import { buildPdfDataFromUpload } from "@/lib/pdf/pdf-item";
 import { broadcastWorkspaceEventFromServer } from "@/lib/realtime/server-broadcast";
-import { invalidateWorkspaceCache } from "@/app/api/mcp/route";
+import { invalidateWorkspaceCache } from "@/lib/mcp/workspace-cache";
 
 /** Create params for a single item (used by create and bulkCreate). Exported for autogen. */
 export type CreateItemParams = {

--- a/src/lib/base-url.ts
+++ b/src/lib/base-url.ts
@@ -1,0 +1,20 @@
+const PRODUCTION_URL = "https://thinkex.app";
+
+/**
+ * Returns the canonical app base URL.
+ * Safe to call from both server and client code.
+ *
+ * Priority:
+ *  1. NEXT_PUBLIC_APP_URL — if it is not a localhost address
+ *  2. Hard-coded production URL as fallback
+ *
+ * Localhost values are intentionally ignored so that config snippets
+ * shown to users always reference the live deployment.
+ */
+export function getBaseURL(): string {
+  const envUrl = process.env.NEXT_PUBLIC_APP_URL;
+  if (envUrl && !envUrl.includes("localhost") && !envUrl.includes("127.0.0.1")) {
+    return envUrl.replace(/\/$/, "");
+  }
+  return PRODUCTION_URL;
+}

--- a/src/lib/base-url.ts
+++ b/src/lib/base-url.ts
@@ -5,16 +5,36 @@ const PRODUCTION_URL = "https://thinkex.app";
  * Safe to call from both server and client code.
  *
  * Priority:
- *  1. NEXT_PUBLIC_APP_URL — if it is not a localhost address
- *  2. Hard-coded production URL as fallback
+ *  1. NEXT_PUBLIC_APP_URL — validated and trimmed; localhost values are
+ *     intentionally skipped so config snippets always show the live URL.
+ *  2. Hard-coded PRODUCTION_URL as fallback.
  *
- * Localhost values are intentionally ignored so that config snippets
- * shown to users always reference the live deployment.
+ * In non-production server environments (local dev, self-hosted) where
+ * NEXT_PUBLIC_APP_URL is absent or points to localhost, an Error is thrown
+ * so callers don't silently emit config snippets pointing at the live site.
+ * Client-side code (browser) always receives PRODUCTION_URL as fallback to
+ * avoid crashing the component tree.
  */
 export function getBaseURL(): string {
-  const envUrl = process.env.NEXT_PUBLIC_APP_URL;
+  const envUrl = process.env.NEXT_PUBLIC_APP_URL?.trim();
+
   if (envUrl && !envUrl.includes("localhost") && !envUrl.includes("127.0.0.1")) {
     return envUrl.replace(/\/$/, "");
   }
+
+  // On the server in a non-production environment (local dev, preview without
+  // NEXT_PUBLIC_APP_URL set) fail loudly rather than silently returning the
+  // production URL. typeof window check distinguishes server from browser.
+  if (
+    typeof window === "undefined" &&
+    process.env.NODE_ENV !== "production" &&
+    process.env.VERCEL_ENV !== "production"
+  ) {
+    throw new Error(
+      "NEXT_PUBLIC_APP_URL is missing or points to localhost. " +
+      "Set it to the canonical deployment URL (e.g. https://your-app.vercel.app)."
+    );
+  }
+
   return PRODUCTION_URL;
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -376,3 +376,16 @@ export const workspaceItemReads = pgTable(
 		}),
 	]
 );
+
+export const apiKeys = pgTable("api_keys", {
+	id: text("id").primaryKey().default(sql`gen_random_uuid()`),
+	userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+	keyHash: text("key_hash").notNull().unique(),
+	keyPrefix: text("key_prefix").notNull(),
+	label: text("label"),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: "string" }).defaultNow().notNull(),
+	lastUsedAt: timestamp("last_used_at", { withTimezone: true, mode: "string" }),
+	revokedAt: timestamp("revoked_at", { withTimezone: true, mode: "string" }),
+}, (table) => [
+	index("api_keys_user_id_idx").on(table.userId),
+]);

--- a/src/lib/mcp/workspace-cache.ts
+++ b/src/lib/mcp/workspace-cache.ts
@@ -3,13 +3,58 @@ import type { AgentState } from "@/lib/workspace-state/types";
 
 const stateCache = new Map<string, { state: AgentState; expiresAt: number }>();
 const CACHE_TTL_MS = 30_000;
+const CACHE_MAX_SIZE = 200;
+const PRUNE_INTERVAL_MS = 60_000;
+
+/**
+ * Removes expired entries from stateCache and, when the map still exceeds
+ * CACHE_MAX_SIZE after TTL pruning, evicts the oldest-inserted entries first
+ * (Map iteration order is insertion order in V8).
+ */
+function pruneStateCache(): void {
+  const now = Date.now();
+  for (const [key, entry] of stateCache) {
+    if (entry.expiresAt < now) {
+      stateCache.delete(key);
+    }
+  }
+  // Evict oldest entries when the cache is still over its size cap
+  if (stateCache.size > CACHE_MAX_SIZE) {
+    const overflow = stateCache.size - CACHE_MAX_SIZE;
+    let evicted = 0;
+    for (const key of stateCache.keys()) {
+      stateCache.delete(key);
+      if (++evicted >= overflow) break;
+    }
+  }
+}
+
+// Run periodic cleanup; the interval is unref'd so it won't keep the process
+// alive in test/serverless environments that track active handles.
+if (typeof setInterval !== "undefined") {
+  const timer = setInterval(pruneStateCache, PRUNE_INTERVAL_MS);
+  if (typeof timer === "object" && timer !== null && "unref" in timer) {
+    (timer as NodeJS.Timeout).unref();
+  }
+}
 
 export async function getCachedState(workspaceId: string): Promise<AgentState> {
   const cached = stateCache.get(workspaceId);
   if (cached && cached.expiresAt > Date.now()) return cached.state;
 
   const state = await loadWorkspaceState(workspaceId);
-  stateCache.set(workspaceId, { state, expiresAt: Date.now() + CACHE_TTL_MS });
+
+  // Only cache a state that looks like a real workspace. loadWorkspaceState
+  // returns { items: [], globalTitle: "" } as an error fallback — caching
+  // that would suppress DB errors for CACHE_TTL_MS on every request.
+  const isRealState =
+    state != null &&
+    (state.items.length > 0 || (state.globalTitle != null && state.globalTitle !== ""));
+
+  if (isRealState) {
+    stateCache.set(workspaceId, { state, expiresAt: Date.now() + CACHE_TTL_MS });
+  }
+
   return state;
 }
 

--- a/src/lib/mcp/workspace-cache.ts
+++ b/src/lib/mcp/workspace-cache.ts
@@ -42,19 +42,10 @@ export async function getCachedState(workspaceId: string): Promise<AgentState> {
   const cached = stateCache.get(workspaceId);
   if (cached && cached.expiresAt > Date.now()) return cached.state;
 
+  // loadWorkspaceState throws on DB error, so any state that reaches here is
+  // a genuine result (including legitimately empty new workspaces).
   const state = await loadWorkspaceState(workspaceId);
-
-  // Only cache a state that looks like a real workspace. loadWorkspaceState
-  // returns { items: [], globalTitle: "" } as an error fallback — caching
-  // that would suppress DB errors for CACHE_TTL_MS on every request.
-  const isRealState =
-    state != null &&
-    (state.items.length > 0 || (state.globalTitle != null && state.globalTitle !== ""));
-
-  if (isRealState) {
-    stateCache.set(workspaceId, { state, expiresAt: Date.now() + CACHE_TTL_MS });
-  }
-
+  stateCache.set(workspaceId, { state, expiresAt: Date.now() + CACHE_TTL_MS });
   return state;
 }
 

--- a/src/lib/mcp/workspace-cache.ts
+++ b/src/lib/mcp/workspace-cache.ts
@@ -1,0 +1,18 @@
+import { loadWorkspaceState } from "@/lib/workspace/state-loader";
+import type { AgentState } from "@/lib/workspace-state/types";
+
+const stateCache = new Map<string, { state: AgentState; expiresAt: number }>();
+const CACHE_TTL_MS = 30_000;
+
+export async function getCachedState(workspaceId: string): Promise<AgentState> {
+  const cached = stateCache.get(workspaceId);
+  if (cached && cached.expiresAt > Date.now()) return cached.state;
+
+  const state = await loadWorkspaceState(workspaceId);
+  stateCache.set(workspaceId, { state, expiresAt: Date.now() + CACHE_TTL_MS });
+  return state;
+}
+
+export function invalidateWorkspaceCache(workspaceId: string) {
+  stateCache.delete(workspaceId);
+}

--- a/src/lib/workspace/state-loader.ts
+++ b/src/lib/workspace/state-loader.ts
@@ -49,17 +49,9 @@ export async function loadWorkspaceState(workspaceId: string): Promise<AgentStat
     } as WorkspaceEvent));
 
     // Replay events to get current state
-    const currentState = replayEvents(workspaceEvents_typed, workspaceId, baseState);
-
-    return currentState;
+    return replayEvents(workspaceEvents_typed, workspaceId, baseState);
   } catch (error) {
     console.error("Error loading workspace state from events:", error);
-    
-    // Fallback to empty state if event loading fails
-    return {
-      items: [],
-      globalTitle: "",
-      workspaceId: workspaceId,
-    };
+    throw error;
   }
 }

--- a/src/workflows/audio-transcribe/steps/persist-result.ts
+++ b/src/workflows/audio-transcribe/steps/persist-result.ts
@@ -3,6 +3,7 @@ import { db } from "@/lib/db/client";
 import { createEvent } from "@/lib/workspace/events";
 import { checkAndCreateSnapshot } from "@/lib/workspace/snapshot-manager";
 import { broadcastWorkspaceEventFromServer } from "@/lib/realtime/server-broadcast";
+import { invalidateWorkspaceCache } from "@/app/api/mcp/route";
 import type { AudioData, Item } from "@/lib/workspace-state/types";
 import type { TranscribeResult } from "./transcribe";
 
@@ -67,6 +68,7 @@ export async function persistAudioResult(
         `Version conflict appending event ${event.id} to workspace ${workspaceId} (baseVersion=${versionResult[0]?.version ?? 0}). Workflow will retry automatically.`,
       );
     }
+    invalidateWorkspaceCache(workspaceId);
 
     await broadcastWorkspaceEventFromServer(workspaceId, {
       ...event,
@@ -134,6 +136,7 @@ export async function persistAudioFailure(
         `Version conflict appending event ${event.id} to workspace ${workspaceId} (baseVersion=${versionResult[0]?.version ?? 0}). Workflow will retry automatically.`,
       );
     }
+    invalidateWorkspaceCache(workspaceId);
 
     await broadcastWorkspaceEventFromServer(workspaceId, {
       ...event,

--- a/src/workflows/audio-transcribe/steps/persist-result.ts
+++ b/src/workflows/audio-transcribe/steps/persist-result.ts
@@ -3,7 +3,7 @@ import { db } from "@/lib/db/client";
 import { createEvent } from "@/lib/workspace/events";
 import { checkAndCreateSnapshot } from "@/lib/workspace/snapshot-manager";
 import { broadcastWorkspaceEventFromServer } from "@/lib/realtime/server-broadcast";
-import { invalidateWorkspaceCache } from "@/app/api/mcp/route";
+import { invalidateWorkspaceCache } from "@/lib/mcp/workspace-cache";
 import type { AudioData, Item } from "@/lib/workspace-state/types";
 import type { TranscribeResult } from "./transcribe";
 

--- a/src/workflows/ocr-dispatch/steps/persist-results.ts
+++ b/src/workflows/ocr-dispatch/steps/persist-results.ts
@@ -5,6 +5,7 @@ import { checkAndCreateSnapshot } from "@/lib/workspace/snapshot-manager";
 import type { WorkspaceEvent } from "@/lib/workspace/events";
 import type { OcrItemResult } from "@/lib/ocr/types";
 import { broadcastWorkspaceEventFromServer } from "@/lib/realtime/server-broadcast";
+import { invalidateWorkspaceCache } from "@/app/api/mcp/route";
 import type { ImageData, Item, PdfData } from "@/lib/workspace-state/types";
 
 const APPEND_RESULT_REGEX = /\(\s*(\d+)\s*,\s*(t|f|true|false)\s*\)/i;
@@ -51,6 +52,7 @@ async function appendWorkspaceEvent(
       `Version conflict appending event ${event.id} to workspace ${workspaceId} (baseVersion=${baseVersion}). Workflow will retry automatically.`,
     );
   }
+  invalidateWorkspaceCache(workspaceId);
 
   await broadcastWorkspaceEventFromServer(workspaceId, {
     ...event,

--- a/src/workflows/ocr-dispatch/steps/persist-results.ts
+++ b/src/workflows/ocr-dispatch/steps/persist-results.ts
@@ -5,7 +5,7 @@ import { checkAndCreateSnapshot } from "@/lib/workspace/snapshot-manager";
 import type { WorkspaceEvent } from "@/lib/workspace/events";
 import type { OcrItemResult } from "@/lib/ocr/types";
 import { broadcastWorkspaceEventFromServer } from "@/lib/realtime/server-broadcast";
-import { invalidateWorkspaceCache } from "@/app/api/mcp/route";
+import { invalidateWorkspaceCache } from "@/lib/mcp/workspace-cache";
 import type { ImageData, Item, PdfData } from "@/lib/workspace-state/types";
 
 const APPEND_RESULT_REGEX = /\(\s*(\d+)\s*,\s*(t|f|true|false)\s*\)/i;


### PR DESCRIPTION
Adds a read-only MCP (Model Context Protocol) server at /api/mcp so users can connect their IDE (Cursor, VS Code, Claude Code) to their ThinkEx workspace and pull grounded context directly into the AI.

What's included:

- Five MCP tools: list_workspaces, list_workspace, get_recent, search_workspace, and read_item — all read-only
- API key auth: Separate from Better Auth — keys are SHA-256 hashed at rest, soft-deleted on revoke, and checked via Authorization: Bearer tx_<key> header
- Workspace cache: 30s in-memory cache for workspace state to avoid redundant DB reads on repeated tool calls; automatically invalidated when a new event is posted
- Security hardening: Body size limits, regex length cap + ReDoS protection, cross-user access prevention on all workspace tools, sanitized error messages that never leak raw DB output
- Account Settings UI: New "MCP Access" section where users can create labelled API keys, see last-used dates, and revoke keys
- IDE config snippets: In-app setup instructions for Cursor (global + project), VS Code, and Claude Code

**Important**
DB change: One new migration (drizzle/0006_add_api_keys.sql) adding the api_keys table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account settings: create, view, and revoke MCP API keys with one-time display of raw keys.
  * IDE configuration tab with copyable setup snippets.
  * MCP server endpoint providing authenticated workspace tools (list, search, read, call).
  * New UI table component for displaying lists.

* **Chores**
  * Added runtime SDK dependency for MCP.
  * Server-side workspace caching (TTL) and explicit cache invalidation across workflows and mutations.

* **Other**
  * Database support added for storing API keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->