### PR TITLE
Refactor/ai gateway provider fallbacks and routing

### DIFF
--- a/src/app/api/threads/[id]/title/route.ts
+++ b/src/app/api/threads/[id]/title/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { google } from "@ai-sdk/google";
 import { generateText } from "ai";
 import { db } from "@/lib/db/client";
 import { chatThreads } from "@/lib/db/schema";
@@ -10,7 +9,12 @@ import {
 } from "@/lib/api/workspace-helpers";
 import { eq } from "drizzle-orm";
 import { withServerObservability } from "@/lib/with-server-observability";
-import { getModelForPurpose } from "@/lib/ai/models";
+import { getGatewayModelIdForPurpose } from "@/lib/ai/models";
+import {
+  buildGatewayProviderOptions,
+  createGatewayLanguageModel,
+  getGatewayAttributionHeaders,
+} from "@/lib/ai/gateway-provider-options";
 
 function extractTextFromMessage(msg: { content?: unknown[] }): string {
   if (!msg.content || !Array.isArray(msg.content)) return "";
@@ -69,8 +73,14 @@ export const POST = withServerObservability(
 
         if (conversationText.trim()) {
           try {
-            const { text } = await generateText({
-              model: google(getModelForPurpose("title-generation")),
+            const gatewayModelId =
+              getGatewayModelIdForPurpose("title-generation");
+            const { text, providerMetadata } = await generateText({
+              model: createGatewayLanguageModel(gatewayModelId),
+              providerOptions: buildGatewayProviderOptions(gatewayModelId, {
+                userId,
+              }) as any,
+              headers: getGatewayAttributionHeaders(),
               system: `Generate a very short chat title (2-6 words) that captures the topic. Output ONLY the title, no quotes or punctuation.`,
               prompt: `Conversation:\n\n${conversationText}\n\nTitle:`,
               experimental_telemetry: {
@@ -81,6 +91,15 @@ export const POST = withServerObservability(
                 },
               },
             });
+            const provider =
+              (providerMetadata as any)?.gateway?.routing?.resolvedProvider ??
+              (providerMetadata as any)?.gateway?.routing?.finalProvider;
+            if (provider) {
+              console.log(
+                "[threads/title] Gateway resolved provider:",
+                provider,
+              );
+            }
             const generated = text.trim().slice(0, 60);
             if (generated) title = generated;
           } catch (err) {

--- a/src/app/api/workspaces/generate-title/route.ts
+++ b/src/app/api/workspaces/generate-title/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { google } from "@ai-sdk/google";
 import { generateText, Output } from "ai";
 import { z } from "zod";
 import { requireAuth, withErrorHandling } from "@/lib/api/workspace-helpers";
@@ -8,7 +7,12 @@ import {
   WORKSPACE_ICON_NAMES,
   formatIconForStorage,
 } from "@/lib/workspace-icons";
-import { getModelForPurpose } from "@/lib/ai/models";
+import { getGatewayModelIdForPurpose } from "@/lib/ai/models";
+import {
+  buildGatewayProviderOptions,
+  createGatewayLanguageModel,
+  getGatewayAttributionHeaders,
+} from "@/lib/ai/gateway-provider-options";
 
 const MAX_TITLE_LENGTH = 60;
 
@@ -17,7 +21,7 @@ const MAX_TITLE_LENGTH = 60;
  * Generate a concise workspace title, icon, and color from a user prompt.
  */
 async function handlePOST(request: NextRequest) {
-  await requireAuth();
+  const userId = await requireAuth();
 
   let body;
   try {
@@ -41,8 +45,13 @@ async function handlePOST(request: NextRequest) {
     );
   }
 
-  const { output } = await generateText({
-    model: google(getModelForPurpose("title-generation")),
+  const gatewayModelId = getGatewayModelIdForPurpose("title-generation");
+  const { output, providerMetadata } = await generateText({
+    model: createGatewayLanguageModel(gatewayModelId),
+    providerOptions: buildGatewayProviderOptions(gatewayModelId, {
+      userId,
+    }) as any,
+    headers: getGatewayAttributionHeaders(),
     experimental_telemetry: {
       isEnabled: true,
       metadata: { "tcc.conversational": "true" },
@@ -74,6 +83,15 @@ Available colors should be vibrant and match the topic theme. Use hex format lik
 
 Generate appropriate workspace title, icon, and color for this topic.`,
   });
+  const provider =
+    (providerMetadata as any)?.gateway?.routing?.resolvedProvider ??
+    (providerMetadata as any)?.gateway?.routing?.finalProvider;
+  if (provider) {
+    console.log(
+      "[workspaces/generate-title] Gateway resolved provider:",
+      provider,
+    );
+  }
 
   let title = output.title.trim();
   if (title.length > MAX_TITLE_LENGTH) {

--- a/src/lib/ai/gateway-provider-options.ts
+++ b/src/lib/ai/gateway-provider-options.ts
@@ -15,18 +15,34 @@ export function buildGatewayProviderOptions(
 ): Record<string, unknown> {
   const gatewayOptions: Record<string, unknown> = {
     caching: "auto",
-    models: [gatewayModelId],
     ...(ctx.userId ? { user: ctx.userId } : {}),
   };
 
   const def = getModelDefinition(gatewayModelId);
+
+  if (def?.gateway?.fallbacks?.length) {
+    gatewayOptions.models = def.gateway.fallbacks;
+  }
+
   if (def?.gateway?.routing) {
     gatewayOptions.order = def.gateway.routing.order;
     gatewayOptions.only = def.gateway.routing.only;
   } else if (gatewayModelId.startsWith("anthropic/")) {
-    gatewayOptions.order = ["bedrock", "anthropic"];
-    gatewayOptions.only = ["bedrock", "anthropic"];
+    gatewayOptions.order = ["bedrock", "azure", "anthropic"];
+    gatewayOptions.only = ["bedrock", "azure", "anthropic"];
   }
+
+  gatewayOptions.providerTimeouts = {
+    byok: {
+      bedrock: 12000,
+      anthropic: 10000,
+      google: 10000,
+      vertex: 12000,
+      openai: 10000,
+    },
+  };
+
+  const providerSpecificOptions: Record<string, unknown> = {};
 
   const googleConfig: Record<string, unknown> = {
     grounding: {
@@ -42,9 +58,18 @@ export function buildGatewayProviderOptions(
       "minimal";
   }
 
+  providerSpecificOptions.google = googleConfig;
+
+  if (gatewayModelId.startsWith("openai/") || gatewayModelId.includes("gpt-")) {
+    providerSpecificOptions.openai = {
+      reasoningEffort: "medium",
+      reasoningSummary: "auto",
+    };
+  }
+
   return {
     gateway: gatewayOptions,
-    google: googleConfig,
+    ...providerSpecificOptions,
   };
 }
 

--- a/src/lib/ai/gateway-provider-options.ts
+++ b/src/lib/ai/gateway-provider-options.ts
@@ -35,6 +35,7 @@ export function buildGatewayProviderOptions(
   gatewayOptions.providerTimeouts = {
     byok: {
       bedrock: 12000,
+      azure: 10000,
       anthropic: 10000,
       google: 10000,
       vertex: 12000,
@@ -43,28 +44,30 @@ export function buildGatewayProviderOptions(
   };
 
   const providerSpecificOptions: Record<string, unknown> = {};
+  const reasoning = def?.gateway?.reasoning;
 
   const googleConfig: Record<string, unknown> = {
     grounding: {
       // googleSearchRetrieval removed to force usage of explicit web_search tool
     },
-    thinkingConfig: {
-      includeThoughts: true,
-    },
   };
 
-  if (gatewayModelId.includes("gemini-3-flash")) {
-    (googleConfig.thinkingConfig as Record<string, unknown>).thinkingLevel =
-      "minimal";
+  if (reasoning?.google) {
+    Object.assign(googleConfig, reasoning.google);
+  } else if (gatewayModelId.includes("gemini")) {
+    googleConfig.thinkingConfig = {
+      includeThoughts: true,
+    };
   }
 
   providerSpecificOptions.google = googleConfig;
 
-  if (gatewayModelId.startsWith("openai/") || gatewayModelId.includes("gpt-")) {
-    providerSpecificOptions.openai = {
-      reasoningEffort: "medium",
-      reasoningSummary: "auto",
-    };
+  if (reasoning?.anthropic) {
+    providerSpecificOptions.anthropic = reasoning.anthropic;
+  }
+
+  if (reasoning?.openai) {
+    providerSpecificOptions.openai = reasoning.openai;
   }
 
   return {

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -15,6 +15,8 @@ export interface ModelDefinition {
   /** Optional Gateway routing when multiple backends serve the same logical model. */
   gateway?: {
     routing?: GatewayRouting;
+    /** Fallback models tried in order if primary fails (gateway `models` option). Use full `provider/model` format. */
+    fallbacks?: string[];
   };
   ui?: {
     providerLabel: string;
@@ -36,13 +38,20 @@ export type ModelPurpose =
   | "audio-transcribe"
   | "escalation";
 
-const PROVIDER_PREFIX_RE = /^(google|anthropic|openai)\//;
+const PROVIDER_PREFIX_RE = /^(google|anthropic|openai|azure)\//;
 
 export const MODEL_REGISTRY: Record<string, ModelDefinition> = {
   "gemini-3.1-pro-preview": {
     id: "gemini-3.1-pro-preview",
     provider: "google",
     tier: "pro",
+    gateway: {
+      routing: {
+        order: ["vertex", "google"],
+        only: ["vertex", "google"],
+      },
+      fallbacks: ["anthropic/claude-sonnet-4.6", "openai/gpt-5-chat"],
+    },
     ui: {
       providerLabel: "Gemini",
       displayName: "Gemini 3.1 Pro",
@@ -57,6 +66,13 @@ export const MODEL_REGISTRY: Record<string, ModelDefinition> = {
     id: "gemini-3-flash-preview",
     provider: "google",
     tier: "fast",
+    gateway: {
+      routing: {
+        order: ["vertex", "google"],
+        only: ["vertex", "google"],
+      },
+      fallbacks: ["anthropic/claude-haiku-4.5", "openai/gpt-5-chat"],
+    },
     ui: {
       providerLabel: "Gemini",
       displayName: "Gemini 3.0 Flash",
@@ -71,11 +87,25 @@ export const MODEL_REGISTRY: Record<string, ModelDefinition> = {
     id: "gemini-2.5-flash",
     provider: "google",
     tier: "fast",
+    gateway: {
+      routing: {
+        order: ["vertex", "google"],
+        only: ["vertex", "google"],
+      },
+      fallbacks: ["google/gemini-3-flash-preview"],
+    },
   },
   "gemini-2.5-flash-lite": {
     id: "gemini-2.5-flash-lite",
     provider: "google",
     tier: "lite",
+    gateway: {
+      routing: {
+        order: ["vertex", "google"],
+        only: ["vertex", "google"],
+      },
+      fallbacks: ["google/gemini-2.5-flash"],
+    },
   },
   "claude-sonnet-4.6": {
     id: "claude-sonnet-4.6",
@@ -83,9 +113,10 @@ export const MODEL_REGISTRY: Record<string, ModelDefinition> = {
     tier: "pro",
     gateway: {
       routing: {
-        order: ["bedrock", "anthropic"],
-        only: ["bedrock", "anthropic"],
+        order: ["bedrock", "azure", "anthropic"],
+        only: ["bedrock", "azure", "anthropic"],
       },
+      fallbacks: ["google/gemini-3.1-pro-preview", "openai/gpt-5-chat"],
     },
     ui: {
       providerLabel: "Claude",
@@ -103,9 +134,10 @@ export const MODEL_REGISTRY: Record<string, ModelDefinition> = {
     tier: "fast",
     gateway: {
       routing: {
-        order: ["bedrock", "anthropic"],
-        only: ["bedrock", "anthropic"],
+        order: ["bedrock", "azure", "anthropic"],
+        only: ["bedrock", "azure", "anthropic"],
       },
+      fallbacks: ["google/gemini-3-flash-preview", "openai/gpt-5-chat"],
     },
     ui: {
       providerLabel: "Claude",
@@ -121,6 +153,13 @@ export const MODEL_REGISTRY: Record<string, ModelDefinition> = {
     id: "gpt-5-chat",
     provider: "openai",
     tier: "standard",
+    gateway: {
+      routing: {
+        order: ["openai", "azure"],
+        only: ["openai", "azure"],
+      },
+      fallbacks: ["anthropic/claude-sonnet-4.6", "google/gemini-3.1-pro-preview"],
+    },
     ui: {
       providerLabel: "ChatGPT",
       displayName: "GPT 5",

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -35,8 +35,7 @@ export type ModelPurpose =
   | "autogen-search"
   | "autogen-distill"
   | "autogen-content"
-  | "audio-transcribe"
-  | "escalation";
+  | "audio-transcribe";
 
 const PROVIDER_PREFIX_RE = /^(google|anthropic|openai|azure)\//;
 
@@ -158,7 +157,10 @@ export const MODEL_REGISTRY: Record<string, ModelDefinition> = {
         order: ["openai", "azure"],
         only: ["openai", "azure"],
       },
-      fallbacks: ["anthropic/claude-sonnet-4.6", "google/gemini-3.1-pro-preview"],
+      fallbacks: [
+        "anthropic/claude-sonnet-4.6",
+        "google/gemini-3.1-pro-preview",
+      ],
     },
     ui: {
       providerLabel: "ChatGPT",
@@ -180,7 +182,6 @@ const PURPOSE_MODEL_MAP: Record<ModelPurpose, string> = {
   "autogen-distill": "gemini-2.5-flash-lite",
   "autogen-content": "gemini-2.5-flash",
   "audio-transcribe": "gemini-2.5-flash",
-  escalation: "gemini-3.1-pro-preview",
 };
 
 export function getModelForPurpose(purpose: ModelPurpose): string {

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -8,6 +8,23 @@ export type GatewayRouting = {
   only: string[];
 };
 
+export interface ReasoningConfig {
+  google?: {
+    thinkingConfig: {
+      includeThoughts?: boolean;
+      thinkingLevel?: "minimal" | "low" | "medium" | "high";
+      thinkingBudget?: number;
+    };
+  };
+  anthropic?: {
+    thinking: { type: "adaptive" } | { type: "enabled"; budgetTokens: number };
+  };
+  openai?: {
+    reasoningEffort?: "none" | "low" | "medium" | "high" | "xhigh";
+    reasoningSummary?: "auto" | "concise" | "detailed";
+  };
+}
+
 export interface ModelDefinition {
   id: string;
   provider: ModelProvider;
@@ -17,6 +34,7 @@ export interface ModelDefinition {
     routing?: GatewayRouting;
     /** Fallback models tried in order if primary fails (gateway `models` option). Use full `provider/model` format. */
     fallbacks?: string[];
+    reasoning?: ReasoningConfig;
   };
   ui?: {
     providerLabel: string;
@@ -50,6 +68,11 @@ export const MODEL_REGISTRY: Record<string, ModelDefinition> = {
         only: ["vertex", "google"],
       },
       fallbacks: ["anthropic/claude-sonnet-4.6", "openai/gpt-5-chat"],
+      reasoning: {
+        google: {
+          thinkingConfig: { includeThoughts: true },
+        },
+      },
     },
     ui: {
       providerLabel: "Gemini",
@@ -71,6 +94,14 @@ export const MODEL_REGISTRY: Record<string, ModelDefinition> = {
         only: ["vertex", "google"],
       },
       fallbacks: ["anthropic/claude-haiku-4.5", "openai/gpt-5-chat"],
+      reasoning: {
+        google: {
+          thinkingConfig: {
+            includeThoughts: true,
+            thinkingLevel: "minimal",
+          },
+        },
+      },
     },
     ui: {
       providerLabel: "Gemini",
@@ -92,6 +123,11 @@ export const MODEL_REGISTRY: Record<string, ModelDefinition> = {
         only: ["vertex", "google"],
       },
       fallbacks: ["google/gemini-3-flash-preview"],
+      reasoning: {
+        google: {
+          thinkingConfig: { includeThoughts: true, thinkingBudget: 1024 },
+        },
+      },
     },
   },
   "gemini-2.5-flash-lite": {
@@ -104,6 +140,11 @@ export const MODEL_REGISTRY: Record<string, ModelDefinition> = {
         only: ["vertex", "google"],
       },
       fallbacks: ["google/gemini-2.5-flash"],
+      reasoning: {
+        google: {
+          thinkingConfig: { includeThoughts: false },
+        },
+      },
     },
   },
   "claude-sonnet-4.6": {
@@ -116,6 +157,11 @@ export const MODEL_REGISTRY: Record<string, ModelDefinition> = {
         only: ["bedrock", "azure", "anthropic"],
       },
       fallbacks: ["google/gemini-3.1-pro-preview", "openai/gpt-5-chat"],
+      reasoning: {
+        anthropic: {
+          thinking: { type: "adaptive" },
+        },
+      },
     },
     ui: {
       providerLabel: "Claude",
@@ -137,6 +183,11 @@ export const MODEL_REGISTRY: Record<string, ModelDefinition> = {
         only: ["bedrock", "azure", "anthropic"],
       },
       fallbacks: ["google/gemini-3-flash-preview", "openai/gpt-5-chat"],
+      reasoning: {
+        anthropic: {
+          thinking: { type: "adaptive" },
+        },
+      },
     },
     ui: {
       providerLabel: "Claude",
@@ -161,6 +212,12 @@ export const MODEL_REGISTRY: Record<string, ModelDefinition> = {
         "anthropic/claude-sonnet-4.6",
         "google/gemini-3.1-pro-preview",
       ],
+      reasoning: {
+        openai: {
+          reasoningEffort: "medium",
+          reasoningSummary: "auto",
+        },
+      },
     },
     ui: {
       providerLabel: "ChatGPT",

--- a/src/lib/ai/tools/web-search.ts
+++ b/src/lib/ai/tools/web-search.ts
@@ -5,7 +5,12 @@ import {
   WebSearchResultSchema,
   type WebSearchResult,
 } from "@/lib/ai/web-search-shared";
-import { getModelForPurpose } from "@/lib/ai/models";
+import { getGatewayModelIdForPurpose } from "@/lib/ai/models";
+import {
+  buildGatewayProviderOptions,
+  createGatewayLanguageModel,
+  getGatewayAttributionHeaders,
+} from "@/lib/ai/gateway-provider-options";
 
 const VERTEX_REDIRECT_HOST = "vertexaisearch.cloud.google.com";
 const VERTEX_REDIRECT_PATH = "/grounding-api-redirect/";
@@ -107,8 +112,11 @@ export async function resolveGroundingChunksToSources(
 export async function executeWebSearch(
   query: string,
 ): Promise<WebSearchResult> {
+  const gatewayModelId = getGatewayModelIdForPurpose("web-search");
   const { text, providerMetadata } = await generateText({
-    model: google(getModelForPurpose("web-search")),
+    model: createGatewayLanguageModel(gatewayModelId),
+    providerOptions: buildGatewayProviderOptions(gatewayModelId) as any,
+    headers: getGatewayAttributionHeaders(),
     tools: {
       googleSearch: google.tools.googleSearch({}),
     } as ToolSet,
@@ -123,6 +131,12 @@ Key findings:
 - [Additional findings]`,
     stopWhen: stepCountIs(10),
   });
+  const resolvedProvider =
+    (providerMetadata as any)?.gateway?.routing?.resolvedProvider ??
+    (providerMetadata as any)?.gateway?.routing?.finalProvider;
+  if (resolvedProvider) {
+    console.log("[web-search] Gateway resolved provider:", resolvedProvider);
+  }
 
   const groundingMetadata = (
     providerMetadata?.google as {

--- a/src/lib/ai/tools/web-search.ts
+++ b/src/lib/ai/tools/web-search.ts
@@ -122,7 +122,7 @@ export async function executeWebSearch(
       ...baseProviderOptions,
       gateway: {
         ...baseProviderOptions.gateway,
-        only: ["google"],
+        only: ["google"], // google.tools.googleSearch requires Google AI provider, not Vertex
         order: ["google"],
       },
     },

--- a/src/lib/ai/tools/web-search.ts
+++ b/src/lib/ai/tools/web-search.ts
@@ -113,9 +113,19 @@ export async function executeWebSearch(
   query: string,
 ): Promise<WebSearchResult> {
   const gatewayModelId = getGatewayModelIdForPurpose("web-search");
+  const baseProviderOptions = buildGatewayProviderOptions(
+    gatewayModelId,
+  ) as Record<string, any>;
   const { text, providerMetadata } = await generateText({
     model: createGatewayLanguageModel(gatewayModelId),
-    providerOptions: buildGatewayProviderOptions(gatewayModelId) as any,
+    providerOptions: {
+      ...baseProviderOptions,
+      gateway: {
+        ...baseProviderOptions.gateway,
+        only: ["google"],
+        order: ["google"],
+      },
+    },
     headers: getGatewayAttributionHeaders(),
     tools: {
       googleSearch: google.tools.googleSearch({}),


### PR DESCRIPTION
This PR hardens AI gateway configuration by adding provider routing to all models, cross-model fallback chains for failover, and BYOK provider timeouts for fast failover. Anthropic models now prefer Bedrock then Azure then direct API, Gemini models prefer Vertex then Google, and OpenAI models prefer direct then Azure. All registered models have explicit `gateway.routing` defined, and user-selectable models have tier-appropriate fallbacks.

## Core Changes

- **src/lib/ai/models.ts**: Added `fallbacks?: string[]` to `ModelDefinition.gateway`. Added `azure` to `PROVIDER_PREFIX_RE`. Populated `gateway.routing` (`order`/`only`) on all models: Claude uses `["bedrock", "azure", "anthropic"]`, Gemini uses `["vertex", "google"]`, OpenAI uses `["openai", "azure"]`. User-selectable models have cross-provider fallbacks (e.g., `gemini-3.1-pro-preview` falls back to Claude 4.6 then GPT-5); utility models have minimal fallbacks.

- **src/lib/ai/gateway-provider-options.ts**: Removed no-op `models: [gatewayModelId]` and replaced with `def.gateway.fallbacks`. Added `providerTimeouts.byok` with 10-12s timeouts per provider. Updated anthropic catch-all to include `azure` before direct API. Added `openai` provider config with `reasoningEffort: "medium"` and `reasoningSummary: "auto"` for GPT models. Separated gateway options from provider-specific options.

<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/pull/344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/task/5ec36a0a-e71d-494a-8425-ede23c2c3977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-23&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-23"><img alt="ENG-23 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-23"></picture></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic cross‑provider fallback lists for models to improve reliability when a primary model is unavailable
  * Expanded routing to include Azure for Anthropic-backed models and additional provider ordering
  * Provider-specific reasoning/tuning settings per model (Google/Gemini, Anthropic, OpenAI)
  * Per‑provider timeouts applied for Bedrock, Azure, Anthropic, Google/Vertex, and OpenAI
  * Improved gateway attribution so resolved providers are recorded for requests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->