### PR TITLE
Refactor/replace heic2any with heic-to

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.2",
     "gsap": "^3.14.2",
-    "heic2any": "^0.0.4",
+    "heic-to": "^1.4.2",
     "jsonrepair": "^3.13.2",
     "katex": "^0.16.45",
     "lodash.throttle": "^4.1.1",

--- a/src/lib/uploads/convert-heic.ts
+++ b/src/lib/uploads/convert-heic.ts
@@ -30,11 +30,9 @@ export async function convertHeicToJpegIfNeeded(file: File): Promise<File> {
 
   // Fast sync gate — skip obviously non-HEIC files
   if (!isHeicFile(file)) {
-    // Some browsers (especially Android/Windows) report HEIC files as
-    // "application/octet-stream". Fall through to magic-byte check for
-    // files with no recognized image MIME type.
-    const hasImageMime = file.type.startsWith("image/");
-    if (hasImageMime) return file;
+    // Only fall through for ambiguous MIME types that might actually be HEIC
+    const isAmbiguousMime = file.type === "" || file.type === "application/octet-stream";
+    if (!isAmbiguousMime) return file;
   }
 
   try {
@@ -48,7 +46,9 @@ export async function convertHeicToJpegIfNeeded(file: File): Promise<File> {
       type: "image/jpeg",
       quality: 0.9,
     });
-    const name = file.name.replace(HEIC_EXTS, ".jpg");
+    const name = HEIC_EXTS.test(file.name)
+      ? file.name.replace(HEIC_EXTS, ".jpg")
+      : file.name.replace(/(\.[^.]+)?$/, ".jpg");
 
     return new File([jpegBlob], name, { type: "image/jpeg" });
   } catch (err) {

--- a/src/lib/uploads/convert-heic.ts
+++ b/src/lib/uploads/convert-heic.ts
@@ -2,34 +2,54 @@
  * Client-side HEIC/HEIF → JPEG conversion for browser compatibility.
  * Safari displays HEIC natively; Chrome/Firefox do not.
  * Converting before upload ensures images work everywhere.
+ *
+ * Uses `heic-to` (libheif 1.21.2) which supports modern iOS 18+ HEIC
+ * variants and detects HEIC via magic bytes, not just MIME type.
  */
 
 const HEIC_TYPES = ["image/heic", "image/heif"];
 const HEIC_EXTS = /\.(heic|heif)$/i;
 
+/**
+ * Quick synchronous check based on MIME type and file extension.
+ * Used by callers that need a fast, non-async gate (e.g. accept lists).
+ */
 export function isHeicFile(file: File): boolean {
-  return (
-    HEIC_TYPES.includes(file.type) || HEIC_EXTS.test(file.name)
-  );
+  return HEIC_TYPES.includes(file.type) || HEIC_EXTS.test(file.name);
 }
 
 /**
  * Converts HEIC/HEIF to JPEG in the browser. Returns the original file
- * if not HEIC or if conversion fails. Uses heic2any (browser-only).
+ * if not HEIC or if conversion fails. Uses heic-to (browser-only).
+ *
+ * Detection uses `isHeic()` from heic-to which reads the file's magic
+ * bytes — this catches files some browsers label as application/octet-stream.
  */
 export async function convertHeicToJpegIfNeeded(file: File): Promise<File> {
   if (typeof window === "undefined") return file;
-  if (!isHeicFile(file)) return file;
+
+  // Fast sync gate — skip obviously non-HEIC files
+  if (!isHeicFile(file)) {
+    // Some browsers (especially Android/Windows) report HEIC files as
+    // "application/octet-stream". Fall through to magic-byte check for
+    // files with no recognized image MIME type.
+    const hasImageMime = file.type.startsWith("image/");
+    if (hasImageMime) return file;
+  }
 
   try {
-    const heic2any = (await import("heic2any")).default;
-    const result = await heic2any({
+    // Dynamic import keeps heic-to (~200KB WASM) out of the main bundle
+    const { isHeic, heicTo } = await import("heic-to");
+    const heic = await isHeic(file);
+    if (!heic) return file;
+
+    const jpegBlob = await heicTo({
       blob: file,
-      toType: "image/jpeg",
+      type: "image/jpeg",
       quality: 0.9,
     });
-    const jpegBlob = Array.isArray(result) ? result[0] : result;
     const name = file.name.replace(HEIC_EXTS, ".jpg");
+
     return new File([jpegBlob], name, { type: "image/jpeg" });
   } catch (err) {
     console.warn("HEIC conversion failed, uploading original:", err);


### PR DESCRIPTION
This PR replaces the stale `heic2any` library with `heic-to` for client-side HEIC/HEIF to JPEG conversion. The new library uses libheif 1.21.2 and supports iOS 18+ HEIC variants, while detecting files via magic bytes instead of just MIME type. The public API remains unchanged.

## Core Changes

- **package.json**: Swapped `heic2any` (^0.0.4) for `heic-to` (^1.4.2)
- **src/lib/uploads/convert-heic.ts**: Rewrote conversion logic to use `heic-to`, including dynamic import of named exports `isHeic` and `heicTo`, magic-byte detection to catch `application/octet-stream` files, and simplified Blob handling since `heicTo` returns a single Blob (not an array)

<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/pull/346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/task/ca1cd560-f786-47c3-adff-d6baf3e087de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-29&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-29"><img alt="ENG-29 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-29"></picture></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image format conversion dependency to improve HEIC-to-JPEG conversion reliability.

* **Bug Fixes**
  * Enhanced HEIC file detection with content-based validation, ensuring more accurate image format conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->