### PR TITLE
Disable Supermemory wrapper until upstream publishes AI SDK v6 fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,5 +54,11 @@ MISTRAL_API_KEY=your-mistral-api-key
 # Supermemory (memory layer for chat — https://console.supermemory.ai)
 # Optional: when unset, the memory toggle is a no-op server-side.
 SUPERMEMORY_API_KEY=sm_...
+
+# Kill switch for the Supermemory wrapper. Must be exactly "true" to enable.
+# DO NOT flip on until `@supermemory/tools` is bumped to a version containing
+# https://github.com/supermemoryai/supermemory/pull/854 (expected 1.4.2+).
+# Published 1.4.1 breaks AI SDK v6 with `AI_UnsupportedModelVersionError`.
+SUPERMEMORY_ENABLED=false
 # Optional: MISTRAL_OCR_ENDPOINT=https://api.mistral.ai/v1/ocr
 # Optional: MISTRAL_OCR_MODEL=mistral-ocr-latest

--- a/src/lib/ai/supermemory.ts
+++ b/src/lib/ai/supermemory.ts
@@ -16,6 +16,30 @@ export function maybeWithSupermemory<T>(
 ): T {
   const { userId, threadId, memoryEnabled } = options;
 
+  // HOTFIX KILL SWITCH (see ENG-059 follow-up).
+  //
+  // Published `@supermemory/tools@1.4.1` wraps the language model with
+  // `{ ...model, doGenerate, doStream }`. In AI SDK v6, `specificationVersion`,
+  // `provider`, `modelId`, and `supportedUrls` live on the LanguageModelV3
+  // prototype — spread drops them, so `streamText` throws
+  // `AI_UnsupportedModelVersionError: ... specification version "v2"`.
+  //
+  // Upstream PR https://github.com/supermemoryai/supermemory/pull/854 (merged
+  // into main as commit 76b0f27) replaces the spread with a Proxy. As of
+  // April 16 2026 that fix is NOT yet published to npm — `latest` is still
+  // 1.4.1 from March 19.
+  //
+  // Until a fixed version (expected 1.4.2+) is published:
+  //   - Disabled/unset: wrapper is a no-op. UI toggle is cosmetic but all
+  //     other plumbing (UI state, transport field, PostHog property, route
+  //     body read) stays intact.
+  //   - Enabled with the literal string "true": wrapper runs as before. Only
+  //     set this AFTER bumping `@supermemory/tools` to a version containing
+  //     PR #854.
+  if (process.env.SUPERMEMORY_ENABLED !== "true") {
+    return model;
+  }
+
   if (!memoryEnabled) return model;
   if (!userId) return model;
 


### PR DESCRIPTION
This PR gates the Supermemory wrapper behind `SUPERMEMORY_ENABLED !== "true"` to bypass an upstream incompatibility between `@supermemory/tools@1.4.1` and AI SDK v6 that causes `AI_UnsupportedModelVersionError`. All client-side plumbing (UI toggle, transport field, route body) remains intact so the feature can be re-enabled via env var once upstream ships a fixed version.

- **src/lib/ai/supermemory.ts**: Added early-return guard `if (process.env.SUPERMEMORY_ENABLED !== "true")` to skip wrapping; detailed comment explains AI SDK v6 prototype spread issue and references upstream PR #854.
- **.env.example**: Added `SUPERMEMORY_ENABLED=false` with instructions to only flip to "true" after bumping `@supermemory/tools` to a version containing the Proxy fix.

<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/pull/386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/task/41fad4b7-8c71-441c-9636-80ca4ca73875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-61&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-61"><img alt="ENG-61 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-61"></picture></a>