### PR TITLE
Fix DEFAULT_THREAD_ID leak — ensure real thread UUID reaches /api/chat

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -134,6 +134,10 @@ async function handlePOST(req: Request) {
     activeFolderId = body.activeFolderId;
     // AssistantChatTransport passes thread remoteId as body.id (see assistant-ui react-ai-sdk)
     const threadId = body.id ?? body.threadId ?? null;
+    logger.info("🧵 [CHAT-API] Thread ID:", {
+      threadId,
+      isDefault: threadId === "DEFAULT_THREAD_ID",
+    });
 
     // Create tools using the modular factory (before convertToModelMessages so
     // toModelOutput can sanitize historical tool results for the model)

--- a/src/components/assistant-ui/WorkspaceRuntimeProvider.tsx
+++ b/src/components/assistant-ui/WorkspaceRuntimeProvider.tsx
@@ -214,6 +214,13 @@ export function WorkspaceRuntimeProvider({
             console.warn("[WorkspaceRuntimeProvider] Thread init failed:", e);
           }
 
+          if (process.env.NODE_ENV === "development") {
+            console.debug(
+              "[WorkspaceRuntimeProvider] Thread ID for request:",
+              threadRemoteId ?? "(fallback)",
+            );
+          }
+
           return {
             body: {
               ...options.body,

--- a/src/components/assistant-ui/WorkspaceRuntimeProvider.tsx
+++ b/src/components/assistant-ui/WorkspaceRuntimeProvider.tsx
@@ -40,6 +40,23 @@ function createWorkspaceChatRuntimeHook(
   };
 }
 
+/**
+ * Bridges the outer RemoteThreadListRuntime's initialize() into a ref
+ * so the transport's prepareSendMessagesRequest can eagerly resolve the
+ * real thread remoteId before each chat request.
+ *
+ * Workaround for https://github.com/assistant-ui/assistant-ui/issues/3578
+ */
+function ThreadInitBridge({
+  initRef,
+}: {
+  initRef: React.MutableRefObject<(() => Promise<{ remoteId: string }>) | null>;
+}) {
+  const aui = useAui();
+  initRef.current = () => aui.threadListItem().initialize();
+  return null;
+}
+
 export function WorkspaceRuntimeProvider({
   workspaceId,
   children,
@@ -99,6 +116,9 @@ export function WorkspaceRuntimeProvider({
     activeFolderId,
     selectedCardsContext: "",
   });
+  const threadInitRef = useRef<(() => Promise<{ remoteId: string }>) | null>(
+    null,
+  );
   chatApiPayloadRef.current.workspaceId = workspaceId;
   chatApiPayloadRef.current.modelId = selectedModelId;
   chatApiPayloadRef.current.activeFolderId = activeFolderId;
@@ -184,6 +204,27 @@ export function WorkspaceRuntimeProvider({
       new AssistantChatTransport({
         api: "/api/chat",
         body: () => ({ ...chatApiPayloadRef.current }),
+        prepareSendMessagesRequest: async (options) => {
+          let threadRemoteId: string | undefined;
+
+          try {
+            const result = await threadInitRef.current?.();
+            threadRemoteId = result?.remoteId;
+          } catch (e) {
+            console.warn("[WorkspaceRuntimeProvider] Thread init failed:", e);
+          }
+
+          return {
+            body: {
+              ...options.body,
+              id: threadRemoteId ?? options.body?.id,
+              messages: options.messages,
+              trigger: options.trigger,
+              messageId: options.messageId,
+              metadata: options.requestMetadata,
+            },
+          };
+        },
       }),
     // Body snapshot comes from the ref via Resolvable function above.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- stable transport instance
@@ -206,6 +247,7 @@ export function WorkspaceRuntimeProvider({
 
   return (
     <AssistantRuntimeProvider runtime={runtime} aui={aui}>
+      <ThreadInitBridge initRef={threadInitRef} />
       <AssistantAvailableProvider>{children}</AssistantAvailableProvider>
     </AssistantRuntimeProvider>
   );


### PR DESCRIPTION
This PR works around an upstream bug in `AssistantChatTransport` where `body.id` was always the sentinel string `"DEFAULT_THREAD_ID"` instead of the real database UUID. By eagerly calling the outer `RemoteThreadListRuntime`'s `initialize()` via a bridge component and overriding the transport's `prepareSendMessagesRequest`, we ensure the actual `remoteId` is injected into every `/api/chat` request.

- **src/components/assistant-ui/WorkspaceRuntimeProvider.tsx**: Added `ThreadInitBridge` component to wire `aui.threadListItem().initialize()` into a ref accessible by the transport; added `threadInitRef`; extended `AssistantChatTransport` with `prepareSendMessagesRequest` to await thread init and override `body.id` with the resolved `remoteId`.

<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/pull/379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/task/b77607d9-09a7-4e3a-9e6f-75a598d8776e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-55&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-55"><img alt="ENG-55 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-55"></picture></a>