### PR TITLE
Re-enable Supermemory wrapper via 1.4.3 bump

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,9 +56,10 @@ MISTRAL_API_KEY=your-mistral-api-key
 SUPERMEMORY_API_KEY=sm_...
 
 # Kill switch for the Supermemory wrapper. Must be exactly "true" to enable.
-# DO NOT flip on until `@supermemory/tools` is bumped to a version containing
-# https://github.com/supermemoryai/supermemory/pull/854 (expected 1.4.2+).
-# Published 1.4.1 breaks AI SDK v6 with `AI_UnsupportedModelVersionError`.
-SUPERMEMORY_ENABLED=false
+# `@supermemory/tools@1.4.3+` contains the Proxy-based fix for AI SDK v6
+# (https://github.com/supermemoryai/supermemory/pull/854). If you downgrade
+# the dep or upstream regresses, set this to "false" to neutralize the
+# wrapper without ripping out any UI/transport plumbing.
+SUPERMEMORY_ENABLED=true
 # Optional: MISTRAL_OCR_ENDPOINT=https://api.mistral.ai/v1/ocr
 # Optional: MISTRAL_OCR_MODEL=mistral-ocr-latest

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@streamdown/math": "^1.0.2",
     "@streamdown/mermaid": "^1.0.2",
     "@supabase/supabase-js": "^2.101.1",
-    "@supermemory/tools": "^1.4.1",
+    "@supermemory/tools": "^1.4.3",
     "@tanstack/pacer": "^0.20.1",
     "@tanstack/react-pacer": "^0.21.1",
     "@tanstack/react-query": "^5.96.1",

--- a/src/lib/ai/supermemory.ts
+++ b/src/lib/ai/supermemory.ts
@@ -16,26 +16,12 @@ export function maybeWithSupermemory<T>(
 ): T {
   const { userId, threadId, memoryEnabled } = options;
 
-  // HOTFIX KILL SWITCH (see ENG-059 follow-up).
-  //
-  // Published `@supermemory/tools@1.4.1` wraps the language model with
-  // `{ ...model, doGenerate, doStream }`. In AI SDK v6, `specificationVersion`,
-  // `provider`, `modelId`, and `supportedUrls` live on the LanguageModelV3
-  // prototype — spread drops them, so `streamText` throws
-  // `AI_UnsupportedModelVersionError: ... specification version "v2"`.
-  //
-  // Upstream PR https://github.com/supermemoryai/supermemory/pull/854 (merged
-  // into main as commit 76b0f27) replaces the spread with a Proxy. As of
-  // April 16 2026 that fix is NOT yet published to npm — `latest` is still
-  // 1.4.1 from March 19.
-  //
-  // Until a fixed version (expected 1.4.2+) is published:
-  //   - Disabled/unset: wrapper is a no-op. UI toggle is cosmetic but all
-  //     other plumbing (UI state, transport field, PostHog property, route
-  //     body read) stays intact.
-  //   - Enabled with the literal string "true": wrapper runs as before. Only
-  //     set this AFTER bumping `@supermemory/tools` to a version containing
-  //     PR #854.
+  // Server-side kill switch. Neutralizes the wrapper without touching UI,
+  // state, or transport plumbing — set the env to `false` to
+  // disable if upstream regresses or we need to bisect prod issues.
+  // History: disabled in ENG-061 when @supermemory/tools@1.4.1 broke AI SDK
+  // v6 (see https://github.com/supermemoryai/supermemory/pull/854); re-enabled
+  // in ENG-062 on @supermemory/tools@1.4.3+.
   if (process.env.SUPERMEMORY_ENABLED !== "true") {
     return model;
   }


### PR DESCRIPTION
This PR bumps `@supermemory/tools` to `v1.4.3`, which contains the Proxy-based fix for AI SDK v6 compatibility, and flips the kill switch default back to enabled.

- **package.json**: Bumped `@supermemory/tools` from `^1.4.1` to `^1.4.3`.
- **pnpm-lock.yaml**: Updated lockfile to reflect the new dependency version.
- **.env.example**: Set `SUPERMEMORY_ENABLED=true` and updated documentation to reference the specific fixed version and upstream PR.
- **src/lib/ai/supermemory.ts**: Pruned the incident-specific comment block; the `SUPERMEMORY_ENABLED` guard and wrapper logic remain intact.

**Post-merge step**: Ensure `SUPERMEMORY_ENABLED=true` is set in the Vercel production environment.

<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/pull/387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/task/7ae69247-2242-4207-bd26-39c12381a2a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-62&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-62"><img alt="ENG-62 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ENG-62"></picture></a>