### PR TITLE
feat(assistant): add escalate_model tool for complex reasoning

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -298,13 +298,13 @@ async function handlePOST(req: Request) {
         return {
           model: escalationModel,
           providerOptions: {
-            ...providerOptions,
             gateway: {
-              ...((providerOptions as any)?.gateway ?? {}),
+              caching: "auto",
               models: [escalationModelId],
+              ...(userId ? { user: userId } : {}),
             },
             google: {
-              ...((providerOptions as any)?.google ?? {}),
+              grounding: {},
               thinkingConfig: {
                 thinkingLevel: "high",
                 includeThoughts: true,

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -14,6 +14,7 @@ import type { UIMessage } from "ai";
 import { logger } from "@/lib/utils/logger";
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
+import { CHAT_TOOL } from "@/lib/ai/chat-tool-names";
 import { createChatTools } from "@/lib/ai/tools";
 import {
   capturePostHogServerException,
@@ -22,7 +23,11 @@ import {
 import { withServerObservability } from "@/lib/with-server-observability";
 import { normalizeLegacyToolMessages } from "@/lib/ai/legacy-tool-message-compat";
 import type { ReplySelection } from "@/lib/stores/ui-store";
-import { getDefaultChatModelId, resolveGatewayModelId } from "@/lib/ai/models";
+import {
+  getDefaultChatModelId,
+  getModelForPurpose,
+  resolveGatewayModelId,
+} from "@/lib/ai/models";
 
 /**
  * Extract workspaceId from system context or request body
@@ -261,6 +266,53 @@ async function handlePOST(req: Request) {
       system,
       messages: convertedMessages,
       stopWhen: stepCountIs(25),
+      prepareStep: ({ steps }) => {
+        const wasEscalated = steps.some((step) =>
+          step.toolCalls.some((tc) => tc.toolName === CHAT_TOOL.ESCALATE_MODEL),
+        );
+
+        if (!wasEscalated) return undefined;
+
+        const escalationModelId = resolveGatewayModelId(
+          getModelForPurpose("escalation"),
+        );
+        const posthogClient = getPostHogServerClient();
+        const escalationTracedModel = posthogClient
+          ? withTracing(gateway(escalationModelId) as any, posthogClient, {
+              posthogDistinctId: userId || "anonymous",
+              posthogProperties: {
+                workspaceId,
+                activeFolderId,
+                modelId: escalationModelId,
+                escalated: true,
+              },
+            })
+          : (gateway(escalationModelId) as any);
+
+        const escalationModel = wrapLanguageModel({
+          model: escalationTracedModel,
+          middleware:
+            process.env.NODE_ENV === "development" ? devToolsMiddleware() : [],
+        });
+
+        return {
+          model: escalationModel,
+          providerOptions: {
+            ...providerOptions,
+            gateway: {
+              ...((providerOptions as any)?.gateway ?? {}),
+              models: [escalationModelId],
+            },
+            google: {
+              ...((providerOptions as any)?.google ?? {}),
+              thinkingConfig: {
+                thinkingLevel: "high",
+                includeThoughts: true,
+              },
+            },
+          },
+        };
+      },
       tools,
       providerOptions,
       headers: {

--- a/src/components/assistant-ui/EscalateModelToolUI.tsx
+++ b/src/components/assistant-ui/EscalateModelToolUI.tsx
@@ -9,25 +9,23 @@ import { cn } from "@/lib/utils";
 import type { EscalateModelResult } from "@/lib/ai/tool-result-schemas";
 
 /**
- * Minimal tool UI for escalate_model — shows a thinking indicator while running,
- * a completion chip when done. The actual analysis is consumed by the model
- * and paraphrased in the assistant's text response.
+ * Minimal tool UI for escalate_model — shows the model upgrade status.
  */
 export const renderEscalateModelToolUI: AssistantToolUIProps<
-  { problem: string },
+  { reason: string },
   EscalateModelResult
 >["render"] = ({ status }) => {
   return (
     <ToolUIErrorBoundary componentName="EscalateModel">
       {status.type === "running" ? (
-        <ToolUILoadingShell label="Escalating to smarter model…" />
+        <ToolUILoadingShell label="Upgrading model…" />
       ) : status.type === "incomplete" ? (
         <div
           className={cn(
             "my-1 rounded-md border border-border/50 bg-card/50 px-3 py-2 text-xs text-muted-foreground",
           )}
         >
-          Escalation could not complete. Try rephrasing the question.
+          Model upgrade could not complete.
         </div>
       ) : (
         <div
@@ -39,7 +37,7 @@ export const renderEscalateModelToolUI: AssistantToolUIProps<
             className="size-3.5 shrink-0 text-muted-foreground/80"
             aria-hidden
           />
-          <span>Analysis complete</span>
+          <span>Model upgraded</span>
         </div>
       )}
     </ToolUIErrorBoundary>

--- a/src/components/assistant-ui/EscalateModelToolUI.tsx
+++ b/src/components/assistant-ui/EscalateModelToolUI.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { CheckCircle2Icon } from "lucide-react";
+import type { AssistantToolUIProps } from "@assistant-ui/react";
+
+import { ToolUIErrorBoundary } from "@/components/tool-ui/shared";
+import { ToolUILoadingShell } from "@/components/assistant-ui/tool-ui-loading-shell";
+import { cn } from "@/lib/utils";
+import type { EscalateModelResult } from "@/lib/ai/tool-result-schemas";
+
+/**
+ * Minimal tool UI for escalate_model — shows a thinking indicator while running,
+ * a completion chip when done. The actual analysis is consumed by the model
+ * and paraphrased in the assistant's text response.
+ */
+export const renderEscalateModelToolUI: AssistantToolUIProps<
+  { problem: string },
+  EscalateModelResult
+>["render"] = ({ status }) => {
+  return (
+    <ToolUIErrorBoundary componentName="EscalateModel">
+      {status.type === "running" ? (
+        <ToolUILoadingShell label="Escalating to smarter model…" />
+      ) : status.type === "incomplete" ? (
+        <div
+          className={cn(
+            "my-1 rounded-md border border-border/50 bg-card/50 px-3 py-2 text-xs text-muted-foreground",
+          )}
+        >
+          Escalation could not complete. Try rephrasing the question.
+        </div>
+      ) : (
+        <div
+          className={cn(
+            "my-1 flex items-center gap-2 rounded-md border border-border/40 bg-muted/20 px-3 py-2 text-xs text-muted-foreground",
+          )}
+        >
+          <CheckCircle2Icon
+            className="size-3.5 shrink-0 text-muted-foreground/80"
+            aria-hidden
+          />
+          <span>Analysis complete</span>
+        </div>
+      )}
+    </ToolUIErrorBoundary>
+  );
+};

--- a/src/components/assistant-ui/chat-toolkit.tsx
+++ b/src/components/assistant-ui/chat-toolkit.tsx
@@ -16,6 +16,7 @@ import { renderSearchWorkspaceToolUI } from "@/components/assistant-ui/SearchWor
 import { renderURLContextToolUI } from "@/components/assistant-ui/URLContextToolUI";
 import { renderWebSearchToolUI } from "@/components/assistant-ui/WebSearchToolUI";
 import { renderExecuteCodeToolUI } from "@/components/assistant-ui/ExecuteCodeToolUI";
+import { renderEscalateModelToolUI } from "@/components/assistant-ui/EscalateModelToolUI";
 import { renderYouTubeSearchToolUI } from "@/components/assistant-ui/YouTubeSearchToolUI";
 
 function createBackendTool(
@@ -58,6 +59,10 @@ export const chatToolToolkit: Toolkit = {
   ...withLegacyNames(
     CHAT_TOOL.CODE_EXECUTE,
     createBackendTool(renderExecuteCodeToolUI),
+  ),
+  ...withLegacyNames(
+    CHAT_TOOL.ESCALATE_MODEL,
+    createBackendTool(renderEscalateModelToolUI),
   ),
   ...withLegacyNames(
     CHAT_TOOL.WORKSPACE_SEARCH,

--- a/src/lib/ai/chat-tool-names.ts
+++ b/src/lib/ai/chat-tool-names.ts
@@ -17,6 +17,7 @@ export const CHAT_TOOL = {
   YOUTUBE_SEARCH: "youtube_search",
   YOUTUBE_ADD: "youtube_add",
   CODE_EXECUTE: "code_execute",
+  ESCALATE_MODEL: "escalate_model",
 } as const;
 
 export type ChatToolName = (typeof CHAT_TOOL)[keyof typeof CHAT_TOOL];
@@ -89,6 +90,8 @@ export function isCanonicalChatToolName(name: string): name is ChatToolName {
 }
 
 /** Autogen / SSE events that mirror the web search tool */
-export function matchesWebSearchStreamToolName(name: string | undefined): boolean {
+export function matchesWebSearchStreamToolName(
+  name: string | undefined,
+): boolean {
   return name === CHAT_TOOL.WEB_SEARCH || name === "webSearch";
 }

--- a/src/lib/ai/escalate-model-shared.ts
+++ b/src/lib/ai/escalate-model-shared.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const EscalateModelResultSchema = z.object({
+  analysis: z.string(),
+});
+
+export type EscalateModelResult = z.infer<typeof EscalateModelResultSchema>;

--- a/src/lib/ai/escalate-model-shared.ts
+++ b/src/lib/ai/escalate-model-shared.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 
 export const EscalateModelResultSchema = z.object({
-  analysis: z.string(),
+  escalated: z.boolean(),
+  reason: z.string(),
 });
 
 export type EscalateModelResult = z.infer<typeof EscalateModelResultSchema>;

--- a/src/lib/ai/tool-result-schemas.ts
+++ b/src/lib/ai/tool-result-schemas.ts
@@ -9,6 +9,7 @@ import {
   CodeExecuteResultSchema,
   normalizeCodeExecuteResult,
 } from "@/lib/ai/code-execute-shared";
+import { EscalateModelResultSchema } from "@/lib/ai/tools/escalate-model";
 
 /**
  * Shared schemas and parsers for tool results. Used by assistant-ui Tool UIs
@@ -32,7 +33,9 @@ export type WorkspaceResult = z.infer<typeof WorkspaceResultSchema>;
 export const EditItemResultSchema = baseWorkspace
   .extend({
     diff: z.string().optional(),
-    filediff: z.object({ additions: z.number(), deletions: z.number() }).optional(),
+    filediff: z
+      .object({ additions: z.number(), deletions: z.number() })
+      .optional(),
     cardCount: z.number().optional(),
     questionCount: z.number().optional(),
   })
@@ -74,11 +77,13 @@ export function parseWorkspaceResult(input: unknown): WorkspaceResult {
 }
 
 /** selectCards */
-export const SelectCardsResultSchema = baseWorkspace.extend({
-  message: z.string(),
-  addedCount: z.number().optional(),
-  invalidIds: z.array(z.string()).optional(),
-}).passthrough();
+export const SelectCardsResultSchema = baseWorkspace
+  .extend({
+    message: z.string(),
+    addedCount: z.number().optional(),
+    invalidIds: z.array(z.string()).optional(),
+  })
+  .passthrough();
 
 export type SelectCardsResult = z.infer<typeof SelectCardsResultSchema>;
 
@@ -87,13 +92,15 @@ export function parseSelectCardsResult(input: unknown): SelectCardsResult {
 }
 
 /** quiz_create */
-export const QuizResultSchema = baseWorkspace.extend({
-  quizId: z.string().optional(),
-  title: z.string().optional(),
-  questionCount: z.number().optional(),
-  questionsAdded: z.number().optional(),
-  totalQuestions: z.number().optional(),
-}).passthrough();
+export const QuizResultSchema = baseWorkspace
+  .extend({
+    quizId: z.string().optional(),
+    title: z.string().optional(),
+    questionCount: z.number().optional(),
+    questionsAdded: z.number().optional(),
+    totalQuestions: z.number().optional(),
+  })
+  .passthrough();
 
 export type QuizResult = z.infer<typeof QuizResultSchema>;
 
@@ -111,13 +118,17 @@ export function parseQuizResult(input: unknown): QuizResult {
 }
 
 /** flashcards_create */
-export const FlashcardResultSchema = baseWorkspace.extend({
-  title: z.string().optional(),
-  cardCount: z.number().optional(),
-  cardsAdded: z.number().optional(),
-  deckName: z.string().optional(),
-  cards: z.array(z.object({ front: z.string(), back: z.string() })).optional(),
-}).passthrough();
+export const FlashcardResultSchema = baseWorkspace
+  .extend({
+    title: z.string().optional(),
+    cardCount: z.number().optional(),
+    cardsAdded: z.number().optional(),
+    deckName: z.string().optional(),
+    cards: z
+      .array(z.object({ front: z.string(), back: z.string() }))
+      .optional(),
+  })
+  .passthrough();
 
 export type FlashcardResult = z.infer<typeof FlashcardResultSchema>;
 
@@ -135,7 +146,10 @@ export function parseFlashcardResult(input: unknown): FlashcardResult {
 }
 
 /** web_fetch – result is string or { text, metadata } */
-export const URLContextResultSchema = z.union([z.string(), ProcessUrlsOutputSchema]);
+export const URLContextResultSchema = z.union([
+  z.string(),
+  ProcessUrlsOutputSchema,
+]);
 
 export type URLContextResult = z.infer<typeof URLContextResultSchema>;
 
@@ -163,4 +177,14 @@ export function parseCodeExecuteResult(input: unknown): CodeExecuteResult {
   }
 
   return parseWithSchema(CodeExecuteResultSchema, input, "CodeExecuteResult");
+}
+
+export type EscalateModelResult = z.infer<typeof EscalateModelResultSchema>;
+
+export function parseEscalateModelResult(input: unknown): EscalateModelResult {
+  return parseWithSchema(
+    EscalateModelResultSchema,
+    input,
+    "EscalateModelResult",
+  );
 }

--- a/src/lib/ai/tool-result-schemas.ts
+++ b/src/lib/ai/tool-result-schemas.ts
@@ -9,7 +9,7 @@ import {
   CodeExecuteResultSchema,
   normalizeCodeExecuteResult,
 } from "@/lib/ai/code-execute-shared";
-import { EscalateModelResultSchema } from "@/lib/ai/tools/escalate-model";
+import { EscalateModelResultSchema } from "@/lib/ai/escalate-model-shared";
 
 /**
  * Shared schemas and parsers for tool results. Used by assistant-ui Tool UIs

--- a/src/lib/ai/tools/escalate-model.ts
+++ b/src/lib/ai/tools/escalate-model.ts
@@ -3,12 +3,10 @@ import { tool, generateText, zodSchema } from "ai";
 import { google } from "@ai-sdk/google";
 import type { GoogleLanguageModelOptions } from "@ai-sdk/google";
 import { getModelForPurpose } from "@/lib/ai/models";
-
-export const EscalateModelResultSchema = z.object({
-  analysis: z.string(),
-});
-
-export type EscalateModelResult = z.infer<typeof EscalateModelResultSchema>;
+import {
+  EscalateModelResultSchema,
+  type EscalateModelResult,
+} from "@/lib/ai/escalate-model-shared";
 
 /**
  * Delegate a complex reasoning task to a higher-intelligence model with extended thinking.

--- a/src/lib/ai/tools/escalate-model.ts
+++ b/src/lib/ai/tools/escalate-model.ts
@@ -1,69 +1,36 @@
 import { z } from "zod";
-import { tool, generateText, zodSchema } from "ai";
-import { google } from "@ai-sdk/google";
-import type { GoogleLanguageModelOptions } from "@ai-sdk/google";
-import { getModelForPurpose } from "@/lib/ai/models";
+import { tool, zodSchema } from "ai";
 import {
   EscalateModelResultSchema,
   type EscalateModelResult,
 } from "@/lib/ai/escalate-model-shared";
 
 /**
- * Delegate a complex reasoning task to a higher-intelligence model with extended thinking.
+ * Signal tool — calling this triggers a model switch via prepareStep in the chat route.
+ * The tool itself does no LLM work; it just returns an acknowledgment.
  */
-export async function escalateToHigherModel(
-  problem: string,
-  options?: { abortSignal?: AbortSignal },
-): Promise<EscalateModelResult> {
-  const modelId = getModelForPurpose("escalation");
-
-  const { text } = await generateText({
-    model: google(modelId),
-    abortSignal: options?.abortSignal,
-    experimental_telemetry: { isEnabled: true },
-    providerOptions: {
-      google: {
-        thinkingConfig: {
-          thinkingLevel: "high",
-          includeThoughts: false,
-        },
-      } satisfies GoogleLanguageModelOptions,
-    },
-    system: `You are an expert reasoning assistant. Analyze the problem below thoroughly and precisely.
-
-Think step by step. Consider edge cases. Verify your reasoning. If the problem involves math or logic, check your work.
-
-Provide a clear, well-structured analysis followed by a definitive answer. Be thorough but concise.`,
-    prompt: problem,
-  });
-
-  return {
-    analysis: text.trim() || "No analysis produced.",
-  };
-}
-
 export function createEscalateModelTool() {
   return tool({
     description: [
-      "Escalate a complex reasoning problem to a higher-intelligence model with extended thinking capabilities.",
-      "Use when a problem requires careful multi-step reasoning, complex analysis, or when you want to verify your thinking on a hard problem.",
-      "Pass a self-contained problem description — the delegate does not see the chat history.",
+      "Escalate to a higher-intelligence model for the remainder of this response.",
+      "Call this when the current problem requires deeper reasoning, complex analysis, or careful verification.",
+      "After calling, you will be upgraded to a more capable model that will continue the response with full context.",
     ].join(" "),
     inputSchema: zodSchema(
       z.object({
-        problem: z
+        reason: z
           .string()
           .min(1)
-          .max(32_000)
+          .max(500)
           .describe(
-            "Self-contained problem description with all necessary context, data, and constraints. The delegate model does not see the chat history.",
+            "Brief explanation of why escalation is needed (e.g. 'complex multi-step math proof', 'nuanced legal analysis')",
           ),
       }),
     ),
     strict: true,
     outputSchema: zodSchema(EscalateModelResultSchema),
-    execute: async ({ problem }, { abortSignal }) => {
-      return await escalateToHigherModel(problem, { abortSignal });
+    execute: async ({ reason }): Promise<EscalateModelResult> => {
+      return { escalated: true, reason };
     },
   });
 }

--- a/src/lib/ai/tools/escalate-model.ts
+++ b/src/lib/ai/tools/escalate-model.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+import { tool, generateText, zodSchema } from "ai";
+import { google } from "@ai-sdk/google";
+import type { GoogleLanguageModelOptions } from "@ai-sdk/google";
+import { getModelForPurpose } from "@/lib/ai/models";
+
+export const EscalateModelResultSchema = z.object({
+  analysis: z.string(),
+});
+
+export type EscalateModelResult = z.infer<typeof EscalateModelResultSchema>;
+
+/**
+ * Delegate a complex reasoning task to a higher-intelligence model with extended thinking.
+ */
+export async function escalateToHigherModel(
+  problem: string,
+  options?: { abortSignal?: AbortSignal },
+): Promise<EscalateModelResult> {
+  const modelId = getModelForPurpose("escalation");
+
+  const { text } = await generateText({
+    model: google(modelId),
+    abortSignal: options?.abortSignal,
+    experimental_telemetry: { isEnabled: true },
+    providerOptions: {
+      google: {
+        thinkingConfig: {
+          thinkingLevel: "high",
+          includeThoughts: false,
+        },
+      } satisfies GoogleLanguageModelOptions,
+    },
+    system: `You are an expert reasoning assistant. Analyze the problem below thoroughly and precisely.
+
+Think step by step. Consider edge cases. Verify your reasoning. If the problem involves math or logic, check your work.
+
+Provide a clear, well-structured analysis followed by a definitive answer. Be thorough but concise.`,
+    prompt: problem,
+  });
+
+  return {
+    analysis: text.trim() || "No analysis produced.",
+  };
+}
+
+export function createEscalateModelTool() {
+  return tool({
+    description: [
+      "Escalate a complex reasoning problem to a higher-intelligence model with extended thinking capabilities.",
+      "Use when a problem requires careful multi-step reasoning, complex analysis, or when you want to verify your thinking on a hard problem.",
+      "Pass a self-contained problem description — the delegate does not see the chat history.",
+    ].join(" "),
+    inputSchema: zodSchema(
+      z.object({
+        problem: z
+          .string()
+          .min(1)
+          .max(32_000)
+          .describe(
+            "Self-contained problem description with all necessary context, data, and constraints. The delegate model does not see the chat history.",
+          ),
+      }),
+    ),
+    strict: true,
+    outputSchema: zodSchema(EscalateModelResultSchema),
+    execute: async ({ problem }, { abortSignal }) => {
+      return await escalateToHigherModel(problem, { abortSignal });
+    },
+  });
+}

--- a/src/lib/ai/tools/index.ts
+++ b/src/lib/ai/tools/index.ts
@@ -21,6 +21,7 @@ import { createWebSearchTool } from "./web-search";
 import { createSearchWorkspaceTool } from "./search-workspace";
 import { createReadWorkspaceTool } from "./read-workspace";
 import { createExecuteCodeTool } from "./execute-code";
+import { createEscalateModelTool } from "./escalate-model";
 import { logger } from "@/lib/utils/logger";
 import { CHAT_TOOL } from "@/lib/ai/chat-tool-names";
 
@@ -58,6 +59,7 @@ export function createChatTools(config: ChatToolsConfig): Record<string, any> {
     // Search
     [CHAT_TOOL.WEB_SEARCH]: createWebSearchTool(),
     [CHAT_TOOL.CODE_EXECUTE]: createExecuteCodeTool(),
+    [CHAT_TOOL.ESCALATE_MODEL]: createEscalateModelTool(),
     [CHAT_TOOL.WORKSPACE_SEARCH]: createSearchWorkspaceTool(ctx),
     [CHAT_TOOL.WORKSPACE_READ]: createReadWorkspaceTool(ctx),
 

--- a/src/lib/utils/format-workspace-context.ts
+++ b/src/lib/utils/format-workspace-context.ts
@@ -147,6 +147,12 @@ If the information is time-sensitive, niche, or uncertain, prefer web_search.
 
 ${getCodeExecutionSystemInstructions()}
 
+MODEL ESCALATION (escalate_model):
+Use escalate_model when: careful multi-step reasoning is needed, complex logical or mathematical analysis, verifying your own reasoning on a hard problem, nuanced questions where you're uncertain, problems with subtle edge cases.
+Do NOT use for: simple factual questions, straightforward text generation, computational tasks (use code_execute instead), current information lookup (use web_search instead), or tasks other specialized tools handle better.
+The delegate runs a higher-intelligence model with extended thinking. It does not see the chat history — pass a self-contained problem description with all relevant context, data, and constraints.
+After the tool returns, explain the analysis to the user in plain language. Do not expose tool internals or raw JSON.
+
 PDF: Always try workspace_read first for workspace PDFs (pageStart/pageEnd for page ranges). If content is not yet extracted, tell the user it is still being prepared and try again shortly.
 PDF VISUALS: PDF OCR in this workspace gives you textual structure from the PDF, including normal text and inline tables, but not visual understanding of charts, figures, diagrams, or screenshots embedded in the PDF. Do not claim you can see those visuals unless the user has separately attached a screenshot/image of that region. If the user needs help with a chart or figure from a PDF, tell them to open the PDF and use the camera button in the top right of the open pdf panelto add a screenshot of that area to chat.
 When selected card metadata includes (currently viewing) or activePage=N (for PDFs), the user has that item or page open. Prioritize these for ambiguous references ("this", "here", "this page", "what I'm looking at") and tailor responses to that context.

--- a/src/lib/utils/format-workspace-context.ts
+++ b/src/lib/utils/format-workspace-context.ts
@@ -148,10 +148,9 @@ If the information is time-sensitive, niche, or uncertain, prefer web_search.
 ${getCodeExecutionSystemInstructions()}
 
 MODEL ESCALATION (escalate_model):
-Use escalate_model when: careful multi-step reasoning is needed, complex logical or mathematical analysis, verifying your own reasoning on a hard problem, nuanced questions where you're uncertain, problems with subtle edge cases.
+Use escalate_model when: careful multi-step reasoning is needed, complex logical or mathematical analysis, verifying your reasoning on a hard problem, nuanced questions where you're uncertain, problems with subtle edge cases.
 Do NOT use for: simple factual questions, straightforward text generation, computational tasks (use code_execute instead), current information lookup (use web_search instead), or tasks other specialized tools handle better.
-The delegate runs a higher-intelligence model with extended thinking. It does not see the chat history — pass a self-contained problem description with all relevant context, data, and constraints.
-After the tool returns, explain the analysis to the user in plain language. Do not expose tool internals or raw JSON.
+Calling this tool upgrades you to a higher-intelligence model with extended thinking for the remainder of this response. You keep full conversation context — just continue your response normally after the tool returns. Provide a brief reason for escalation in the tool input.
 
 PDF: Always try workspace_read first for workspace PDFs (pageStart/pageEnd for page ranges). If content is not yet extracted, tell the user it is still being prepared and try again shortly.
 PDF VISUALS: PDF OCR in this workspace gives you textual structure from the PDF, including normal text and inline tables, but not visual understanding of charts, figures, diagrams, or screenshots embedded in the PDF. Do not claim you can see those visuals unless the user has separately attached a screenshot/image of that region. If the user needs help with a chart or figure from a PDF, tell them to open the PDF and use the camera button in the top right of the open pdf panelto add a screenshot of that area to chat.


### PR DESCRIPTION
This PR adds an `escalate_model` tool that delegates complex reasoning tasks to a higher-intelligence model with extended thinking, following the same delegation pattern as `code_execute`. The escalation model is resolved from the registry (`getModelForPurpose('escalation')`), and the result is presented via a minimal UI that shows status without exposing raw output.

**Tool Implementation**
- `src/lib/ai/chat-tool-names.ts`: Add `ESCALATE_MODEL` to `CHAT_TOOL` enum
- `src/lib/ai/tools/escalate-model.ts`: New tool. Delegates to `gemini-3.1-pro-preview` with `thinkingLevel: "high"`, returns `{ analysis }`
- `src/lib/ai/tools/index.ts`: Register in `createChatTools()` alongside other tools

**Result Schema & Tool UI**
- `src/lib/ai/tool-result-schemas.ts`: Import and re-export `EscalateModelResultSchema` and `parseEscalateModelResult`
- `src/components/assistant-ui/EscalateModelToolUI.tsx`: New UI. Shows loading, incomplete, and completion states matching `ExecuteCodeToolUI`
- `src/components/assistant-ui/chat-toolkit.tsx`: Register UI with `withLegacyNames`

**System Prompt Guidance**
- `src/lib/utils/format-workspace-context.ts`: Add `MODEL ESCALATION` block after code execution instructions. Specifies when to use (multi-step reasoning, verification, edge cases) and when NOT to use (simple facts, computation → `code_execute`, current info → `web_search`). Emphasizes self-contained problem descriptions since the delegate has no chat history access.

<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/pull/325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/task/76b774cd-d0d3-4f19-8be2-a8a402808e11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=SCO-7&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=SCO-7"><img alt="SCO-7 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=SCO-7"></picture></a>