### PR TITLE
Fix Zero query auth enforcement and workspace access validation

### DIFF
--- a/src/app/api/zero/query/route.ts
+++ b/src/app/api/zero/query/route.ts
@@ -14,7 +14,7 @@ type QueryRequest = {
   args?: readonly unknown[];
 };
 
-async function assertWorkspaceReadAccess(
+async function hasWorkspaceReadAccess(
   workspaceId: string,
   userId: string,
 ): Promise<boolean> {
@@ -82,8 +82,15 @@ export async function POST(request: NextRequest) {
       ),
     ];
 
+    if (workspaceIds.length === 0) {
+      return NextResponse.json(
+        { error: "No workspace context provided" },
+        { status: 400 },
+      );
+    }
+
     for (const workspaceId of workspaceIds) {
-      const hasAccess = await assertWorkspaceReadAccess(workspaceId, userId);
+      const hasAccess = await hasWorkspaceReadAccess(workspaceId, userId);
       if (!hasAccess) {
         throw new Error(WORKSPACE_ACCESS_DENIED_ERROR);
       }

--- a/src/app/api/zero/query/route.ts
+++ b/src/app/api/zero/query/route.ts
@@ -1,19 +1,112 @@
 import { NextRequest, NextResponse } from "next/server";
-import { mustGetQuery } from "@rocicorp/zero";
+import { mustGetQuery, type ReadonlyJSONValue } from "@rocicorp/zero";
 import { handleQueryRequest } from "@rocicorp/zero/server";
+import { and, eq } from "drizzle-orm";
 import { auth } from "@/lib/auth";
+import { db } from "@/lib/db/client";
+import { workspaceCollaborators, workspaces } from "@/lib/db/schema";
 import { queries } from "@/lib/zero/queries";
 import { schema } from "@/lib/zero/zero-schema.gen";
 
+const WORKSPACE_ACCESS_DENIED_ERROR = "Workspace access denied";
+
+type QueryRequest = {
+  args?: readonly unknown[];
+};
+
+async function assertWorkspaceReadAccess(
+  workspaceId: string,
+  userId: string,
+): Promise<boolean> {
+  const [workspace] = await db
+    .select({ ownerId: workspaces.userId })
+    .from(workspaces)
+    .where(eq(workspaces.id, workspaceId))
+    .limit(1);
+
+  if (!workspace) {
+    return false;
+  }
+
+  if (workspace.ownerId === userId) {
+    return true;
+  }
+
+  const [collaborator] = await db
+    .select({ id: workspaceCollaborators.id })
+    .from(workspaceCollaborators)
+    .where(
+      and(
+        eq(workspaceCollaborators.workspaceId, workspaceId),
+        eq(workspaceCollaborators.userId, userId),
+      ),
+    )
+    .limit(1);
+
+  return !!collaborator;
+}
+
 export async function POST(request: NextRequest) {
   const session = await auth.api.getSession({ headers: request.headers });
-  const ctx = { userId: session?.user?.id ?? null };
 
-  const result = await handleQueryRequest(
-    (name, args) => mustGetQuery(queries, name).fn({ args, ctx }),
-    schema,
-    request,
-  );
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
-  return NextResponse.json(result);
+  const userId = session.user.id;
+  const ctx = { userId };
+
+  try {
+    const body = (await request.json()) as unknown;
+    const queryRequests =
+      Array.isArray(body) && Array.isArray(body[1])
+        ? (body[1] as QueryRequest[])
+        : [];
+    const workspaceIds = [
+      ...new Set(
+        queryRequests.flatMap((queryRequest) => {
+          const args = queryRequest.args;
+          const firstArg = args?.[0];
+
+          if (
+            firstArg &&
+            typeof firstArg === "object" &&
+            "workspaceId" in firstArg &&
+            typeof firstArg.workspaceId === "string"
+          ) {
+            return [firstArg.workspaceId];
+          }
+
+          return [];
+        }),
+      ),
+    ];
+
+    for (const workspaceId of workspaceIds) {
+      const hasAccess = await assertWorkspaceReadAccess(workspaceId, userId);
+      if (!hasAccess) {
+        throw new Error(WORKSPACE_ACCESS_DENIED_ERROR);
+      }
+    }
+
+    const result = await handleQueryRequest(
+      (name, args) => mustGetQuery(queries, name).fn({ args, ctx }),
+      schema,
+      body as ReadonlyJSONValue,
+    );
+
+    return NextResponse.json(result);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === WORKSPACE_ACCESS_DENIED_ERROR
+    ) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
 }

--- a/src/lib/zero/client.ts
+++ b/src/lib/zero/client.ts
@@ -3,7 +3,7 @@ import { mutators } from "./mutators";
 import { schema } from "./zero-schema.gen";
 
 export interface ZeroContext {
-  userId: string | null;
+  userId: string;
 }
 
 function createZeroInstance(params: { userId: string }) {


### PR DESCRIPTION
This PR closes an auth gap where the Zero query endpoint accepted unauthenticated requests and didn't validate workspace access, allowing anyone to read workspace items by UUID.

**src/app/api/zero/query/route.ts**: Added 401 gate if no session, then pre-validates workspace read access via `assertWorkspaceReadAccess` (checks `workspaces.ownerId` or `workspaceCollaborators` existence) before query execution, with 403 for denied access.

**src/lib/zero/client.ts**: Tightened `ZeroContext` to require `userId: string` instead of nullable.

<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/pull/385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/task/3bf133a6-6ffe-4ac8-8ee6-31dcd25279da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-60&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-60"><img alt="ENG-60 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-60"></picture></a>