### PR TITLE
Fix withSupermemory wrapper for AI SDK 6 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@streamdown/math": "^1.0.2",
     "@streamdown/mermaid": "^1.0.2",
     "@supabase/supabase-js": "^2.101.1",
+    "@supermemory/tools": "1.4.1",
     "@tanstack/pacer": "^0.20.1",
     "@tanstack/react-pacer": "^0.21.1",
     "@tanstack/react-query": "^5.96.1",

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -9,6 +9,7 @@ import {
 } from "ai";
 import { devToolsMiddleware } from "@ai-sdk/devtools";
 import { withTracing } from "@posthog/ai";
+import { withSupermemory } from "@/lib/ai/supermemory-compat";
 import type { UIMessage } from "ai";
 import { logger } from "@/lib/utils/logger";
 import { auth } from "@/lib/auth";
@@ -132,6 +133,7 @@ async function handlePOST(req: Request) {
     const system = body.system || "";
     workspaceId = extractWorkspaceId(body);
     activeFolderId = body.activeFolderId;
+    const isMemoryEnabled = body.isMemoryEnabled ?? false;
     // AssistantChatTransport passes thread remoteId as body.id (see assistant-ui react-ai-sdk)
     const threadId = body.id ?? body.threadId ?? null;
 
@@ -212,9 +214,20 @@ async function handlePOST(req: Request) {
         })
       : (baseGatewayModel as any);
 
+    const supermemoryApiKey = process.env.SUPERMEMORY_API_KEY;
+    const memoryModel =
+      supermemoryApiKey && userId && isMemoryEnabled
+        ? withSupermemory(tracedModel, userId, {
+            apiKey: supermemoryApiKey,
+            mode: "full",
+            addMemory: "always",
+            conversationId: threadId ?? undefined,
+          })
+        : tracedModel;
+
     // Use AI Gateway
     const model = wrapLanguageModel({
-      model: tracedModel,
+      model: memoryModel,
       middleware:
         process.env.NODE_ENV === "development" ? devToolsMiddleware() : [],
     });

--- a/src/lib/ai/supermemory-compat.ts
+++ b/src/lib/ai/supermemory-compat.ts
@@ -1,0 +1,49 @@
+import { withSupermemory as originalWithSupermemory } from "@supermemory/tools/ai-sdk";
+import type { LanguageModel as AiLanguageModel } from "ai";
+
+type LanguageModel = Exclude<AiLanguageModel, string>;
+
+/**
+ * Wrapper around `withSupermemory` that fixes AI SDK 6 compatibility.
+ *
+ * `@supermemory/tools@1.4.1` uses object spread to wrap the model, which drops
+ * non-enumerable / prototype properties (`specificationVersion`, `provider`,
+ * `modelId`) that AI SDK 6 requires. This shim calls the original wrapper then
+ * copies those properties back from the original model.
+ *
+ * Remove this once `@supermemory/tools` ships a fix.
+ * Upstream issue: https://github.com/supermemoryai/supermemory-sdk/issues/XXX
+ */
+export function withSupermemory(
+  model: LanguageModel,
+  containerTag: string,
+  options: Parameters<typeof originalWithSupermemory>[2],
+): LanguageModel {
+  const wrapped = originalWithSupermemory(
+    model as any,
+    containerTag,
+    options,
+  ) as any;
+
+  const specProps = [
+    "specificationVersion",
+    "provider",
+    "modelId",
+    "defaultObjectGenerationMode",
+    "supportsImageUrls",
+    "supportsStructuredOutputs",
+    "supportedUrls",
+  ] as const;
+
+  for (const prop of specProps) {
+    if (wrapped[prop] === undefined && (model as any)[prop] !== undefined) {
+      Object.defineProperty(wrapped, prop, {
+        get: () => (model as any)[prop],
+        enumerable: true,
+        configurable: true,
+      });
+    }
+  }
+
+  return wrapped as LanguageModel;
+}


### PR DESCRIPTION
This PR fixes `AI_UnsupportedModelVersionError` when Supermemory is enabled by creating a compatibility shim that preserves model metadata properties dropped by `@supermemory/tools@1.4.1`'s object spread wrapper.

- **src/lib/ai/supermemory-compat.ts**: NEW — Shim wrapper that re-attaches non-enumerable properties (`specificationVersion`, `provider`, `modelId`, etc.) from the original model after `withSupermemory` wraps it
- **src/app/api/chat/route.ts**: Import local shim instead of `@supermemory/tools/ai-sdk`; conditionally wrap `tracedModel` with `withSupermemory` when `isMemoryEnabled` is true and API key is present
- **package.json**: Added `@supermemory/tools@1.4.1` dependency

<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/pull/370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/task/09e5be56-ce86-48b6-9670-a3592cb57c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-48&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-48"><img alt="ENG-48 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-48"></picture></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Chat now includes an optional memory feature that preserves conversation context when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->