### PR TITLE
Implement persistent context compaction system for chat

### DIFF
--- a/drizzle/0002_quiet_grandmaster.sql
+++ b/drizzle/0002_quiet_grandmaster.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "chat_threads" ADD COLUMN "compression_summary" text;--> statement-breakpoint
+ALTER TABLE "chat_threads" ADD COLUMN "compressed_up_to_message_id" text;--> statement-breakpoint
+ALTER TABLE "chat_threads" ADD COLUMN "last_input_tokens" integer;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,2782 @@
+{
+  "id": "8dab6d16-57bb-4fda-8fc9-5d71c671b9d3",
+  "prevId": "77a2e4b0-3244-4eda-8ffd-41ba7999b3e1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_messages_thread": {
+          "name": "idx_chat_messages_thread",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_messages_thread_created": {
+          "name": "idx_chat_messages_thread_created",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_thread_id_chat_threads_id_fk": {
+          "name": "chat_messages_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_messages_thread_message_key": {
+          "name": "chat_messages_thread_message_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "thread_id",
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_threads": {
+      "name": "chat_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "head_message_id": {
+          "name": "head_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compression_summary": {
+          "name": "compression_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compressed_up_to_message_id": {
+          "name": "compressed_up_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_input_tokens": {
+          "name": "last_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_chat_threads_workspace": {
+          "name": "idx_chat_threads_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_user": {
+          "name": "idx_chat_threads_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_last_message": {
+          "name": "idx_chat_threads_last_message",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_workspace_id_workspaces_id_fk": {
+          "name": "chat_threads_workspace_id_workspaces_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_threads_user_id_user_id_fk": {
+          "name": "chat_threads_user_id_user_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "chat_threads_user_scoped": {
+          "name": "chat_threads_user_scoped",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((chat_threads.user_id = (auth.jwt() ->> 'sub'::text))\n   AND ((EXISTS ( SELECT 1 FROM workspaces w\n   WHERE ((w.id = chat_threads.workspace_id) AND (w.user_id = (auth.jwt() ->> 'sub'::text)))))\n   OR (EXISTS ( SELECT 1 FROM workspace_collaborators c\n   WHERE ((c.workspace_id = chat_threads.workspace_id) AND (c.user_id = (auth.jwt() ->> 'sub'::text)))))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_token": {
+          "name": "idx_session_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_profiles_user_id": {
+          "name": "idx_user_profiles_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_profiles_user_id_key": {
+          "name": "user_profiles_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {
+        "Users can insert their own profile": {
+          "name": "Users can insert their own profile",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(( SELECT (auth.jwt() ->> 'sub'::text)) = user_id)"
+        },
+        "Users can update their own profile": {
+          "name": "Users can update their own profile",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ]
+        },
+        "Users can view their own profile": {
+          "name": "Users can view their own profile",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_collaborators": {
+      "name": "workspace_collaborators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_level": {
+          "name": "permission_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'editor'"
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_collaborators_lookup": {
+          "name": "idx_workspace_collaborators_lookup",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_collaborators_workspace": {
+          "name": "idx_workspace_collaborators_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_collaborators_last_opened_at": {
+          "name": "idx_workspace_collaborators_last_opened_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "last_opened_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_collaborators_workspace_id_fkey": {
+          "name": "workspace_collaborators_workspace_id_fkey",
+          "tableFrom": "workspace_collaborators",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_collaborators_invite_token_unique": {
+          "name": "workspace_collaborators_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_token"
+          ]
+        },
+        "workspace_collaborators_workspace_user_unique": {
+          "name": "workspace_collaborators_workspace_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {
+        "Owners can manage collaborators": {
+          "name": "Owners can manage collaborators",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM workspaces w\n  WHERE ((w.id = workspace_collaborators.workspace_id) AND (w.user_id = (auth.jwt() ->> 'sub'::text)))))"
+        },
+        "Collaborators can view their access": {
+          "name": "Collaborators can view their access",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(user_id = (auth.jwt() ->> 'sub'::text))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_events": {
+      "name": "workspace_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_workspace_events_event_id": {
+          "name": "idx_workspace_events_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_events_timestamp": {
+          "name": "idx_workspace_events_timestamp",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int8_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_events_user_name": {
+          "name": "idx_workspace_events_user_name",
+          "columns": [
+            {
+              "expression": "user_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_events_workspace": {
+          "name": "idx_workspace_events_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_events_workspace_id_fkey": {
+          "name": "workspace_events_workspace_id_fkey",
+          "tableFrom": "workspace_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_events_event_id_key": {
+          "name": "workspace_events_event_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "policies": {
+        "Users can insert workspace events they have write access to": {
+          "name": "Users can insert workspace events they have write access to",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ],
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM workspaces\n  WHERE ((workspaces.id = workspace_events.workspace_id) AND (workspaces.user_id = (auth.jwt() ->> 'sub'::text))))) OR (EXISTS ( SELECT 1\n   FROM workspace_collaborators c\n  WHERE ((c.workspace_id = workspace_events.workspace_id) AND (c.user_id = (auth.jwt() ->> 'sub'::text)) AND (c.permission_level = 'editor'::text))))"
+        },
+        "Users can read workspace events they have access to": {
+          "name": "Users can read workspace events they have access to",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM workspaces\n  WHERE ((workspaces.id = workspace_events.workspace_id) AND (workspaces.user_id = (auth.jwt() ->> 'sub'::text))))) OR (EXISTS ( SELECT 1\n   FROM workspace_collaborators c\n  WHERE ((c.workspace_id = workspace_events.workspace_id) AND (c.user_id = (auth.jwt() ->> 'sub'::text)))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invites": {
+      "name": "workspace_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_level": {
+          "name": "permission_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'editor'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_invites_token": {
+          "name": "idx_workspace_invites_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_invites_email": {
+          "name": "idx_workspace_invites_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_invites_workspace": {
+          "name": "idx_workspace_invites_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_invites_workspace_id_fkey": {
+          "name": "workspace_invites_workspace_id_fkey",
+          "tableFrom": "workspace_invites",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_invites_token_key": {
+          "name": "workspace_invites_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {
+        "Public can view invite by token": {
+          "name": "Public can view invite by token",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "Users can insert invites for workspaces they own/edit": {
+          "name": "Users can insert invites for workspaces they own/edit",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM workspaces w\n  WHERE ((w.id = workspace_invites.workspace_id) AND (w.user_id = (auth.jwt() ->> 'sub'::text))))) OR (EXISTS ( SELECT 1\n   FROM workspace_collaborators c\n  WHERE ((c.workspace_id = workspace_invites.workspace_id) AND (c.user_id = (auth.jwt() ->> 'sub'::text)) AND (c.permission_level = 'editor'::text))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_item_content": {
+      "name": "workspace_item_content",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_schema_version": {
+          "name": "data_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structured_data": {
+          "name": "structured_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_data": {
+          "name": "asset_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_data": {
+          "name": "embed_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_data": {
+          "name": "source_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_item_content_workspace": {
+          "name": "idx_workspace_item_content_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_item_content_workspace_item_fkey": {
+          "name": "workspace_item_content_workspace_item_fkey",
+          "tableFrom": "workspace_item_content",
+          "tableTo": "workspace_items",
+          "columnsFrom": [
+            "workspace_id",
+            "item_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_item_content_pkey": {
+          "name": "workspace_item_content_pkey",
+          "columns": [
+            "workspace_id",
+            "item_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can read workspace item content they have access to": {
+          "name": "Users can read workspace item content they have access to",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM workspaces\n  WHERE ((workspaces.id = workspace_item_content.workspace_id) AND (workspaces.user_id = (auth.jwt() ->> 'sub'::text))))) OR (EXISTS ( SELECT 1\n   FROM workspace_collaborators c\n  WHERE ((c.workspace_id = workspace_item_content.workspace_id) AND (c.user_id = (auth.jwt() ->> 'sub'::text)))))"
+        },
+        "Users can write workspace item content they have write access to": {
+          "name": "Users can write workspace item content they have write access to",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "public"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM workspaces\n  WHERE ((workspaces.id = workspace_item_content.workspace_id) AND (workspaces.user_id = (auth.jwt() ->> 'sub'::text))))) OR (EXISTS ( SELECT 1\n   FROM workspace_collaborators c\n  WHERE ((c.workspace_id = workspace_item_content.workspace_id) AND (c.user_id = (auth.jwt() ->> 'sub'::text)) AND (c.permission_level = 'editor'::text))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM workspaces\n  WHERE ((workspaces.id = workspace_item_content.workspace_id) AND (workspaces.user_id = (auth.jwt() ->> 'sub'::text))))) OR (EXISTS ( SELECT 1\n   FROM workspace_collaborators c\n  WHERE ((c.workspace_id = workspace_item_content.workspace_id) AND (c.user_id = (auth.jwt() ->> 'sub'::text)) AND (c.permission_level = 'editor'::text))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_item_extracted": {
+      "name": "workspace_item_extracted",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "content_preview": {
+          "name": "content_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ocr_text": {
+          "name": "ocr_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_text": {
+          "name": "transcript_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ocr_pages": {
+          "name": "ocr_pages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_segments": {
+          "name": "transcript_segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_item_extracted_workspace": {
+          "name": "idx_workspace_item_extracted_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_item_extracted_workspace_item_fkey": {
+          "name": "workspace_item_extracted_workspace_item_fkey",
+          "tableFrom": "workspace_item_extracted",
+          "tableTo": "workspace_items",
+          "columnsFrom": [
+            "workspace_id",
+            "item_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_item_extracted_pkey": {
+          "name": "workspace_item_extracted_pkey",
+          "columns": [
+            "workspace_id",
+            "item_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can read workspace item extracted data they have access to": {
+          "name": "Users can read workspace item extracted data they have access to",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM workspaces\n  WHERE ((workspaces.id = workspace_item_extracted.workspace_id) AND (workspaces.user_id = (auth.jwt() ->> 'sub'::text))))) OR (EXISTS ( SELECT 1\n   FROM workspace_collaborators c\n  WHERE ((c.workspace_id = workspace_item_extracted.workspace_id) AND (c.user_id = (auth.jwt() ->> 'sub'::text)))))"
+        },
+        "Users can write workspace item extracted data they have write access to": {
+          "name": "Users can write workspace item extracted data they have write access to",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "public"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM workspaces\n  WHERE ((workspaces.id = workspace_item_extracted.workspace_id) AND (workspaces.user_id = (auth.jwt() ->> 'sub'::text))))) OR (EXISTS ( SELECT 1\n   FROM workspace_collaborators c\n  WHERE ((c.workspace_id = workspace_item_extracted.workspace_id) AND (c.user_id = (auth.jwt() ->> 'sub'::text)) AND (c.permission_level = 'editor'::text))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM workspaces\n  WHERE ((workspaces.id = workspace_item_extracted.workspace_id) AND (workspaces.user_id = (auth.jwt() ->> 'sub'::text))))) OR (EXISTS ( SELECT 1\n   FROM workspace_collaborators c\n  WHERE ((c.workspace_id = workspace_item_extracted.workspace_id) AND (c.user_id = (auth.jwt() ->> 'sub'::text)) AND (c.permission_level = 'editor'::text))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_item_projection_state": {
+      "name": "workspace_item_projection_state",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_applied_version": {
+          "name": "last_applied_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_item_projection_state_version": {
+          "name": "idx_workspace_item_projection_state_version",
+          "columns": [
+            {
+              "expression": "last_applied_version",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_item_projection_state_workspace_id_fkey": {
+          "name": "workspace_item_projection_state_workspace_id_fkey",
+          "tableFrom": "workspace_item_projection_state",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can read workspace item projection state they have access to": {
+          "name": "Users can read workspace item projection state they have access to",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM workspaces\n  WHERE ((workspaces.id = workspace_item_projection_state.workspace_id) AND (workspaces.user_id = (auth.jwt() ->> 'sub'::text))))) OR (EXISTS ( SELECT 1\n   FROM workspace_collaborators c\n  WHERE ((c.workspace_id = workspace_item_projection_state.workspace_id) AND (c.user_id = (auth.jwt() ->> 'sub'::text)))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_item_user_state": {
+      "name": "workspace_item_user_state",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'item'"
+        },
+        "state_type": {
+          "name": "state_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_schema_version": {
+          "name": "state_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_item_user_state_workspace_user": {
+          "name": "idx_workspace_item_user_state_workspace_user",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_item_user_state_item": {
+          "name": "idx_workspace_item_user_state_item",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_item_user_state_workspace_item_fkey": {
+          "name": "workspace_item_user_state_workspace_item_fkey",
+          "tableFrom": "workspace_item_user_state",
+          "tableTo": "workspace_items",
+          "columnsFrom": [
+            "workspace_id",
+            "item_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "item_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_item_user_state_pkey": {
+          "name": "workspace_item_user_state_pkey",
+          "columns": [
+            "workspace_id",
+            "item_id",
+            "user_id",
+            "state_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can read their workspace item user state": {
+          "name": "Users can read their workspace item user state",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "((workspace_item_user_state.user_id = (auth.jwt() ->> 'sub'::text)) AND ((EXISTS ( SELECT 1\n   FROM workspaces\n  WHERE ((workspaces.id = workspace_item_user_state.workspace_id) AND (workspaces.user_id = (auth.jwt() ->> 'sub'::text))))) OR (EXISTS ( SELECT 1\n   FROM workspace_collaborators c\n  WHERE ((c.workspace_id = workspace_item_user_state.workspace_id) AND (c.user_id = (auth.jwt() ->> 'sub'::text)))))))"
+        },
+        "Users can write their workspace item user state": {
+          "name": "Users can write their workspace item user state",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "public"
+          ],
+          "using": "((workspace_item_user_state.user_id = (auth.jwt() ->> 'sub'::text)) AND ((EXISTS ( SELECT 1\n   FROM workspaces\n  WHERE ((workspaces.id = workspace_item_user_state.workspace_id) AND (workspaces.user_id = (auth.jwt() ->> 'sub'::text))))) OR (EXISTS ( SELECT 1\n   FROM workspace_collaborators c\n  WHERE ((c.workspace_id = workspace_item_user_state.workspace_id) AND (c.user_id = (auth.jwt() ->> 'sub'::text)))))))",
+          "withCheck": "((workspace_item_user_state.user_id = (auth.jwt() ->> 'sub'::text)) AND ((EXISTS ( SELECT 1\n   FROM workspaces\n  WHERE ((workspaces.id = workspace_item_user_state.workspace_id) AND (workspaces.user_id = (auth.jwt() ->> 'sub'::text))))) OR (EXISTS ( SELECT 1\n   FROM workspace_collaborators c\n  WHERE ((c.workspace_id = workspace_item_user_state.workspace_id) AND (c.user_id = (auth.jwt() ->> 'sub'::text)))))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_items": {
+      "name": "workspace_items",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_schema_version": {
+          "name": "data_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "processing_status": {
+          "name": "processing_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_ocr": {
+          "name": "has_ocr",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ocr_status": {
+          "name": "ocr_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ocr_page_count": {
+          "name": "ocr_page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_transcript": {
+          "name": "has_transcript",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_count": {
+          "name": "source_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_items_workspace": {
+          "name": "idx_workspace_items_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_items_workspace_folder": {
+          "name": "idx_workspace_items_workspace_folder",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_items_workspace_type": {
+          "name": "idx_workspace_items_workspace_type",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_items_workspace_updated": {
+          "name": "idx_workspace_items_workspace_updated",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_items_workspace_version": {
+          "name": "idx_workspace_items_workspace_version",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "source_version",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_items_workspace_processing": {
+          "name": "idx_workspace_items_workspace_processing",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "processing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_items_workspace_ocr": {
+          "name": "idx_workspace_items_workspace_ocr",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "has_ocr",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "bool_ops"
+            },
+            {
+              "expression": "ocr_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_items_workspace_ocr_page_count": {
+          "name": "idx_workspace_items_workspace_ocr_page_count",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "ocr_page_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_items_workspace_has_transcript": {
+          "name": "idx_workspace_items_workspace_has_transcript",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "has_transcript",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "bool_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_items_workspace_source_count": {
+          "name": "idx_workspace_items_workspace_source_count",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "source_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_items_workspace_id_fkey": {
+          "name": "workspace_items_workspace_id_fkey",
+          "tableFrom": "workspace_items",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_items_pkey": {
+          "name": "workspace_items_pkey",
+          "columns": [
+            "workspace_id",
+            "item_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can read workspace items they have access to": {
+          "name": "Users can read workspace items they have access to",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM workspaces\n  WHERE ((workspaces.id = workspace_items.workspace_id) AND (workspaces.user_id = (auth.jwt() ->> 'sub'::text))))) OR (EXISTS ( SELECT 1\n   FROM workspace_collaborators c\n  WHERE ((c.workspace_id = workspace_items.workspace_id) AND (c.user_id = (auth.jwt() ->> 'sub'::text)))))"
+        },
+        "Users can write workspace items they have write access to": {
+          "name": "Users can write workspace items they have write access to",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "public"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM workspaces\n  WHERE ((workspaces.id = workspace_items.workspace_id) AND (workspaces.user_id = (auth.jwt() ->> 'sub'::text))))) OR (EXISTS ( SELECT 1\n   FROM workspace_collaborators c\n  WHERE ((c.workspace_id = workspace_items.workspace_id) AND (c.user_id = (auth.jwt() ->> 'sub'::text)) AND (c.permission_level = 'editor'::text))))",
+          "withCheck": "(EXISTS ( SELECT 1\n   FROM workspaces\n  WHERE ((workspaces.id = workspace_items.workspace_id) AND (workspaces.user_id = (auth.jwt() ->> 'sub'::text))))) OR (EXISTS ( SELECT 1\n   FROM workspace_collaborators c\n  WHERE ((c.workspace_id = workspace_items.workspace_id) AND (c.user_id = (auth.jwt() ->> 'sub'::text)) AND (c.permission_level = 'editor'::text))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_share_links": {
+      "name": "workspace_share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_level": {
+          "name": "permission_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'editor'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_workspace_share_links_token": {
+          "name": "idx_workspace_share_links_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_share_links_workspace": {
+          "name": "idx_workspace_share_links_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_share_links_workspace_id_fkey": {
+          "name": "workspace_share_links_workspace_id_fkey",
+          "tableFrom": "workspace_share_links",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_share_links_token_key": {
+          "name": "workspace_share_links_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        },
+        "workspace_share_links_workspace_key": {
+          "name": "workspace_share_links_workspace_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {
+        "Public can view share link by token": {
+          "name": "Public can view share link by token",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "Owners and editors can manage share links": {
+          "name": "Owners and editors can manage share links",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(EXISTS ( SELECT 1\n   FROM workspaces w\n  WHERE ((w.id = workspace_share_links.workspace_id) AND (w.user_id = (auth.jwt() ->> 'sub'::text))))) OR (EXISTS ( SELECT 1\n   FROM workspace_collaborators c\n  WHERE ((c.workspace_id = workspace_share_links.workspace_id) AND (c.user_id = (auth.jwt() ->> 'sub'::text)) AND (c.permission_level = 'editor'::text))))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_snapshots": {
+      "name": "workspace_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_version": {
+          "name": "snapshot_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_snapshots_version": {
+          "name": "idx_workspace_snapshots_version",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            },
+            {
+              "expression": "snapshot_version",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_snapshots_workspace": {
+          "name": "idx_workspace_snapshots_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_snapshots_workspace_id_fkey": {
+          "name": "workspace_snapshots_workspace_id_fkey",
+          "tableFrom": "workspace_snapshots",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_snapshots_workspace_id_snapshot_version_key": {
+          "name": "workspace_snapshots_workspace_id_snapshot_version_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "snapshot_version"
+          ]
+        }
+      },
+      "policies": {
+        "Service role can insert workspace snapshots": {
+          "name": "Service role can insert workspace snapshots",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ],
+          "withCheck": "true"
+        },
+        "Users can read workspace snapshots they have access to": {
+          "name": "Users can read workspace snapshots they have access to",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'blank'"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_workspaces_created_at": {
+          "name": "idx_workspaces_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspaces_slug": {
+          "name": "idx_workspaces_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspaces_user_id": {
+          "name": "idx_workspaces_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspaces_user_slug": {
+          "name": "idx_workspaces_user_slug",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspaces_user_sort_order": {
+          "name": "idx_workspaces_user_sort_order",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspaces_last_opened_at": {
+          "name": "idx_workspaces_last_opened_at",
+          "columns": [
+            {
+              "expression": "last_opened_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can delete their own workspaces": {
+          "name": "Users can delete their own workspaces",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(( SELECT (auth.jwt() ->> 'sub'::text)) = user_id)"
+        },
+        "Users can insert their own workspaces": {
+          "name": "Users can insert their own workspaces",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ]
+        },
+        "Users can update their own workspaces": {
+          "name": "Users can update their own workspaces",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ]
+        },
+        "Users can view their own workspaces": {
+          "name": "Users can view their own workspaces",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775704317855,
       "tag": "0001_stormy_rawhide_kid",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1776229184387,
+      "tag": "0002_quiet_grandmaster",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -29,7 +29,7 @@ import {
 } from "@/lib/ai/gateway-provider-options";
 import { db } from "@/lib/db/client";
 import { chatThreads } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import {
   compactMessages,
   type CompressionState,
@@ -154,7 +154,12 @@ async function handlePOST(req: Request) {
           lastInputTokens: chatThreads.lastInputTokens,
         })
         .from(chatThreads)
-        .where(eq(chatThreads.id, threadId))
+        .where(
+          and(
+            eq(chatThreads.id, threadId),
+            eq(chatThreads.userId, userId ?? ""),
+          ),
+        )
         .limit(1);
       if (thread) {
         compressionState = thread;

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -27,6 +27,13 @@ import {
   createGatewayLanguageModel,
   getGatewayAttributionHeaders,
 } from "@/lib/ai/gateway-provider-options";
+import { db } from "@/lib/db/client";
+import { chatThreads } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import {
+  compactMessages,
+  type CompressionState,
+} from "@/lib/ai/context-compactor";
 
 /**
  * Extract workspaceId from system context or request body
@@ -134,6 +141,25 @@ async function handlePOST(req: Request) {
     activeFolderId = body.activeFolderId;
     // AssistantChatTransport passes thread remoteId as body.id (see assistant-ui react-ai-sdk)
     const threadId = body.id ?? body.threadId ?? null;
+    let compressionState: CompressionState = {
+      compressionSummary: null,
+      compressedUpToMessageId: null,
+      lastInputTokens: null,
+    };
+    if (threadId) {
+      const [thread] = await db
+        .select({
+          compressionSummary: chatThreads.compressionSummary,
+          compressedUpToMessageId: chatThreads.compressedUpToMessageId,
+          lastInputTokens: chatThreads.lastInputTokens,
+        })
+        .from(chatThreads)
+        .where(eq(chatThreads.id, threadId))
+        .limit(1);
+      if (thread) {
+        compressionState = thread;
+      }
+    }
 
     // Create tools using the modular factory (before convertToModelMessages so
     // toModelOutput can sanitize historical tool results for the model)
@@ -159,11 +185,21 @@ async function handlePOST(req: Request) {
     }
 
     const validatedMessages = validation.data;
+    const compactionModelId = resolveGatewayModelId(
+      body.modelId || getDefaultChatModelId(),
+    );
+    const compaction = await compactMessages(
+      validatedMessages,
+      compressionState,
+      compactionModelId,
+    );
+    const messagesToConvert = compaction.messages;
+    let pendingCompressionUpdate = compaction.updatedState;
 
     // Convert messages (pass tools so toModelOutput strips event from historical tool results)
     let convertedMessages;
     try {
-      convertedMessages = await convertToModelMessages(validatedMessages, {
+      convertedMessages = await convertToModelMessages(messagesToConvert, {
         tools,
       });
     } catch (convertError) {
@@ -188,9 +224,7 @@ async function handlePOST(req: Request) {
     // Get pre-formatted selected cards context from client (no DB fetch needed)
     const selectedCardsContext = getSelectedCardsContext(body);
 
-    const modelId = resolveGatewayModelId(
-      body.modelId || getDefaultChatModelId(),
-    );
+    const modelId = compactionModelId;
 
     // Inject selected cards + reply selections into the last user message
     injectSelectionContext(
@@ -250,13 +284,42 @@ async function handlePOST(req: Request) {
           inputTokens: usage?.inputTokens,
           outputTokens: usage?.outputTokens,
           totalTokens: usage?.totalTokens,
-          cachedInputTokens: usage?.cachedInputTokens, // Standard property
+          cachedInputTokens: usage?.cachedInputTokens,
           reasoningTokens: usage?.reasoningTokens,
-          // Note: Extended provider-specific properties might not be available consistently via Gateway
           finishReason,
         };
 
         logger.info("📊 [CHAT-API] Final Token Usage:", usageInfo);
+
+        if (threadId && (usage?.inputTokens || pendingCompressionUpdate)) {
+          const updates: Record<string, unknown> = {};
+          if (usage?.inputTokens) {
+            updates.lastInputTokens = usage.inputTokens;
+          }
+          if (pendingCompressionUpdate) {
+            updates.compressionSummary =
+              pendingCompressionUpdate.compressionSummary;
+            updates.compressedUpToMessageId =
+              pendingCompressionUpdate.compressedUpToMessageId;
+          }
+          db.update(chatThreads)
+            .set(updates)
+            .where(eq(chatThreads.id, threadId))
+            .then(() => {
+              logger.debug("🗜️ [COMPACTOR] Compression state persisted", {
+                threadId,
+              });
+            })
+            .catch((err) => {
+              logger.error(
+                "🗜️ [COMPACTOR] Failed to persist compression state",
+                {
+                  error: err instanceof Error ? err.message : String(err),
+                  threadId,
+                },
+              );
+            });
+        }
       },
       onStepFinish: (result) => {
         // stepType exists in runtime but may not be in type definitions

--- a/src/lib/ai/context-compactor/compressor.ts
+++ b/src/lib/ai/context-compactor/compressor.ts
@@ -1,0 +1,68 @@
+import { generateText } from "ai";
+import type { UIMessage } from "ai";
+import { getGatewayModelIdForPurpose } from "@/lib/ai/models";
+import {
+  buildGatewayProviderOptions,
+  createGatewayLanguageModel,
+  getGatewayAttributionHeaders,
+} from "@/lib/ai/gateway-provider-options";
+import { logger } from "@/lib/utils/logger";
+import {
+  COMPRESSION_SYSTEM_PROMPT,
+  COMPRESSION_USER_PROMPT,
+  formatConversationForCompression,
+} from "./prompts";
+
+let consecutiveFailures = 0;
+const MAX_FAILURES = 3;
+
+export async function compressMessages(
+  messagesToCompress: UIMessage[],
+  existingSummary?: string | null,
+): Promise<string | null> {
+  if (consecutiveFailures >= MAX_FAILURES) {
+    logger.warn("🗜️ [COMPACTOR] Circuit breaker open — skipping compression");
+    return null;
+  }
+
+  try {
+    let conversationText = formatConversationForCompression(messagesToCompress);
+
+    if (existingSummary) {
+      conversationText = `[Previous summary]\n${existingSummary}\n\n[New messages]\n${conversationText}`;
+    }
+
+    const prompt = COMPRESSION_USER_PROMPT.replace(
+      "{CONVERSATION}",
+      conversationText,
+    );
+
+    const gatewayModelId = getGatewayModelIdForPurpose("title-generation");
+    const { text } = await generateText({
+      model: createGatewayLanguageModel(gatewayModelId),
+      providerOptions: buildGatewayProviderOptions(gatewayModelId) as any,
+      headers: getGatewayAttributionHeaders(),
+      system: COMPRESSION_SYSTEM_PROMPT,
+      prompt,
+    });
+
+    const summary = text.trim();
+    if (!summary) {
+      throw new Error("Empty summary returned");
+    }
+
+    consecutiveFailures = 0;
+    logger.info("🗜️ [COMPACTOR] Compression succeeded", {
+      inputMessages: messagesToCompress.length,
+      summaryLength: summary.length,
+    });
+    return summary;
+  } catch (error) {
+    consecutiveFailures++;
+    logger.error("🗜️ [COMPACTOR] Compression failed", {
+      error: error instanceof Error ? error.message : String(error),
+      consecutiveFailures,
+    });
+    return null;
+  }
+}

--- a/src/lib/ai/context-compactor/compressor.ts
+++ b/src/lib/ai/context-compactor/compressor.ts
@@ -14,15 +14,21 @@ import {
 } from "./prompts";
 
 let consecutiveFailures = 0;
+let lastFailureTime = 0;
 const MAX_FAILURES = 3;
+const BREAKER_RESET_MS = 60_000;
 
 export async function compressMessages(
   messagesToCompress: UIMessage[],
   existingSummary?: string | null,
 ): Promise<string | null> {
   if (consecutiveFailures >= MAX_FAILURES) {
-    logger.warn("🗜️ [COMPACTOR] Circuit breaker open — skipping compression");
-    return null;
+    if (Date.now() - lastFailureTime < BREAKER_RESET_MS) {
+      logger.warn("🗜️ [COMPACTOR] Circuit breaker open — skipping compression");
+      return null;
+    }
+    logger.info("🗜️ [COMPACTOR] Circuit breaker reset after timeout");
+    consecutiveFailures = 0;
   }
 
   try {
@@ -59,6 +65,7 @@ export async function compressMessages(
     return summary;
   } catch (error) {
     consecutiveFailures++;
+    lastFailureTime = Date.now();
     logger.error("🗜️ [COMPACTOR] Compression failed", {
       error: error instanceof Error ? error.message : String(error),
       consecutiveFailures,

--- a/src/lib/ai/context-compactor/index.ts
+++ b/src/lib/ai/context-compactor/index.ts
@@ -1,0 +1,129 @@
+import type { UIMessage } from "ai";
+import { logger } from "@/lib/utils/logger";
+import { compressMessages } from "./compressor";
+import { makeSummaryUIMessage } from "./prompts";
+import {
+  estimateUIMessagesTokens,
+  getContextBudget,
+  getPreserveThreshold,
+} from "./token-budget";
+
+const MIN_PRESERVE_TURNS = 3;
+
+export interface CompressionState {
+  compressionSummary: string | null;
+  compressedUpToMessageId: string | null;
+  lastInputTokens: number | null;
+}
+
+export interface CompactionResult {
+  messages: UIMessage[];
+  updatedState: CompressionState | null;
+}
+
+export async function compactMessages(
+  messages: UIMessage[],
+  state: CompressionState,
+  modelId: string,
+): Promise<CompactionResult> {
+  const budget = getContextBudget(modelId);
+  const preserveThreshold = getPreserveThreshold(modelId);
+  const estimatedTokens =
+    state.lastInputTokens ?? estimateUIMessagesTokens(messages);
+
+  logger.debug("🗜️ [COMPACTOR] Evaluating budget", {
+    estimatedTokens,
+    budget,
+    hasExistingSummary: !!state.compressionSummary,
+    messageCount: messages.length,
+  });
+
+  if (state.compressionSummary && state.compressedUpToMessageId) {
+    const cutoffIdx = messages.findIndex(
+      (message) => message.id === state.compressedUpToMessageId,
+    );
+
+    if (cutoffIdx !== -1) {
+      const recentMessages = messages.slice(cutoffIdx + 1);
+      const recentTokens = estimateUIMessagesTokens(recentMessages);
+      const summaryTokens = state.compressionSummary.length * 0.3;
+      const totalWithSummary = recentTokens + summaryTokens;
+
+      if (totalWithSummary < budget) {
+        logger.debug("🗜️ [COMPACTOR] Using cached summary", {
+          recentMessages: recentMessages.length,
+          totalWithSummary: Math.ceil(totalWithSummary),
+        });
+        return {
+          messages: [
+            makeSummaryUIMessage(state.compressionSummary),
+            ...recentMessages,
+          ],
+          updatedState: null,
+        };
+      }
+
+      logger.info(
+        "🗜️ [COMPACTOR] Re-compressing — conversation grew past budget",
+      );
+    } else {
+      logger.warn("🗜️ [COMPACTOR] Stale cache — discarding summary", {
+        missingMessageId: state.compressedUpToMessageId,
+      });
+    }
+  }
+
+  if (estimatedTokens < budget) {
+    return { messages, updatedState: null };
+  }
+
+  let preserveFromIdx = messages.length;
+  let preserveTokens = 0;
+  let userTurnsSeen = 0;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msgTokens = estimateUIMessagesTokens([messages[i]]);
+    if (messages[i].role === "user") userTurnsSeen++;
+
+    if (
+      userTurnsSeen > MIN_PRESERVE_TURNS &&
+      preserveTokens + msgTokens > preserveThreshold
+    ) {
+      break;
+    }
+    preserveFromIdx = i;
+    preserveTokens += msgTokens;
+  }
+
+  if (preserveFromIdx <= 1) {
+    logger.debug("🗜️ [COMPACTOR] Not enough messages to compress");
+    return { messages, updatedState: null };
+  }
+
+  const toCompress = messages.slice(0, preserveFromIdx);
+  const toPreserve = messages.slice(preserveFromIdx);
+  const cutoffMessageId = toCompress[toCompress.length - 1].id;
+
+  logger.info("🗜️ [COMPACTOR] Compressing messages", {
+    compressing: toCompress.length,
+    preserving: toPreserve.length,
+    cutoffMessageId,
+  });
+
+  const summary = await compressMessages(toCompress, state.compressionSummary);
+
+  if (!summary) {
+    return { messages, updatedState: null };
+  }
+
+  return {
+    messages: [makeSummaryUIMessage(summary), ...toPreserve],
+    updatedState: {
+      compressionSummary: summary,
+      compressedUpToMessageId: cutoffMessageId,
+      lastInputTokens: state.lastInputTokens,
+    },
+  };
+}
+
+export { estimateTokens, estimateUIMessagesTokens } from "./token-budget";

--- a/src/lib/ai/context-compactor/index.ts
+++ b/src/lib/ai/context-compactor/index.ts
@@ -3,6 +3,7 @@ import { logger } from "@/lib/utils/logger";
 import { compressMessages } from "./compressor";
 import { makeSummaryUIMessage } from "./prompts";
 import {
+  estimateTokens,
   estimateUIMessagesTokens,
   getContextBudget,
   getPreserveThreshold,
@@ -30,6 +31,7 @@ export async function compactMessages(
   const preserveThreshold = getPreserveThreshold(modelId);
   const estimatedTokens =
     state.lastInputTokens ?? estimateUIMessagesTokens(messages);
+  let needsRecompression = false;
 
   logger.debug("🗜️ [COMPACTOR] Evaluating budget", {
     estimatedTokens,
@@ -46,7 +48,7 @@ export async function compactMessages(
     if (cutoffIdx !== -1) {
       const recentMessages = messages.slice(cutoffIdx + 1);
       const recentTokens = estimateUIMessagesTokens(recentMessages);
-      const summaryTokens = state.compressionSummary.length * 0.3;
+      const summaryTokens = estimateTokens(state.compressionSummary);
       const totalWithSummary = recentTokens + summaryTokens;
 
       if (totalWithSummary < budget) {
@@ -66,14 +68,16 @@ export async function compactMessages(
       logger.info(
         "🗜️ [COMPACTOR] Re-compressing — conversation grew past budget",
       );
+      needsRecompression = true;
     } else {
       logger.warn("🗜️ [COMPACTOR] Stale cache — discarding summary", {
         missingMessageId: state.compressedUpToMessageId,
       });
+      needsRecompression = true;
     }
   }
 
-  if (estimatedTokens < budget) {
+  if (estimatedTokens < budget && !needsRecompression) {
     return { messages, updatedState: null };
   }
 
@@ -121,7 +125,7 @@ export async function compactMessages(
     updatedState: {
       compressionSummary: summary,
       compressedUpToMessageId: cutoffMessageId,
-      lastInputTokens: state.lastInputTokens,
+      lastInputTokens: null,
     },
   };
 }

--- a/src/lib/ai/context-compactor/prompts.ts
+++ b/src/lib/ai/context-compactor/prompts.ts
@@ -1,0 +1,75 @@
+import { getToolName, isToolUIPart, type UIMessage } from "ai";
+
+export const COMPRESSION_SYSTEM_PROMPT = `You are a conversation summarizer. Your job is to compress a chat conversation into a dense, information-rich summary that preserves all important context.
+
+Rules:
+- Preserve ALL factual information: names, numbers, dates, URLs, code snippets, decisions made
+- Preserve the user's stated goals, preferences, and constraints
+- Preserve any tool calls and their results (what was searched, what was found)
+- Preserve the assistant's key conclusions and recommendations
+- Do NOT add opinions or new information
+- Do NOT use phrases like "the user asked" or "the assistant responded" — state facts directly
+- Write in compact bullet points grouped by topic
+- Target roughly 1/4 the length of the original conversation
+- If there are code blocks or technical details that are actively being worked on, preserve them verbatim`;
+
+export const COMPRESSION_USER_PROMPT = `Summarize this conversation, preserving all important context:
+
+<conversation>
+{CONVERSATION}
+</conversation>
+
+Provide a dense summary:`;
+
+export function makeSummaryUIMessage(summary: string): UIMessage {
+  return {
+    id: "__compression_summary__",
+    role: "user",
+    parts: [
+      {
+        type: "text",
+        text: wrapSummary(summary),
+      },
+    ],
+    createdAt: new Date(0),
+  } as UIMessage;
+}
+
+export function wrapSummary(summary: string): string {
+  return `[Previous conversation summary — treat as established context]\n\n${summary}`;
+}
+
+export function formatConversationForCompression(
+  messages: UIMessage[],
+): string {
+  return messages
+    .map((msg) => {
+      const role = msg.role === "user" ? "User" : "Assistant";
+      const text = msg.parts
+        .map((p) => {
+          if (p.type === "text") return p.text;
+          if (isToolUIPart(p)) {
+            let result = `[Tool: ${getToolName(p)}`;
+            if ("input" in p && p.input !== undefined) {
+              try {
+                result += ` args=${JSON.stringify(p.input)}`;
+              } catch {}
+            }
+            if ("output" in p && p.output !== undefined) {
+              try {
+                result += ` → ${JSON.stringify(p.output)}`;
+              } catch {}
+            } else if ("errorText" in p && p.errorText) {
+              result += ` → ${p.errorText}`;
+            }
+            result += "]";
+            return result;
+          }
+          return "";
+        })
+        .filter(Boolean)
+        .join("\n");
+      return `${role}:\n${text}`;
+    })
+    .join("\n\n");
+}

--- a/src/lib/ai/context-compactor/token-budget.ts
+++ b/src/lib/ai/context-compactor/token-budget.ts
@@ -1,0 +1,77 @@
+import { getToolName, isToolUIPart, type UIMessage } from "ai";
+
+const MODEL_BUDGETS: Record<string, number> = {
+  "gemini-3.1-pro": 180_000,
+  "gemini-3-flash": 180_000,
+  "gemini-2.5-flash": 180_000,
+  "gemini-2.5-flash-lite": 180_000,
+  "claude-sonnet-4.6": 160_000,
+  "claude-haiku-4.5": 160_000,
+  "gpt-5-chat": 100_000,
+};
+const DEFAULT_BUDGET = 120_000;
+const PRESERVE_RATIO = 0.75;
+
+export function estimateTokens(text: string): number {
+  let tokens = 0;
+  for (const char of text) {
+    const code = char.codePointAt(0) ?? 0;
+    if (
+      (code >= 0x4e00 && code <= 0x9fff) ||
+      (code >= 0x3400 && code <= 0x4dbf) ||
+      (code >= 0xf900 && code <= 0xfaff)
+    ) {
+      tokens += 1.5;
+    } else {
+      tokens += 0.3;
+    }
+  }
+  return Math.ceil(tokens);
+}
+
+export function extractTextFromUIMessage(msg: UIMessage): string {
+  return msg.parts
+    .map((p) => {
+      if (p.type === "text") return p.text;
+      if (isToolUIPart(p)) {
+        const parts = [getToolName(p)];
+        if ("input" in p && p.input !== undefined) {
+          try {
+            parts.push(JSON.stringify(p.input));
+          } catch {}
+        }
+        if ("output" in p && p.output !== undefined) {
+          try {
+            parts.push(JSON.stringify(p.output));
+          } catch {}
+        } else if ("errorText" in p && p.errorText) {
+          parts.push(p.errorText);
+        }
+        return parts.join(" ");
+      }
+      return "";
+    })
+    .join(" ");
+}
+
+export function estimateUIMessagesTokens(messages: UIMessage[]): number {
+  return messages.reduce(
+    (sum, msg) => sum + estimateTokens(extractTextFromUIMessage(msg)),
+    0,
+  );
+}
+
+export function getContextBudget(modelId: string): number {
+  const bare = modelId.replace(
+    /^(google|anthropic|openai|azure|vertex|bedrock)\//,
+    "",
+  );
+  for (const [key, budget] of Object.entries(MODEL_BUDGETS)) {
+    if (bare.startsWith(key)) return budget;
+  }
+  return DEFAULT_BUDGET;
+}
+
+export function getPreserveThreshold(modelId: string): number {
+  return Math.floor(getContextBudget(modelId) * PRESERVE_RATIO);
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -896,6 +896,12 @@ export const chatThreads = pgTable(
     }).defaultNow(),
     /** Tip of current branch for threaded conversations; used when loading history. */
     headMessageId: text("head_message_id"),
+    /** Cached LLM-generated summary of compressed messages */
+    compressionSummary: text("compression_summary"),
+    /** The message ID up to which messages have been compressed into the summary */
+    compressedUpToMessageId: text("compressed_up_to_message_id"),
+    /** Token count from the last model response (usage.inputTokens from onFinish) */
+    lastInputTokens: integer("last_input_tokens"),
   },
   (table) => [
     index("idx_chat_threads_workspace").using(


### PR DESCRIPTION
This PR implements a server-side context compaction system that compresses long chat histories into cached summaries. When a conversation exceeds a model's token budget, older messages are summarized via a lightweight LLM call and persisted to the `chat_threads` table. The summary is cached and reused on subsequent requests, reducing token usage and API costs while preserving critical context. The client sends full history every time; server-side logic decides when to compress.

- **src/lib/db/schema.ts**: Add `compressionSummary`, `compressedUpToMessageId`, `lastInputTokens` columns to `chatThreads` table
- **src/lib/ai/context-compactor/index.ts**: Main orchestration logic; evaluates token budget, caches/invalidates summaries, triggers re-compression when conversation grows past budget
- **src/lib/ai/context-compactor/token-budget.ts**: Heuristic token estimation (CJK vs Latin) and model-specific context budget calculation
- **src/lib/ai/context-compactor/prompts.ts**: Compression prompts and `makeSummaryUIMessage` formatter that creates synthetic summary message compatible with `convertToModelMessages`
- **src/lib/ai/context-compactor/compressor.ts**: LLM compression call with circuit breaker (3 failures → skip)
- **src/app/api/chat/route.ts**: Integrate compactor - load state from DB, apply before `convertToModelMessages`, persist `lastInputTokens` and updated summary in `onFinish`
- **drizzle/0002_quiet_grandmaster.sql**: Migration to add compression columns to `chat_threads`

<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/pull/367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/task/63f5b9ec-69a1-47ba-9e5b-c575974a26af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-47&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-47"><img alt="ENG-47 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-47"></picture></a>