### PR TITLE
fix(favicon): use adaptive SVG as sole icon entry to fix Safari (#100)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,13 +39,10 @@ export const metadata: Metadata = {
     images: ["/opengraph.png"],
   },
   icons: {
-    icon: [
-      { url: isDev ? "/favicon-dev.svg" : "/newfav.ico", sizes: "32x32" },
-      {
-        url: isDev ? "/favicon-dev.svg" : "/thinkexdarkfav.svg",
-        type: "image/svg+xml",
-      },
-    ],
+    icon: {
+      url: isDev ? "/favicon-dev.svg" : "/thinkexdarkfav.svg",
+      type: "image/svg+xml",
+    },
     apple: "/apple-touch-icon.png",
   },
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,6 +42,7 @@ export const metadata: Metadata = {
     icon: {
       url: isDev ? "/favicon-dev.svg" : "/thinkexdarkfav.svg",
       type: "image/svg+xml",
+      sizes: "any",
     },
     apple: "/apple-touch-icon.png",
   },


### PR DESCRIPTION
Closes #100.

## Problem
Safari (both prod and localhost) was not displaying the adaptive favicon. On localhost it showed the generic page icon; on prod it showed a non-adaptive variant that didn't change with system theme.

Root cause: `src/app/layout.tsx` declared two `icons.icon` entries — `newfav.ico` and `thinkexdarkfav.svg` — without `media` attributes. Safari picks the first compatible entry, which was the static ICO, and ignored the adaptive SVG entirely.

## Fix
Collapsed the icon array to a single SVG entry. The SVG already has `@media (prefers-color-scheme: light)` CSS embedded, so it adapts on its own. Safari 14+ supports SVG favicons natively, so no fallback is needed.

## Verification
- **Safari, dark mode:** favicon now appears with white squares on dark background ✅
- **Safari, light mode:** favicon now appears with dark squares on light background ✅
- **Chrome, both modes:** unchanged from previous behavior (still adapts on hard refresh) ✅
- **Localhost dev favicon:** blueprint variant now displays correctly in Safari ✅

Note: favicon changes require a hard refresh (Cmd+Option+R) to pick up after deploy.

## Out of scope
- `public/newfav.ico` is left in the repo. It's no longer referenced anywhere in `src/`. Can be deleted in a follow-up cleanup PR.
- `apple-touch-icon.png` is unchanged — iOS dark-mode home-screen icon adaptation is a separate concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated favicon setup into a single SVG-based icon with environment-aware switching, improving favicon consistency across development and production and simplifying icon handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->