### PR TITLE
Fix/thread adapter race condition and deduplicate helpers

### DIFF
--- a/src/app/api/threads/[id]/messages/[messageId]/route.ts
+++ b/src/app/api/threads/[id]/messages/[messageId]/route.ts
@@ -1,78 +1,63 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db/client";
-import { chatThreads, chatMessages } from "@/lib/db/schema";
-import {
-  requireAuth,
-  verifyWorkspaceAccess,
-  verifyThreadOwnership,
-} from "@/lib/api/workspace-helpers";
+import { chatMessages } from "@/lib/db/schema";
+import { requireAuth, getThreadAndVerify } from "@/lib/api/workspace-helpers";
 import { eq, and } from "drizzle-orm";
 import { withServerObservability } from "@/lib/with-server-observability";
-
-async function getThreadAndVerify(threadId: string, userId: string) {
-  const [thread] = await db
-    .select()
-    .from(chatThreads)
-    .where(eq(chatThreads.id, threadId))
-    .limit(1);
-
-  if (!thread) {
-    throw NextResponse.json({ error: "Thread not found" }, { status: 404 });
-  }
-
-  await verifyWorkspaceAccess(thread.workspaceId, userId);
-  verifyThreadOwnership(thread, userId);
-
-  return thread;
-}
 
 /**
  * PATCH /api/threads/[id]/messages/[messageId]
  * Update an existing message (e.g. step timestamps/duration from useExternalHistory)
  */
-export const PATCH = withServerObservability(async function PATCH(
-  req: NextRequest,
-  { params }: { params: Promise<{ id: string; messageId: string }> }
-) {
-  try {
-    const userId = await requireAuth();
-    const { id: threadId, messageId } = await params;
-    const body = await req.json().catch(() => ({}));
-    const { content } = body;
+export const PATCH = withServerObservability(
+  async function PATCH(
+    req: NextRequest,
+    { params }: { params: Promise<{ id: string; messageId: string }> },
+  ) {
+    try {
+      const userId = await requireAuth();
+      const { id: threadId, messageId } = await params;
+      const body = await req.json().catch(() => ({}));
+      const { content } = body;
 
-    if (content === undefined) {
+      if (content === undefined) {
+        return NextResponse.json(
+          { error: "content is required" },
+          { status: 400 },
+        );
+      }
+
+      await getThreadAndVerify(threadId, userId);
+
+      const [updated] = await db
+        .update(chatMessages)
+        .set({
+          content: typeof content === "object" ? content : { raw: content },
+        })
+        .where(
+          and(
+            eq(chatMessages.threadId, threadId),
+            eq(chatMessages.messageId, messageId),
+          ),
+        )
+        .returning({ messageId: chatMessages.messageId });
+
+      if (!updated) {
+        return NextResponse.json(
+          { error: "Message not found" },
+          { status: 404 },
+        );
+      }
+
+      return NextResponse.json({ ok: true });
+    } catch (error) {
+      if (error instanceof Response) return error;
+      console.error("[threads] messages PATCH error:", error);
       return NextResponse.json(
-        { error: "content is required" },
-        { status: 400 }
+        { error: "Internal server error" },
+        { status: 500 },
       );
     }
-
-    await getThreadAndVerify(threadId, userId);
-
-    const [updated] = await db
-      .update(chatMessages)
-      .set({
-        content: typeof content === "object" ? content : { raw: content },
-      })
-      .where(
-        and(
-          eq(chatMessages.threadId, threadId),
-          eq(chatMessages.messageId, messageId)
-        )
-      )
-      .returning({ messageId: chatMessages.messageId });
-
-    if (!updated) {
-      return NextResponse.json({ error: "Message not found" }, { status: 404 });
-    }
-
-    return NextResponse.json({ ok: true });
-  } catch (error) {
-    if (error instanceof Response) return error;
-    console.error("[threads] messages PATCH error:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
-  }
-}, { routeName: "PATCH /api/threads/[id]/messages/[messageId]" });
+  },
+  { routeName: "PATCH /api/threads/[id]/messages/[messageId]" },
+);

--- a/src/app/api/threads/[id]/messages/route.ts
+++ b/src/app/api/threads/[id]/messages/route.ts
@@ -1,54 +1,36 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db/client";
 import { chatThreads, chatMessages } from "@/lib/db/schema";
-import {
-  requireAuth,
-  verifyWorkspaceAccess,
-  verifyThreadOwnership,
-} from "@/lib/api/workspace-helpers";
+import { requireAuth, getThreadAndVerify } from "@/lib/api/workspace-helpers";
 import { eq, and, desc } from "drizzle-orm";
 import { withServerObservability } from "@/lib/with-server-observability";
-
-async function getThreadAndVerify(id: string, userId: string) {
-  const [thread] = await db
-    .select()
-    .from(chatThreads)
-    .where(eq(chatThreads.id, id))
-    .limit(1);
-
-  if (!thread) {
-    throw NextResponse.json({ error: "Thread not found" }, { status: 404 });
-  }
-
-  await verifyWorkspaceAccess(thread.workspaceId, userId);
-  verifyThreadOwnership(thread, userId);
-
-  return thread;
-}
 
 /**
  * GET /api/threads/[id]/messages?format=ai-sdk/v6
  * Load messages for a thread. Format filter is strict (ai-sdk/v6 only).
  */
-export const GET = withServerObservability(async function GET(
-  req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const userId = await requireAuth();
-    const { id } = await params;
-    const { searchParams } = new URL(req.url);
-    const format = searchParams.get("format") ?? "ai-sdk/v6";
+export const GET = withServerObservability(
+  async function GET(
+    req: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+  ) {
+    try {
+      const userId = await requireAuth();
+      const { id } = await params;
+      const { searchParams } = new URL(req.url);
+      const format = searchParams.get("format") ?? "ai-sdk/v6";
 
-    const thread = await getThreadAndVerify(id, userId);
+      const thread = await getThreadAndVerify(id, userId);
 
-    const rows = await db
-      .select()
-      .from(chatMessages)
-      .where(and(eq(chatMessages.threadId, id), eq(chatMessages.format, format)))
-      .orderBy(desc(chatMessages.createdAt));
+      const rows = await db
+        .select()
+        .from(chatMessages)
+        .where(
+          and(eq(chatMessages.threadId, id), eq(chatMessages.format, format)),
+        )
+        .orderBy(desc(chatMessages.createdAt));
 
-    const messages = rows.map((r) => ({
+      const messages = rows.map((r) => ({
         id: r.messageId,
         parent_id: r.parentId,
         format: r.format,
@@ -56,91 +38,102 @@ export const GET = withServerObservability(async function GET(
         created_at: r.createdAt,
       }));
 
-    return NextResponse.json({
-      messages,
-      headId: thread.headMessageId ?? undefined,
-    });
-  } catch (error) {
-    if (error instanceof Response) return error;
-    console.error("[threads] messages GET error:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
-  }
-}, { routeName: "GET /api/threads/[id]/messages" });
+      return NextResponse.json({
+        messages,
+        headId: thread.headMessageId ?? undefined,
+      });
+    } catch (error) {
+      if (error instanceof Response) return error;
+      console.error("[threads] messages GET error:", error);
+      return NextResponse.json(
+        { error: "Internal server error" },
+        { status: 500 },
+      );
+    }
+  },
+  { routeName: "GET /api/threads/[id]/messages" },
+);
 
 /**
  * POST /api/threads/[id]/messages
  * Append a message to a thread
  */
-export const POST = withServerObservability(async function POST(
-  req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const userId = await requireAuth();
-    const { id } = await params;
-    const body = await req.json().catch(() => ({}));
-    const { messageId, parentId, format, content } = body;
-
-    if (!messageId || !format || content === undefined) {
-      return NextResponse.json(
-        { error: "messageId, format, and content are required" },
-        { status: 400 }
-      );
-    }
-
-    const thread = await getThreadAndVerify(id, userId);
-
+export const POST = withServerObservability(
+  async function POST(
+    req: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+  ) {
     try {
-      await db.transaction(async (tx) => {
-        await tx.insert(chatMessages).values({
-          threadId: id,
-          messageId: String(messageId),
-          parentId: parentId ?? null,
-          format: String(format),
-          content: typeof content === "object" ? content : { raw: content },
-        });
+      const userId = await requireAuth();
+      const { id } = await params;
+      const body = await req.json().catch(() => ({}));
+      const { messageId, parentId, format, content } = body;
 
-        // Only update headMessageId when appending to the current head
-        // (avoids overwriting explicit branch head set via PATCH)
-        const shouldUpdateHead =
-          thread.headMessageId == null ||
-          (parentId != null && parentId === thread.headMessageId);
-        const updates: {
-          lastMessageAt: string;
-          updatedAt: string;
-          headMessageId?: string;
-        } = {
-          lastMessageAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-        };
-        if (shouldUpdateHead) updates.headMessageId = String(messageId);
-
-        await tx
-          .update(chatThreads)
-          .set(updates)
-          .where(eq(chatThreads.id, id));
-      });
-    } catch (txError: unknown) {
-      const err = txError as { code?: string };
-      if (err?.code === "23505") {
+      if (!messageId || !format || content === undefined) {
         return NextResponse.json(
-          { error: "Message already exists (duplicate messageId)" },
-          { status: 409 }
+          { error: "messageId, format, and content are required" },
+          { status: 400 },
         );
       }
-      throw txError;
-    }
 
-    return NextResponse.json({ ok: true });
-  } catch (error) {
-    if (error instanceof Response) return error;
-    console.error("[threads] messages POST error:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
-  }
-}, { routeName: "POST /api/threads/[id]/messages" });
+      await getThreadAndVerify(id, userId);
+
+      try {
+        await db.transaction(async (tx) => {
+          const [freshThread] = await tx
+            .select({ headMessageId: chatThreads.headMessageId })
+            .from(chatThreads)
+            .where(eq(chatThreads.id, id))
+            .limit(1);
+
+          await tx.insert(chatMessages).values({
+            threadId: id,
+            messageId: String(messageId),
+            parentId: parentId ?? null,
+            format: String(format),
+            content: typeof content === "object" ? content : { raw: content },
+          });
+
+          // Only update headMessageId when appending to the current head
+          // (avoids overwriting explicit branch head set via PATCH)
+          const shouldUpdateHead =
+            freshThread?.headMessageId == null ||
+            (parentId != null && parentId === freshThread?.headMessageId);
+          const updates: {
+            lastMessageAt: string;
+            updatedAt: string;
+            headMessageId?: string;
+          } = {
+            lastMessageAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          };
+          if (shouldUpdateHead) updates.headMessageId = String(messageId);
+
+          await tx
+            .update(chatThreads)
+            .set(updates)
+            .where(eq(chatThreads.id, id));
+        });
+      } catch (txError: unknown) {
+        const err = txError as { code?: string };
+        if (err?.code === "23505") {
+          return NextResponse.json(
+            { error: "Message already exists (duplicate messageId)" },
+            { status: 409 },
+          );
+        }
+        throw txError;
+      }
+
+      return NextResponse.json({ ok: true });
+    } catch (error) {
+      if (error instanceof Response) return error;
+      console.error("[threads] messages POST error:", error);
+      return NextResponse.json(
+        { error: "Internal server error" },
+        { status: 500 },
+      );
+    }
+  },
+  { routeName: "POST /api/threads/[id]/messages" },
+);

--- a/src/app/api/threads/[id]/route.ts
+++ b/src/app/api/threads/[id]/route.ts
@@ -1,135 +1,129 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db/client";
 import { chatThreads, chatMessages } from "@/lib/db/schema";
-import {
-  requireAuth,
-  verifyWorkspaceAccess,
-  verifyThreadOwnership,
-} from "@/lib/api/workspace-helpers";
+import { requireAuth, getThreadAndVerify } from "@/lib/api/workspace-helpers";
 import { eq, and } from "drizzle-orm";
 import { withServerObservability } from "@/lib/with-server-observability";
-
-async function getThreadAndVerify(
-  id: string,
-  userId: string,
-  permission: "viewer" | "editor" = "viewer"
-) {
-  const [thread] = await db
-    .select()
-    .from(chatThreads)
-    .where(eq(chatThreads.id, id))
-    .limit(1);
-
-  if (!thread) {
-    throw NextResponse.json({ error: "Thread not found" }, { status: 404 });
-  }
-
-  await verifyWorkspaceAccess(thread.workspaceId, userId, permission);
-  verifyThreadOwnership(thread, userId);
-
-  return thread;
-}
 
 /**
  * GET /api/threads/[id]
  * Fetch a single thread
  */
-export const GET = withServerObservability(async function GET(
-  req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const userId = await requireAuth();
-  const { id } = await params;
+export const GET = withServerObservability(
+  async function GET(
+    req: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+  ) {
+    const userId = await requireAuth();
+    const { id } = await params;
 
-  const thread = await getThreadAndVerify(id, userId);
+    const thread = await getThreadAndVerify(id, userId);
 
-  return NextResponse.json({
-    id: thread.id,
-    remoteId: thread.id,
-    status: thread.isArchived ? "archived" : "regular",
-    title: thread.title ?? undefined,
-    externalId: thread.externalId ?? undefined,
-  });
-}, { routeName: "GET /api/threads/[id]" });
+    return NextResponse.json({
+      id: thread.id,
+      remoteId: thread.id,
+      status: thread.isArchived ? "archived" : "regular",
+      title: thread.title ?? undefined,
+      externalId: thread.externalId ?? undefined,
+    });
+  },
+  { routeName: "GET /api/threads/[id]" },
+);
 
 /**
  * PATCH /api/threads/[id]
  * Update thread (e.g. rename)
  */
-export const PATCH = withServerObservability(async function PATCH(
-  req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const userId = await requireAuth();
-    const { id } = await params;
-    const body = await req.json().catch(() => ({}));
-    const { title, headMessageId } = body;
+export const PATCH = withServerObservability(
+  async function PATCH(
+    req: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+  ) {
+    try {
+      const userId = await requireAuth();
+      const { id } = await params;
+      const body = await req.json().catch(() => ({}));
+      const { title, headMessageId } = body;
 
-    await getThreadAndVerify(id, userId, "editor");
+      await getThreadAndVerify(id, userId, "editor");
 
-    const updates: Partial<{ title: string; headMessageId: string | null; updatedAt: string }> = {
-      updatedAt: new Date().toISOString(),
-    };
-    if (title !== undefined) updates.title = String(title);
-    if (headMessageId !== undefined) {
-      if (headMessageId === null) {
-        updates.headMessageId = null;
-      } else {
-        const msgId = String(headMessageId);
-        const [existing] = await db
-          .select({ messageId: chatMessages.messageId })
-          .from(chatMessages)
-          .where(
-            and(eq(chatMessages.threadId, id), eq(chatMessages.messageId, msgId))
-          )
-          .limit(1);
-        if (!existing) {
-          return NextResponse.json(
-            { error: "headMessageId must reference an existing message in this thread" },
-            { status: 400 }
-          );
+      const updates: Partial<{
+        title: string;
+        headMessageId: string | null;
+        updatedAt: string;
+      }> = {
+        updatedAt: new Date().toISOString(),
+      };
+      if (title !== undefined) updates.title = String(title);
+      if (headMessageId !== undefined) {
+        if (headMessageId === null) {
+          updates.headMessageId = null;
+        } else {
+          const msgId = String(headMessageId);
+          const [existing] = await db
+            .select({ messageId: chatMessages.messageId })
+            .from(chatMessages)
+            .where(
+              and(
+                eq(chatMessages.threadId, id),
+                eq(chatMessages.messageId, msgId),
+              ),
+            )
+            .limit(1);
+          if (!existing) {
+            return NextResponse.json(
+              {
+                error:
+                  "headMessageId must reference an existing message in this thread",
+              },
+              { status: 400 },
+            );
+          }
+          updates.headMessageId = msgId;
         }
-        updates.headMessageId = msgId;
       }
+
+      await db.update(chatThreads).set(updates).where(eq(chatThreads.id, id));
+
+      return new Response(null, { status: 204 });
+    } catch (error) {
+      if (error instanceof Response) return error;
+      console.error("[threads] PATCH error:", error);
+      return NextResponse.json(
+        { error: "Internal server error" },
+        { status: 500 },
+      );
     }
-
-    await db.update(chatThreads).set(updates).where(eq(chatThreads.id, id));
-
-    return new Response(null, { status: 204 });
-  } catch (error) {
-    if (error instanceof Response) return error;
-    console.error("[threads] PATCH error:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
-  }
-}, { routeName: "PATCH /api/threads/[id]" });
+  },
+  { routeName: "PATCH /api/threads/[id]" },
+);
 
 /**
  * DELETE /api/threads/[id]
  * Delete a thread (and its messages via cascade)
  */
-export const DELETE = withServerObservability(async function DELETE(
-  req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const userId = await requireAuth();
-    const { id } = await params;
+export const DELETE = withServerObservability(
+  async function DELETE(
+    req: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+  ) {
+    try {
+      const userId = await requireAuth();
+      const { id } = await params;
 
-    await getThreadAndVerify(id, userId, "editor");
+      await getThreadAndVerify(id, userId, "editor");
 
-    await db.delete(chatThreads).where(eq(chatThreads.id, id));
+      await db.delete(chatThreads).where(eq(chatThreads.id, id));
 
-    return new Response(null, { status: 204 });
-  } catch (error) {
-    if (error instanceof Response) return error;
-    console.error("[threads] DELETE error:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
-  }
-}, { routeName: "DELETE /api/threads/[id]" });
+      return new Response(null, { status: 204 });
+    } catch (error) {
+      if (error instanceof Response) return error;
+      console.error("[threads] DELETE error:", error);
+      return NextResponse.json(
+        { error: "Internal server error" },
+        { status: 500 },
+      );
+    }
+  },
+  { routeName: "DELETE /api/threads/[id]" },
+);

--- a/src/lib/api/thread-archive.ts
+++ b/src/lib/api/thread-archive.ts
@@ -13,7 +13,7 @@ import { eq } from "drizzle-orm";
  */
 export async function setThreadArchived(
   threadId: string,
-  isArchived: boolean
+  isArchived: boolean,
 ): Promise<Response> {
   const userId = await requireAuth();
 
@@ -24,7 +24,7 @@ export async function setThreadArchived(
     .limit(1);
 
   if (!thread) {
-    return NextResponse.json({ error: "Thread not found" }, { status: 404 });
+    throw NextResponse.json({ error: "Thread not found" }, { status: 404 });
   }
 
   await verifyWorkspaceAccess(thread.workspaceId, userId, "editor");

--- a/src/lib/api/workspace-helpers.ts
+++ b/src/lib/api/workspace-helpers.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
 import { db, workspaces } from "@/lib/db/client";
-import { workspaceCollaborators } from "@/lib/db/schema";
+import { chatThreads, workspaceCollaborators } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 import { withServerObservability } from "@/lib/with-server-observability";
 
@@ -10,7 +10,11 @@ import { withServerObservability } from "@/lib/with-server-observability";
  * Get authenticated user from session
  * Returns userId, name, and email or null if not authenticated
  */
-export async function getAuthenticatedUser(): Promise<{ userId: string; name?: string; email?: string } | null> {
+export async function getAuthenticatedUser(): Promise<{
+  userId: string;
+  name?: string;
+  email?: string;
+} | null> {
   const session = await auth.api.getSession({
     headers: await headers(),
   });
@@ -32,7 +36,7 @@ export async function getAuthenticatedUser(): Promise<{ userId: string; name?: s
  */
 export async function verifyWorkspaceOwnership(
   workspaceId: string,
-  userId: string
+  userId: string,
 ): Promise<{ userId: string }> {
   const workspace = await db
     .select({ userId: workspaces.userId })
@@ -59,8 +63,11 @@ export async function verifyWorkspaceOwnership(
 export async function verifyWorkspaceAccess(
   workspaceId: string,
   userId: string,
-  requiredPermission: 'viewer' | 'editor' = 'viewer'
-): Promise<{ isOwner: boolean; permissionLevel: 'owner' | 'editor' | 'viewer' }> {
+  requiredPermission: "viewer" | "editor" = "viewer",
+): Promise<{
+  isOwner: boolean;
+  permissionLevel: "owner" | "editor" | "viewer";
+}> {
   // Check if workspace exists and get owner
   const workspace = await db
     .select({ userId: workspaces.userId })
@@ -74,7 +81,7 @@ export async function verifyWorkspaceAccess(
 
   // Owner has full access
   if (workspace[0].userId === userId) {
-    return { isOwner: true, permissionLevel: 'owner' };
+    return { isOwner: true, permissionLevel: "owner" };
   }
 
   // Check if user is a collaborator
@@ -84,8 +91,8 @@ export async function verifyWorkspaceAccess(
     .where(
       and(
         eq(workspaceCollaborators.workspaceId, workspaceId),
-        eq(workspaceCollaborators.userId, userId)
-      )
+        eq(workspaceCollaborators.userId, userId),
+      ),
     )
     .limit(1);
 
@@ -94,9 +101,12 @@ export async function verifyWorkspaceAccess(
   }
 
   // Check if user has required permission level
-  const permLevel = collaborator.permissionLevel as 'editor' | 'viewer';
-  if (requiredPermission === 'editor' && permLevel !== 'editor') {
-    throw NextResponse.json({ error: "Editor access required" }, { status: 403 });
+  const permLevel = collaborator.permissionLevel as "editor" | "viewer";
+  if (requiredPermission === "editor" && permLevel !== "editor") {
+    throw NextResponse.json(
+      { error: "Editor access required" },
+      { status: 403 },
+    );
   }
 
   return { isOwner: false, permissionLevel: permLevel };
@@ -108,11 +118,36 @@ export async function verifyWorkspaceAccess(
  */
 export function verifyThreadOwnership(
   thread: { userId: string },
-  userId: string
+  userId: string,
 ): void {
   if (thread.userId !== userId) {
     throw NextResponse.json({ error: "Access denied" }, { status: 403 });
   }
+}
+
+/**
+ * Look up a chat thread by ID, verify workspace access and thread ownership.
+ * Throws NextResponse (caught by `if (error instanceof Response)` blocks) on failure.
+ */
+export async function getThreadAndVerify(
+  threadId: string,
+  userId: string,
+  permission: "viewer" | "editor" = "viewer",
+) {
+  const [thread] = await db
+    .select()
+    .from(chatThreads)
+    .where(eq(chatThreads.id, threadId))
+    .limit(1);
+
+  if (!thread) {
+    throw NextResponse.json({ error: "Thread not found" }, { status: 404 });
+  }
+
+  await verifyWorkspaceAccess(thread.workspaceId, userId, permission);
+  verifyThreadOwnership(thread, userId);
+
+  return thread;
 }
 
 /**
@@ -121,7 +156,7 @@ export function verifyThreadOwnership(
  */
 export async function verifyWorkspaceOwnershipWithData(
   workspaceId: string,
-  userId: string
+  userId: string,
 ): Promise<typeof workspaces.$inferSelect> {
   const workspace = await db
     .select()
@@ -145,7 +180,7 @@ export async function verifyWorkspaceOwnershipWithData(
  */
 export function withErrorHandling<T extends [Request, ...unknown[]]>(
   handler: (...args: T) => Promise<NextResponse>,
-  routeName: string
+  routeName: string,
 ) {
   return withServerObservability(handler, {
     routeName,
@@ -167,7 +202,11 @@ export async function requireAuth(): Promise<string> {
  * Require authentication with user info - returns userId, name, and email or throws 401
  * Use this when you need user name/email to avoid duplicate session fetches
  */
-export async function requireAuthWithUserInfo(): Promise<{ userId: string; name?: string; email?: string }> {
+export async function requireAuthWithUserInfo(): Promise<{
+  userId: string;
+  name?: string;
+  email?: string;
+}> {
   const user = await getAuthenticatedUser();
   if (!user) {
     throw NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/lib/chat/custom-thread-history-adapter.tsx
+++ b/src/lib/chat/custom-thread-history-adapter.tsx
@@ -26,7 +26,7 @@ type ThreadHistoryAui = {
  * Uses topological sort with created_at + id as tiebreakers for stable ordering.
  */
 export function sortParentsBeforeChildren<
-  T extends { parentId: string | null; message: { id: string } }
+  T extends { parentId: string | null; message: { id: string } },
 >(items: T[], getCreatedAt: (item: T) => string): T[] {
   const output: T[] = [];
   const added = new Set<string>();
@@ -41,12 +41,10 @@ export function sortParentsBeforeChildren<
     items.filter(
       (m) =>
         !added.has(m.message.id) &&
-        (
-          m.parentId === null ||
+        (m.parentId === null ||
           added.has(m.parentId) ||
           !allIds.has(m.parentId) ||
-          m.parentId === m.message.id
-        )
+          m.parentId === m.message.id),
     );
 
   while (output.length < items.length) {
@@ -73,7 +71,7 @@ export function sortParentsBeforeChildren<
 
 export function createCustomThreadHistoryAdapter(
   aui: ThreadHistoryAui,
-  fetchImpl: typeof fetch = fetch
+  fetchImpl: typeof fetch = fetch,
 ): ThreadHistoryAdapter {
   return {
     async load() {
@@ -83,7 +81,7 @@ export function createCustomThreadHistoryAdapter(
       // No-op: ExternalStoreRuntime uses withFormat for persistence
     },
     withFormat<TMessage, TStorageFormat extends Record<string, unknown>>(
-      formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>
+      formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>,
     ): GenericThreadHistoryAdapter<TMessage> {
       return {
         async append(item: MessageFormatItem<TMessage>) {
@@ -102,20 +100,28 @@ export function createCustomThreadHistoryAdapter(
                 format: formatAdapter.format,
                 content: encoded,
               }),
-            }
+            },
           );
 
           if (!res.ok) {
             const err = await res.json().catch(() => ({}));
             throw new Error(
               (err as { error?: string }).error ||
-                `Failed to save message: ${res.status}`
+                `Failed to save message: ${res.status}`,
             );
           }
         },
-        async update(item: MessageFormatItem<TMessage>, localMessageId: string) {
+        async update(
+          item: MessageFormatItem<TMessage>,
+          localMessageId: string,
+        ) {
           const remoteId = aui.threadListItem().getState().remoteId;
-          if (!remoteId) return;
+          if (!remoteId) {
+            console.warn(
+              "[thread-history] update() skipped: thread not yet initialized (no remoteId)",
+            );
+            return;
+          }
 
           const encoded = formatAdapter.encode(item) as TStorageFormat;
 
@@ -125,14 +131,14 @@ export function createCustomThreadHistoryAdapter(
               method: "PATCH",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ content: encoded }),
-            }
+            },
           );
 
           if (!res.ok) {
             const err = await res.json().catch(() => ({}));
             throw new Error(
               (err as { error?: string }).error ||
-                `Failed to update message: ${res.status}`
+                `Failed to update message: ${res.status}`,
             );
           }
         },
@@ -141,7 +147,7 @@ export function createCustomThreadHistoryAdapter(
           if (!remoteId) return { messages: [] };
 
           const res = await fetchImpl(
-            `/api/threads/${encodeURIComponent(remoteId)}/messages?format=${encodeURIComponent(formatAdapter.format)}`
+            `/api/threads/${encodeURIComponent(remoteId)}/messages?format=${encodeURIComponent(formatAdapter.format)}`,
           );
           if (!res.ok) {
             throw new Error(`Failed to load messages: ${res.status}`);
@@ -155,13 +161,10 @@ export function createCustomThreadHistoryAdapter(
             return { messages: [], headId: apiHeadId };
           }
 
-          const filtered = messages.filter(
-            (m: { format?: string }) => m.format === formatAdapter.format
-          );
           type DecodedItem = MessageFormatItem<TMessage> & {
             created_at: string;
           };
-          const decoded: DecodedItem[] = filtered.map(
+          const decoded: DecodedItem[] = messages.map(
             (m: {
               id: string;
               parent_id: string | null;
@@ -179,7 +182,7 @@ export function createCustomThreadHistoryAdapter(
                 ...d,
                 created_at: m.created_at ?? new Date().toISOString(),
               };
-            }
+            },
           );
 
           type SortableItem = {
@@ -189,7 +192,7 @@ export function createCustomThreadHistoryAdapter(
           };
           const sorted = sortParentsBeforeChildren(
             decoded as SortableItem[],
-            (d) => d.created_at
+            (d) => d.created_at,
           ) as DecodedItem[];
 
           const headId =
@@ -224,6 +227,6 @@ export function useCustomThreadHistoryAdapter(): ThreadHistoryAdapter {
 
   return useMemo<ThreadHistoryAdapter>(
     () => createCustomThreadHistoryAdapter(aui),
-    [aui]
+    [aui],
   );
 }


### PR DESCRIPTION
This PR fixes critical thread adapter issues to prevent data loss under concurrent writes, reduces code duplication in route handlers, and improves error/visibility patterns.

**Race Condition Fix**:
- **src/app/api/threads/[id]/messages/route.ts**: Re-read `headMessageId` inside `db.transaction` before deciding whether to update the head pointer, preventing concurrent POSTs from overwriting each other based on stale state

**Deduplication**:
- **src/lib/api/workspace-helpers.ts**: Added shared `getThreadAndVerify()` helper with optional `permission` param
- **src/app/api/threads/[id]/route.ts**: Removed duplicate helper, now imports from shared location
- **src/app/api/threads/[id]/messages/route.ts**: Removed duplicate helper, now imports from shared location
- **src/app/api/threads/[id]/messages/[messageId]/route.ts**: Removed duplicate helper, now imports from shared location

**Client Adapter Cleanup**:
- **src/lib/chat/custom-thread-history-adapter.tsx**: Added `console.warn` when `update()` skips due to missing `remoteId`; removed redundant client-side format filter since server already filters by `format`

**Error Handling Consistency**:
- **src/lib/api/thread-archive.ts**: Changed `setThreadArchived()` to throw 404 `NextResponse` instead of returning it, matching patterns in `verifyWorkspaceAccess` and other helpers

All modified files pass Prettier and oxlint checks.

<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/pull/350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/task/aff0e55a-3ef6-44ce-a2f1-213c83b1bfd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-32&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-32"><img alt="ENG-32 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-32"></picture></a>