### PR TITLE
feat(assistant): wire code_compose into chat tools + system prompt

### DIFF
--- a/src/lib/ai/chat-tool-names.ts
+++ b/src/lib/ai/chat-tool-names.ts
@@ -17,6 +17,7 @@ export const CHAT_TOOL = {
   YOUTUBE_SEARCH: "youtube_search",
   YOUTUBE_ADD: "youtube_add",
   CODE_EXECUTE: "code_execute",
+  CODE_COMPOSE: "code_compose",
 } as const;
 
 export type ChatToolName = (typeof CHAT_TOOL)[keyof typeof CHAT_TOOL];
@@ -38,6 +39,7 @@ export const LEGACY_CHAT_TOOL_NAMES: Record<string, ChatToolName> = {
   searchYoutube: CHAT_TOOL.YOUTUBE_SEARCH,
   addYoutubeVideo: CHAT_TOOL.YOUTUBE_ADD,
   executeCode: CHAT_TOOL.CODE_EXECUTE,
+  codeCompose: CHAT_TOOL.CODE_COMPOSE,
   // Intermediate snake_case (pre–resource_action rename)
   process_urls: CHAT_TOOL.WEB_FETCH,
   search_workspace: CHAT_TOOL.WORKSPACE_SEARCH,
@@ -50,6 +52,7 @@ export const LEGACY_CHAT_TOOL_NAMES: Record<string, ChatToolName> = {
   search_youtube: CHAT_TOOL.YOUTUBE_SEARCH,
   add_youtube_video: CHAT_TOOL.YOUTUBE_ADD,
   youtube_video_add: CHAT_TOOL.YOUTUBE_ADD,
+  code_orchestrate: CHAT_TOOL.CODE_COMPOSE,
 };
 
 const canonicalToLegacy = (() => {

--- a/src/lib/ai/code-compose/execute.ts
+++ b/src/lib/ai/code-compose/execute.ts
@@ -30,9 +30,10 @@ let _ivm: typeof import("isolated-vm") | null = null;
 
 async function getIvm() {
   if (!_ivm) {
-    _ivm = await import("isolated-vm");
+    const mod: any = await import("isolated-vm");
+    _ivm = mod.default ?? mod;
   }
-  return _ivm;
+  return _ivm!;
 }
 
 export const CodeComposeResultSchema = z.object({
@@ -102,7 +103,7 @@ async function executeInSandbox(
   }
 
   const ivm = await getIvm();
-  const isolate = new ivm.default.Isolate({ memoryLimit: ISOLATE_MEMORY_MB });
+  const isolate = new (ivm as any).Isolate({ memoryLimit: ISOLATE_MEMORY_MB });
 
   try {
     const context = await isolate.createContext();

--- a/src/lib/ai/code-compose/execute.ts
+++ b/src/lib/ai/code-compose/execute.ts
@@ -11,7 +11,6 @@
  * 4. Final return value is sent back as the tool result
  */
 
-import ivm from "isolated-vm";
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
 import { logger } from "@/lib/utils/logger";
@@ -26,6 +25,15 @@ import { generateTypeStubs } from "./type-stubs";
 
 const ISOLATE_MEMORY_MB = 128;
 const EXECUTION_TIMEOUT_MS = 30_000;
+
+let _ivm: typeof import("isolated-vm") | null = null;
+
+async function getIvm() {
+  if (!_ivm) {
+    _ivm = await import("isolated-vm");
+  }
+  return _ivm;
+}
 
 export const CodeComposeResultSchema = z.object({
   success: z.boolean(),
@@ -93,12 +101,13 @@ async function executeInSandbox(
     };
   }
 
-  const isolate = new ivm.Isolate({ memoryLimit: ISOLATE_MEMORY_MB });
+  const ivm = await getIvm();
+  const isolate = new ivm.default.Isolate({ memoryLimit: ISOLATE_MEMORY_MB });
 
   try {
     const context = await isolate.createContext();
 
-    await injectToolBridge(context, buildToolExecutorMap(tools), traces);
+    await injectToolBridge(ivm, context, buildToolExecutorMap(tools), traces);
 
     const wrappedCode = `
       (async () => {

--- a/src/lib/ai/code-compose/tool-bridge.ts
+++ b/src/lib/ai/code-compose/tool-bridge.ts
@@ -9,7 +9,6 @@
  * This is the only escape hatch from the sandbox — all I/O goes through here.
  */
 
-import ivm from "isolated-vm";
 import { logger } from "@/lib/utils/logger";
 import { SANDBOX_TO_CANONICAL } from "./type-stubs";
 
@@ -74,7 +73,8 @@ export function buildToolExecutorMap(
  * Also injects console_log for debugging.
  */
 export async function injectToolBridge(
-  context: ivm.Context,
+  ivm: any,
+  context: any,
   executorMap: ToolExecutorMap,
   traces: ExternalCallTrace[],
 ): Promise<void> {
@@ -82,7 +82,7 @@ export async function injectToolBridge(
 
   await jail.set(
     "_host_console_log",
-    new ivm.Reference((...args: any[]) => {
+    new ivm.default.Reference((...args: any[]) => {
       const msg = args
         .map((a) => (typeof a === "string" ? a : JSON.stringify(a)))
         .join(" ");
@@ -99,7 +99,7 @@ export async function injectToolBridge(
   for (const [sandboxName, executor] of executorMap) {
     const canonicalName = SANDBOX_TO_CANONICAL[sandboxName]!;
 
-    const hostFn = new ivm.Reference(async (argsJson: string) => {
+    const hostFn = new ivm.default.Reference(async (argsJson: string) => {
       const start = performance.now();
       let input: unknown;
       let output: unknown;

--- a/src/lib/ai/code-compose/tool-bridge.ts
+++ b/src/lib/ai/code-compose/tool-bridge.ts
@@ -82,7 +82,7 @@ export async function injectToolBridge(
 
   await jail.set(
     "_host_console_log",
-    new ivm.default.Reference((...args: any[]) => {
+    new ivm.Reference((...args: any[]) => {
       const msg = args
         .map((a) => (typeof a === "string" ? a : JSON.stringify(a)))
         .join(" ");
@@ -99,7 +99,7 @@ export async function injectToolBridge(
   for (const [sandboxName, executor] of executorMap) {
     const canonicalName = SANDBOX_TO_CANONICAL[sandboxName]!;
 
-    const hostFn = new ivm.default.Reference(async (argsJson: string) => {
+    const hostFn = new ivm.Reference(async (argsJson: string) => {
       const start = performance.now();
       let input: unknown;
       let output: unknown;

--- a/src/lib/ai/code-compose/type-stubs.ts
+++ b/src/lib/ai/code-compose/type-stubs.ts
@@ -138,6 +138,28 @@ export function generateTypeStubs(): string {
 }
 
 /**
+ * System prompt fragment: when/how to use code_compose.
+ */
+export function getCodeComposeSystemInstructions(): string {
+  return `CODE COMPOSE (code_compose):
+Use code_compose when you need to orchestrate 2+ tool calls, especially:
+- Parallel fetches: searching the web for multiple topics at once
+- Aggregation: reading multiple workspace items and combining their content
+- Data transformation: fetching data then filtering, sorting, or computing statistics
+- Conditional workflows: "if the search finds X, then create Y, otherwise Z"
+- Batch operations: creating multiple flashcard decks or documents from a data source
+
+Do NOT use code_compose when:
+- A single direct tool call suffices (just call the tool directly)
+- The user wants step-by-step confirmation between operations
+- You need to create one item and show it to the user before proceeding
+
+Write JavaScript (not TypeScript). The code runs in a V8 sandbox with access to external_* functions that map to workspace tools. All external_* calls are async — use await and Promise.all() for parallelism. Math and string operations execute in the JS runtime (exact, not predicted). End code with a return statement.
+
+After code_compose returns, explain results to the user in plain language. Never show the code or raw JSON output.`;
+}
+
+/**
  * Mapping from sandbox function name → canonical CHAT_TOOL name.
  * Used by the tool bridge to route external_* calls to real tool executors.
  */

--- a/src/lib/ai/tools/index.ts
+++ b/src/lib/ai/tools/index.ts
@@ -21,6 +21,7 @@ import { createWebSearchTool } from "./web-search";
 import { createSearchWorkspaceTool } from "./search-workspace";
 import { createReadWorkspaceTool } from "./read-workspace";
 import { createExecuteCodeTool } from "./execute-code";
+import { createCodeComposeTool } from "../code-compose/execute";
 import { logger } from "@/lib/utils/logger";
 import { CHAT_TOOL } from "@/lib/ai/chat-tool-names";
 
@@ -51,33 +52,24 @@ export function createChatTools(config: ChatToolsConfig): Record<string, any> {
     logger.error("❌ frontendTools failed:", e);
   }
 
-  return {
-    // URL processing
+  const directTools: Record<string, any> = {
     [CHAT_TOOL.WEB_FETCH]: createProcessUrlsTool(),
-
-    // Search
     [CHAT_TOOL.WEB_SEARCH]: createWebSearchTool(),
     [CHAT_TOOL.CODE_EXECUTE]: createExecuteCodeTool(),
     [CHAT_TOOL.WORKSPACE_SEARCH]: createSearchWorkspaceTool(ctx),
     [CHAT_TOOL.WORKSPACE_READ]: createReadWorkspaceTool(ctx),
-
-    // Workspace operations
     [CHAT_TOOL.DOCUMENT_CREATE]: createDocumentTool(ctx),
     [CHAT_TOOL.ITEM_EDIT]: createEditItemTool(ctx),
-
     [CHAT_TOOL.ITEM_DELETE]: createDeleteItemTool(ctx),
-
-    // Flashcards
     [CHAT_TOOL.FLASHCARDS_CREATE]: createFlashcardsTool(ctx),
-
-    // Quizzes
     [CHAT_TOOL.QUIZ_CREATE]: createQuizTool(ctx),
-
-    // YouTube
     [CHAT_TOOL.YOUTUBE_SEARCH]: createSearchYoutubeTool(),
     [CHAT_TOOL.YOUTUBE_ADD]: createAddYoutubeVideoTool(ctx),
+  };
 
-    // Client tools from frontend
+  return {
+    ...directTools,
+    [CHAT_TOOL.CODE_COMPOSE]: createCodeComposeTool(directTools),
     ...frontendClientTools,
   };
 }

--- a/src/lib/utils/format-workspace-context.ts
+++ b/src/lib/utils/format-workspace-context.ts
@@ -13,6 +13,7 @@ import type {
 import { getVirtualPath } from "./workspace-fs";
 import { getPdfSourceUrl } from "@/lib/pdf/pdf-item";
 import { getCodeExecutionSystemInstructions } from "@/lib/ai/code-execute-environment";
+import { getCodeComposeSystemInstructions } from "@/lib/ai/code-compose/type-stubs";
 
 /**
  * Formats item metadata only (no content). Used for workspace context in system prompt.
@@ -146,6 +147,8 @@ Use internal knowledge for: creative writing, coding, general concepts, summariz
 If the information is time-sensitive, niche, or uncertain, prefer web_search.
 
 ${getCodeExecutionSystemInstructions()}
+
+${getCodeComposeSystemInstructions()}
 
 PDF: Always try workspace_read first for workspace PDFs (pageStart/pageEnd for page ranges). If content is not yet extracted, tell the user it is still being prepared and try again shortly.
 PDF VISUALS: PDF OCR in this workspace gives you textual structure from the PDF, including normal text and inline tables, but not visual understanding of charts, figures, diagrams, or screenshots embedded in the PDF. Do not claim you can see those visuals unless the user has separately attached a screenshot/image of that region. If the user needs help with a chart or figure from a PDF, tell them to open the PDF and use the camera button in the top right of the open pdf panelto add a screenshot of that area to chat.


### PR DESCRIPTION
This PR wires the code_compose tool into the existing chat pipeline by registering it in the tool factory, adding legacy name mappings, and including system prompt instructions.

- **src/lib/ai/chat-tool-names.ts**: Add `CODE_COMPOSE: "code_compose"` to `CHAT_TOOL` and legacy aliases `codeCompose`, `code_orchestrate` to `LEGACY_CHAT_TOOL_NAMES`
- **src/lib/ai/tools/index.ts**: Build `directTools` first, then register `[CHAT_TOOL.CODE_COMPOSE]: createCodeComposeTool(directTools)` in `createChatTools` before client tools
- **src/lib/utils/format-workspace-context.ts**: Call `getCodeComposeSystemInstructions()` after code execution instructions to inject compose guidance into the system prompt
- **src/lib/ai/code-compose/type-stubs.ts**: Export `getCodeComposeSystemInstructions()` containing when/how to use code_compose

<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/pull/327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/task/23e6790b-aa39-4f28-8679-451795e87cc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=SCO-9&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=SCO-9"><img alt="SCO-9 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=SCO-9"></picture></a>