### PR TITLE
feat(code): add Code Compose tool UI

### DIFF
--- a/src/components/assistant-ui/CodeComposeToolUI.tsx
+++ b/src/components/assistant-ui/CodeComposeToolUI.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import type { ReactNode } from "react";
+import {
+  makeAssistantToolUI,
+  type AssistantToolUIProps,
+} from "@assistant-ui/react";
+import { AlertCircle, CheckCircle2, Clock3, Wrench } from "lucide-react";
+import { ToolUILoadingShell } from "@/components/assistant-ui/tool-ui-loading-shell";
+import { ToolUIErrorShell } from "@/components/assistant-ui/tool-ui-error-shell";
+import { Badge } from "@/components/ui/badge";
+import { ToolUIErrorBoundary } from "@/components/tool-ui/shared";
+import { parseCodeComposeResult } from "@/lib/ai/tool-result-schemas";
+import type { CodeComposeResult } from "@/lib/ai/code-compose-shared";
+import { CHAT_TOOL } from "@/lib/ai/chat-tool-names";
+import { cn } from "@/lib/utils";
+
+const TOOL_DISPLAY_NAMES: Record<string, string> = {
+  web_search: "Web Search",
+  web_fetch: "Fetch URLs",
+  workspace_search: "Search Workspace",
+  workspace_read: "Read Workspace",
+  document_create: "Create Document",
+  item_edit: "Edit Item",
+  item_delete: "Delete Item",
+  flashcards_create: "Create Flashcards",
+  quiz_create: "Create Quiz",
+  youtube_search: "YouTube Search",
+  youtube_add: "Add YouTube Video",
+};
+
+function getToolStatusErrorMessage(status: unknown): string | undefined {
+  if (!status || typeof status !== "object") return undefined;
+  const value = status as Record<string, unknown>;
+  if (typeof value.error === "string") return value.error;
+  if (typeof value.message === "string") return value.message;
+  if (
+    value.payload &&
+    typeof value.payload === "object" &&
+    typeof (value.payload as Record<string, unknown>).message === "string"
+  ) {
+    return (value.payload as Record<string, unknown>).message as string;
+  }
+  return undefined;
+}
+
+function getToolDisplayName(canonicalTool: string): string {
+  if (TOOL_DISPLAY_NAMES[canonicalTool]) {
+    return TOOL_DISPLAY_NAMES[canonicalTool];
+  }
+
+  return canonicalTool
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function formatDuration(durationMs: number): string {
+  return `${Math.round(durationMs)} ms`;
+}
+
+type CodeComposeArgs = { code: string };
+
+const CodeComposeSummary = ({ result }: { result: CodeComposeResult }) => {
+  const externalCalls = result.trace?.externalCalls ?? [];
+  const totalDurationMs = result.trace?.totalDurationMs;
+
+  return (
+    <div
+      className={cn(
+        "my-1 w-full rounded-md border border-border/50 bg-card/50 px-3 py-2 text-card-foreground shadow-sm",
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <CheckCircle2
+            className="size-4 shrink-0 text-emerald-500"
+            aria-hidden
+          />
+          <span className="truncate text-xs font-medium">Code Compose</span>
+        </div>
+        <Badge
+          variant="outline"
+          className="text-[10px] text-emerald-600 dark:text-emerald-400"
+        >
+          Succeeded
+        </Badge>
+      </div>
+
+      {externalCalls.length > 0 ? (
+        <div className="mt-2 space-y-1.5">
+          {externalCalls.map((call, index) => {
+            const callFailed = Boolean(call.error);
+            return (
+              <div
+                key={`${call.canonicalTool}-${call.functionName}-${index}`}
+                className="flex items-center justify-between gap-2 rounded-md border border-border/40 bg-muted/20 px-2 py-1.5"
+              >
+                <div className="flex min-w-0 items-center gap-2">
+                  <Wrench
+                    className="size-3.5 shrink-0 text-muted-foreground/70"
+                    aria-hidden
+                  />
+                  <span className="truncate text-xs font-medium text-foreground/90">
+                    {getToolDisplayName(call.canonicalTool)}
+                  </span>
+                  {callFailed && (
+                    <Badge variant="destructive" className="text-[10px]">
+                      Failed
+                    </Badge>
+                  )}
+                </div>
+                <span className="shrink-0 text-[10px] text-muted-foreground">
+                  {formatDuration(call.durationMs)}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="mt-2 rounded-md border border-dashed border-border/50 bg-muted/10 px-2 py-1.5 text-[10px] text-muted-foreground">
+          No external tools called
+        </div>
+      )}
+
+      {typeof totalDurationMs === "number" && (
+        <div className="mt-2 flex items-center justify-between border-t border-border/40 pt-2 text-[10px] text-muted-foreground">
+          <span className="inline-flex items-center gap-1">
+            <Clock3 className="size-3" aria-hidden />
+            Total time
+          </span>
+          <span>{formatDuration(totalDurationMs)}</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const CodeComposeToolUIComponent = makeAssistantToolUI<
+  CodeComposeArgs,
+  CodeComposeResult
+>({
+  toolName: CHAT_TOOL.CODE_COMPOSE,
+  render: ({ result, status }) => {
+    let parsed: CodeComposeResult | null = null;
+    if (status.type === "complete" && result != null) {
+      try {
+        parsed = parseCodeComposeResult(result);
+      } catch (error) {
+        console.error("[CodeComposeToolUI] Failed to parse result", error);
+      }
+    }
+
+    let content: ReactNode = null;
+
+    if (status.type === "running") {
+      content = <ToolUILoadingShell label="Composing..." />;
+    } else if (status.type === "complete" && parsed?.success) {
+      content = <CodeComposeSummary result={parsed} />;
+    } else if (status.type === "complete") {
+      content = (
+        <ToolUIErrorShell
+          label="Code Compose failed"
+          message={parsed?.error ?? "Execution failed"}
+        />
+      );
+    } else if (status.type === "incomplete" && status.reason === "error") {
+      content = (
+        <ToolUIErrorShell
+          label="Code Compose failed"
+          message={getToolStatusErrorMessage(status) ?? "Execution failed"}
+        />
+      );
+    } else if (status.type === "incomplete") {
+      content = (
+        <div className="my-1 flex items-start gap-2 rounded-md border border-border/50 bg-card/50 px-3 py-2 text-xs text-muted-foreground">
+          <AlertCircle className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+          <span>Code Compose did not complete.</span>
+        </div>
+      );
+    }
+
+    return (
+      <ToolUIErrorBoundary componentName="CodeCompose">
+        {content}
+      </ToolUIErrorBoundary>
+    );
+  },
+});
+
+export const renderCodeComposeToolUI: AssistantToolUIProps<
+  CodeComposeArgs,
+  CodeComposeResult
+>["render"] = CodeComposeToolUIComponent.unstable_tool.render;

--- a/src/components/assistant-ui/chat-toolkit.tsx
+++ b/src/components/assistant-ui/chat-toolkit.tsx
@@ -16,6 +16,7 @@ import { renderSearchWorkspaceToolUI } from "@/components/assistant-ui/SearchWor
 import { renderURLContextToolUI } from "@/components/assistant-ui/URLContextToolUI";
 import { renderWebSearchToolUI } from "@/components/assistant-ui/WebSearchToolUI";
 import { renderExecuteCodeToolUI } from "@/components/assistant-ui/ExecuteCodeToolUI";
+import { renderCodeComposeToolUI } from "@/components/assistant-ui/CodeComposeToolUI";
 import { renderYouTubeSearchToolUI } from "@/components/assistant-ui/YouTubeSearchToolUI";
 
 function createBackendTool(
@@ -58,6 +59,10 @@ export const chatToolToolkit: Toolkit = {
   ...withLegacyNames(
     CHAT_TOOL.CODE_EXECUTE,
     createBackendTool(renderExecuteCodeToolUI),
+  ),
+  ...withLegacyNames(
+    CHAT_TOOL.CODE_COMPOSE,
+    createBackendTool(renderCodeComposeToolUI),
   ),
   ...withLegacyNames(
     CHAT_TOOL.WORKSPACE_SEARCH,

--- a/src/lib/ai/code-compose-shared.ts
+++ b/src/lib/ai/code-compose-shared.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+export const CodeComposeTraceSchema = z.object({
+  externalCalls: z
+    .array(
+      z.object({
+        functionName: z.string(),
+        canonicalTool: z.string(),
+        durationMs: z.number(),
+        error: z.string().optional(),
+      }),
+    )
+    .optional(),
+  totalDurationMs: z.number(),
+});
+
+export const CodeComposeResultSchema = z.object({
+  success: z.boolean(),
+  result: z.unknown().optional(),
+  error: z.string().optional(),
+  trace: CodeComposeTraceSchema.optional(),
+});
+
+export type CodeComposeResult = z.infer<typeof CodeComposeResultSchema>;
+
+export function normalizeCodeComposeResult(
+  input: unknown,
+): CodeComposeResult | null {
+  const direct = CodeComposeResultSchema.safeParse(input);
+  if (direct.success) {
+    return direct.data;
+  }
+
+  if (typeof input !== "string") {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(input);
+    const normalized = CodeComposeResultSchema.safeParse(parsed);
+    return normalized.success ? normalized.data : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/ai/tool-result-schemas.ts
+++ b/src/lib/ai/tool-result-schemas.ts
@@ -9,6 +9,11 @@ import {
   CodeExecuteResultSchema,
   normalizeCodeExecuteResult,
 } from "@/lib/ai/code-execute-shared";
+import {
+  CodeComposeResultSchema,
+  normalizeCodeComposeResult,
+  type CodeComposeResult as SharedCodeComposeResult,
+} from "@/lib/ai/code-compose-shared";
 
 /**
  * Shared schemas and parsers for tool results. Used by assistant-ui Tool UIs
@@ -32,7 +37,9 @@ export type WorkspaceResult = z.infer<typeof WorkspaceResultSchema>;
 export const EditItemResultSchema = baseWorkspace
   .extend({
     diff: z.string().optional(),
-    filediff: z.object({ additions: z.number(), deletions: z.number() }).optional(),
+    filediff: z
+      .object({ additions: z.number(), deletions: z.number() })
+      .optional(),
     cardCount: z.number().optional(),
     questionCount: z.number().optional(),
   })
@@ -74,11 +81,13 @@ export function parseWorkspaceResult(input: unknown): WorkspaceResult {
 }
 
 /** selectCards */
-export const SelectCardsResultSchema = baseWorkspace.extend({
-  message: z.string(),
-  addedCount: z.number().optional(),
-  invalidIds: z.array(z.string()).optional(),
-}).passthrough();
+export const SelectCardsResultSchema = baseWorkspace
+  .extend({
+    message: z.string(),
+    addedCount: z.number().optional(),
+    invalidIds: z.array(z.string()).optional(),
+  })
+  .passthrough();
 
 export type SelectCardsResult = z.infer<typeof SelectCardsResultSchema>;
 
@@ -87,13 +96,15 @@ export function parseSelectCardsResult(input: unknown): SelectCardsResult {
 }
 
 /** quiz_create */
-export const QuizResultSchema = baseWorkspace.extend({
-  quizId: z.string().optional(),
-  title: z.string().optional(),
-  questionCount: z.number().optional(),
-  questionsAdded: z.number().optional(),
-  totalQuestions: z.number().optional(),
-}).passthrough();
+export const QuizResultSchema = baseWorkspace
+  .extend({
+    quizId: z.string().optional(),
+    title: z.string().optional(),
+    questionCount: z.number().optional(),
+    questionsAdded: z.number().optional(),
+    totalQuestions: z.number().optional(),
+  })
+  .passthrough();
 
 export type QuizResult = z.infer<typeof QuizResultSchema>;
 
@@ -111,13 +122,17 @@ export function parseQuizResult(input: unknown): QuizResult {
 }
 
 /** flashcards_create */
-export const FlashcardResultSchema = baseWorkspace.extend({
-  title: z.string().optional(),
-  cardCount: z.number().optional(),
-  cardsAdded: z.number().optional(),
-  deckName: z.string().optional(),
-  cards: z.array(z.object({ front: z.string(), back: z.string() })).optional(),
-}).passthrough();
+export const FlashcardResultSchema = baseWorkspace
+  .extend({
+    title: z.string().optional(),
+    cardCount: z.number().optional(),
+    cardsAdded: z.number().optional(),
+    deckName: z.string().optional(),
+    cards: z
+      .array(z.object({ front: z.string(), back: z.string() }))
+      .optional(),
+  })
+  .passthrough();
 
 export type FlashcardResult = z.infer<typeof FlashcardResultSchema>;
 
@@ -135,7 +150,10 @@ export function parseFlashcardResult(input: unknown): FlashcardResult {
 }
 
 /** web_fetch – result is string or { text, metadata } */
-export const URLContextResultSchema = z.union([z.string(), ProcessUrlsOutputSchema]);
+export const URLContextResultSchema = z.union([
+  z.string(),
+  ProcessUrlsOutputSchema,
+]);
 
 export type URLContextResult = z.infer<typeof URLContextResultSchema>;
 
@@ -163,4 +181,17 @@ export function parseCodeExecuteResult(input: unknown): CodeExecuteResult {
   }
 
   return parseWithSchema(CodeExecuteResultSchema, input, "CodeExecuteResult");
+}
+
+export type { CodeComposeResult } from "@/lib/ai/code-compose-shared";
+
+export function parseCodeComposeResult(
+  input: unknown,
+): SharedCodeComposeResult {
+  const normalized = normalizeCodeComposeResult(input);
+  if (normalized) {
+    return normalized;
+  }
+
+  return parseWithSchema(CodeComposeResultSchema, input, "CodeComposeResult");
 }


### PR DESCRIPTION
This PR adds a UI component for the `code_compose` tool that renders execution summaries in the chat when the tool is called.

## New Files
- **src/components/assistant-ui/CodeComposeToolUI.tsx**: Tool UI renderer with loading state, success card showing external tool traces (durations, fail states), and error shell. Uses `makeAssistantToolUI` scaffold.
- **src/lib/ai/code-compose-shared.ts**: Shared schemas (`CodeComposeResultSchema`, `CodeComposeTraceSchema`) and `normalizeCodeComposeResult` for JSON parsing.

## Modified Files
- **src/lib/ai/tool-result-schemas.ts**: Added `parseCodeComposeResult` function and exported `CodeComposeResult` type.
- **src/components/assistant-ui/chat-toolkit.tsx**: Registered `CHAT_TOOL.CODE_COMPOSE` with `renderCodeComposeToolUI` in `chatToolToolkit`.

<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/pull/328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/task/63f59b2d-b52b-42ee-9e0f-a95ba797c0f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=SCO-10&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=SCO-10"><img alt="SCO-10 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=SCO-10"></picture></a>