### PR TITLE
Replace assistant-ui Viewport with custom scroll controller for virtualized thread

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@tanstack/react-pacer": "^0.21.1",
     "@tanstack/react-query": "^5.96.1",
     "@tanstack/react-query-devtools": "^5.96.1",
-    "@tanstack/react-virtual": "^3.13.23",
+    "virtua": "^0.49.1",
     "@tiptap/core": "3.22.3",
     "@tiptap/extension-code-block": "3.22.3",
     "@tiptap/extension-highlight": "3.22.3",

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -129,6 +129,12 @@ type ThreadVirtualizer = Virtualizer<HTMLDivElement, HTMLDivElement>;
 const ROW_ESTIMATE_SIZE = 350;
 // Breathing room above a user message when scrollToIndex(align:'start').
 const SCROLL_PADDING_START = 16;
+// Bottom slack — extra space appended to the virtualized region so a freshly
+// sent user message can be anchored at the top of the viewport even when
+// the assistant hasn't streamed any content below it yet. Without this,
+// scrollToIndex(lastIndex, { align: 'start' }) clamps because the last
+// message is also the bottom of the scrollable area.
+const BOTTOM_SLACK_PX = 800;
 // Rows kept mounted outside the viewport for smooth scrolling.
 const OVERSCAN = 5;
 
@@ -196,8 +202,9 @@ interface ThreadScrollControllerProps {
 
 /**
  * Owns scroll behavior for the virtualized thread.
- * • thread.initialize → bottom, instant
- * • threadListItem.switchedTo → bottom, instant
+ * • thread.initialize → bottom, instant (first hydration of a thread runtime)
+ * • thread id change → bottom, instant (covers switching to a previously
+ *   loaded thread, where thread.initialize won't fire again)
  * • thread.runStart → anchor the new user message at the top, smooth
  * • Streaming: user owns scroll
  */
@@ -205,25 +212,46 @@ const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
   virtualizerRef,
 }) => {
   const aui = useAui();
+  // Track the current thread id via the threadListItem.switchedTo event
+  // payload. We can't read it from thread state (no id field there) and we
+  // can't scroll inside the event itself because the new thread's messages
+  // haven't been imported yet \u2014 so we stash the id and react in an effect.
+  const [activeThreadId, setActiveThreadId] = useState<string | null>(null);
 
   const scrollToLastIndex = useCallback(
     (align: "start" | "end", behavior: ScrollBehavior) => {
       // Read live count from aui state; closure-based counts are unsafe
       // against sibling-effect ordering (VirtualizedMessages may not have
-      // committed yet when the event fires).
+      // committed yet when this fires).
       const count = aui?.thread()?.getState()?.messages.length ?? 0;
       if (count <= 0) return;
-      // rAF so react-virtual sees the new row count before we scroll;
-      // scrollToIndex retries internally for unmeasured rows.
+      // Two RAFs: first lets react-virtual commit the new row count, second
+      // gives measureElement a chance to register row sizes before we scroll.
+      // scrollToIndex itself also retries internally for unmeasured rows.
       requestAnimationFrame(() => {
-        virtualizerRef.current?.scrollToIndex(count - 1, { align, behavior });
+        requestAnimationFrame(() => {
+          virtualizerRef.current?.scrollToIndex(count - 1, { align, behavior });
+        });
       });
     },
     [aui, virtualizerRef],
   );
 
+  // First hydration of a thread runtime (per-instance event, fires once).
   useAuiEvent("thread.initialize", () => scrollToLastIndex("end", "instant"));
-  useAuiEvent("threadListItem.switchedTo", () => scrollToLastIndex("end", "instant"));
+
+  // Switching to a previously loaded thread does NOT re-fire thread.initialize
+  // (each thread runtime caches _isInitialized). Capture the threadId here, then
+  // react in an effect after React commits the new messages array.
+  useAuiEvent("threadListItem.switchedTo", ({ threadId }) => {
+    setActiveThreadId(threadId);
+  });
+  useEffect(() => {
+    if (!activeThreadId) return;
+    scrollToLastIndex("end", "instant");
+  }, [activeThreadId, scrollToLastIndex]);
+
+  // New user message sent \u2192 anchor at top with smooth animation.
   useAuiEvent("thread.runStart", () => scrollToLastIndex("start", "smooth"));
 
   return null;
@@ -294,6 +322,11 @@ const VirtualizedMessages: FC<VirtualizedMessagesProps> = ({
       aui?.thread()?.getState()?.messages[index]?.id ?? index,
     // Breathing room above a user message when scrollToIndex(align:'start').
     scrollPaddingStart: SCROLL_PADDING_START,
+    // Bottom slack — padding appended after the last row so scrollToIndex(
+    // lastIndex, { align: 'start' }) can land the new user message at the top
+    // even when the assistant hasn't streamed content below it yet. Without
+    // this padding, getMaxScrollOffset clamps the scroll mid-viewport.
+    paddingEnd: BOTTOM_SLACK_PX,
     // Native scrollend event on modern browsers skips TanStack's polling.
     useScrollendEvent: true,
     rangeExtractor,

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -197,11 +197,11 @@ const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
   const messageCount = useAuiState((s) => s.thread.messages.length);
   const isRunning = useAuiState((s) => s.thread.isRunning);
 
-  const scrollToLastIndex = useCallback(
-    (count: number, align: "start" | "end", smooth: boolean) => {
-      if (count <= 0) return;
+  const scrollToIndex = useCallback(
+    (index: number, align: "start" | "end", smooth: boolean) => {
+      if (index < 0) return;
       requestAnimationFrame(() => {
-        virtualizerRef.current?.scrollToIndex(count - 1, { align, smooth });
+        virtualizerRef.current?.scrollToIndex(index, { align, smooth });
       });
     },
     [virtualizerRef],
@@ -216,38 +216,78 @@ const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
     if (messageCount <= 0) return;
     if (settledThreadIdRef.current === threadId) return;
     settledThreadIdRef.current = threadId;
-    scrollToLastIndex(messageCount, "end", false);
-  }, [threadId, messageCount, scrollToLastIndex]);
+    scrollToIndex(messageCount - 1, "end", false);
+  }, [threadId, messageCount, scrollToIndex]);
 
-  // 2. isRunning false -> true: capture viewport blank + smooth-scroll the
-  // newly committed user message to the top. Effect-driven because by this
-  // point React has committed, the Virtualizer is mounted, and the row is
-  // in the DOM with a real measured height. `hasScrolledForRunRef` dedupes
-  // when message-count ticks during the run re-fire the effect.
-  const hasScrolledForRunRef = useRef(false);
+  // 2. isRunning false -> true for the ACTIVE thread: capture viewport blank +
+  // smooth-scroll the newly committed user message to the top. The user-row
+  // target matches virtua's chatbot demo exactly: scroll user to align:start,
+  // and the streaming assistant row beneath it carries minHeight slack so
+  // the user stays pinned even before assistant content streams in.
+  //
+  // Guard on `settledThreadIdRef.current === threadId` so that switching to
+  // an already-running thread doesn't re-fire this scroll (the settled
+  // effect above has already jumped to bottom). hasRunScrolledForThreadRef
+  // dedupes across streaming-token ticks within the same run.
+  const runScrolledForThreadRef = useRef<string | null>(null);
   useEffect(() => {
     if (!isRunning) {
-      hasScrolledForRunRef.current = false;
+      runScrolledForThreadRef.current = null;
       return;
     }
-    if (hasScrolledForRunRef.current) return;
-    hasScrolledForRunRef.current = true;
+    // Only react once the thread-switch settling has completed for this id;
+    // prevents mount-time or thread-switch-to-running-thread re-scrolls.
+    if (settledThreadIdRef.current !== threadId) return;
+    // Dedupe per (thread, run): fire exactly once per false->true transition
+    // for this thread id. The ref resets when isRunning flips back to false,
+    // so the next run can fire again.
+    if (runScrolledForThreadRef.current === threadId) return;
+    runScrolledForThreadRef.current = threadId;
     captureBlankRef.current?.();
     const liveCount = aui?.thread()?.getState()?.messages.length ?? 0;
-    scrollToLastIndex(liveCount, "start", true);
-  }, [isRunning, aui, captureBlankRef, scrollToLastIndex]);
+    // Target the USER row, not the last row. At runStart the store holds
+    // [...prior, newUser, optimisticAssistant], so the user is at liveCount-2.
+    // If only the user has landed (count=liveCount-1), fall back to count-1.
+    const userIndex = liveCount >= 2 ? liveCount - 2 : liveCount - 1;
+    scrollToIndex(userIndex, "start", true);
+  }, [
+    isRunning,
+    threadId,
+    aui,
+    captureBlankRef,
+    scrollToIndex,
+  ]);
 
   return null;
 };
 
 const useMessageHoverHandlers = () => {
   const aui = useAui();
+  // Capture the message runtime at hook time so cleanup targets the same
+  // runtime even after the component unmounts (virtualization can remove a
+  // hovered row without ever firing mouseleave). Without this the message's
+  // isHovering state sticks true and its ActionBar stays pinned visible.
+  const hoveringRef = useRef(false);
+  const messageRef = useRef<ReturnType<typeof aui.message> | null>(null);
+  messageRef.current = aui?.message() ?? null;
+
   const onMouseEnter = useCallback(() => {
-    aui?.message()?.setIsHovering?.(true);
-  }, [aui]);
+    hoveringRef.current = true;
+    messageRef.current?.setIsHovering?.(true);
+  }, []);
   const onMouseLeave = useCallback(() => {
-    aui?.message()?.setIsHovering?.(false);
-  }, [aui]);
+    hoveringRef.current = false;
+    messageRef.current?.setIsHovering?.(false);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (hoveringRef.current) {
+        messageRef.current?.setIsHovering?.(false);
+      }
+    };
+  }, []);
+
   return { onMouseEnter, onMouseLeave };
 };
 
@@ -263,6 +303,7 @@ const VirtualizedMessages: FC<VirtualizedMessagesProps> = ({
   captureBlankRef,
 }) => {
   const aui = useAui();
+  const threadId = useAuiState((s) => s.threadListItem.id);
   const messageCount = useAuiState((s) => s.thread.messages.length);
   const isRunning = useAuiState((s) => s.thread.isRunning);
   // Slack state lives for the lifetime of an entire turn (not just while
@@ -293,8 +334,18 @@ const VirtualizedMessages: FC<VirtualizedMessagesProps> = ({
     };
   }, [aui, captureBlankRef, virtualizerRef]);
 
-  // Release slack when the pinned indexes no longer exist in the list
-  // (thread cleared, switched, or messages deleted).
+  // Release slack whenever the thread identity changes — otherwise stale
+  // minHeight can leak into a different thread if it happens to have
+  // enough messages to keep the pinned index valid.
+  useEffect(() => {
+    setBlankSize(0);
+    setLastUserSize(0);
+    setPinnedAssistantIndex(-1);
+    setPinnedUserIndex(-1);
+  }, [threadId]);
+
+  // Also release when the pinned indexes no longer exist in the list
+  // (messages deleted, thread cleared).
   useEffect(() => {
     if (pinnedAssistantIndex >= messageCount && pinnedAssistantIndex !== -1) {
       setBlankSize(0);

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -35,13 +35,14 @@ import {
   MessagePrimitive,
   ThreadPrimitive,
   useAui,
+  useAuiEvent,
   useMessage,
   useMessagePartText,
   useAuiState,
 } from "@assistant-ui/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
-import type { FC, RefObject } from "react";
+import type { FC, MutableRefObject, RefObject } from "react";
 import { createContext, useContext } from "react";
 import { useEffect, useRef, useState, useMemo, useCallback } from "react";
 
@@ -117,6 +118,7 @@ interface ThreadProps {
 
 export const Thread: FC<ThreadProps> = ({ items = [] }) => {
   const viewportRef = useRef<HTMLDivElement>(null);
+  const virtualizerHandleRef = useRef<VirtualizerHandle | null>(null);
 
   return (
     <ThreadPrimitive.Root
@@ -125,10 +127,17 @@ export const Thread: FC<ThreadProps> = ({ items = [] }) => {
         ["--thread-max-width" as string]: "50rem",
       }}
     >
-      <ThreadPrimitive.Viewport
+      {/*
+        Custom scroll container — intentionally NOT ThreadPrimitive.Viewport.
+        assistant-ui's Viewport installs a ResizeObserver + subtree MutationObserver
+        on the scroll container and MessagePrimitive.Root injects inline min-height
+        on the last assistant message via ThreadViewportSlack. Both fight our
+        @tanstack/react-virtual virtualizer (observers fire constantly, Slack's
+        injected min-height is read by measureElement as the row size). We own
+        scroll behavior via ThreadScrollController below.
+      */}
+      <div
         ref={viewportRef}
-        turnAnchor="top"
-        autoScroll={false}
         className="aui-thread-viewport relative flex min-h-0 flex-1 flex-col overflow-x-auto overflow-y-scroll px-4"
       >
         <AuiIf condition={({ thread }) => thread.isLoading}>
@@ -138,8 +147,15 @@ export const Thread: FC<ThreadProps> = ({ items = [] }) => {
           <ThreadWelcome items={items} />
         </AuiIf>
 
-        <VirtualizedMessages scrollRef={viewportRef} />
-      </ThreadPrimitive.Viewport>
+        <VirtualizedMessages
+          scrollRef={viewportRef}
+          virtualizerHandleRef={virtualizerHandleRef}
+        />
+        <ThreadScrollController
+          scrollRef={viewportRef}
+          virtualizerHandleRef={virtualizerHandleRef}
+        />
+      </div>
 
       <div className="aui-thread-composer-wrapper mx-auto flex w-full max-w-[var(--thread-max-width)] flex-shrink-0 flex-col gap-4 overflow-visible rounded-t-3xl bg-sidebar px-4 pb-3 md:pb-4">
         <ComposerHoverWrapper items={items} />
@@ -148,19 +164,153 @@ export const Thread: FC<ThreadProps> = ({ items = [] }) => {
   );
 };
 
-interface VirtualizedMessagesProps {
-  scrollRef: RefObject<HTMLDivElement | null>;
+/**
+ * Imperative handle exposed by VirtualizedMessages so ThreadScrollController
+ * can translate message indices into scrollTop offsets via @tanstack/react-virtual.
+ */
+interface VirtualizerHandle {
+  /** Returns the virtualRow.start for the given message index, or null if not currently mounted/measured. */
+  getRowOffset: (index: number) => number | null;
+  /** Returns current message count. */
+  getCount: () => number;
+  /** Returns the estimateSize() value used by the virtualizer (fallback for unmounted rows). */
+  getEstimatedSize: () => number;
 }
 
-const VirtualizedMessages: FC<VirtualizedMessagesProps> = ({ scrollRef }) => {
+interface ThreadScrollControllerProps {
+  scrollRef: RefObject<HTMLDivElement | null>;
+  virtualizerHandleRef: MutableRefObject<VirtualizerHandle | null>;
+}
+
+/**
+ * Owns scroll behavior for the virtualized thread. Replaces assistant-ui's
+ * ThreadPrimitive.Viewport + turnAnchor + ViewportSlack entirely.
+ *
+ * Behavior:
+ * - thread.initialize (history first load) → bottom, instant.
+ * - threadListItem.switchedTo (thread switch) → bottom, instant.
+ * - thread.runStart (new user message sent) → anchor that user message at the top
+ *   of the viewport, smooth. The "new user message" is messages.length - 1 at runStart.
+ * - Streaming: no auto-scroll. User owns scroll.
+ *
+ * We never install ResizeObserver/MutationObserver on the scroll container —
+ * that loop is exactly what was fighting the virtualizer.
+ */
+const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
+  scrollRef,
+  virtualizerHandleRef,
+}) => {
+  const scrollToBottom = useCallback(
+    (behavior: ScrollBehavior) => {
+      requestAnimationFrame(() => {
+        const el = scrollRef.current;
+        if (!el) return;
+        el.scrollTo({ top: el.scrollHeight, behavior });
+      });
+    },
+    [scrollRef],
+  );
+
+  const scrollIndexToTop = useCallback(
+    (targetIndex: number, behavior: ScrollBehavior) => {
+      // React-virtual may not have measured the new row yet. Retry across a few
+      // frames using the measured offset when available, falling back to
+      // estimateSize * index so we at least land close.
+      let attempts = 0;
+      const attempt = () => {
+        attempts += 1;
+        const el = scrollRef.current;
+        const handle = virtualizerHandleRef.current;
+        if (!el || !handle) return;
+        if (targetIndex < 0 || targetIndex >= handle.getCount()) return;
+
+        const measured = handle.getRowOffset(targetIndex);
+        const top = measured ?? targetIndex * handle.getEstimatedSize();
+        el.scrollTo({ top, behavior });
+
+        if (measured === null && attempts < 3) {
+          requestAnimationFrame(attempt);
+        }
+      };
+      requestAnimationFrame(attempt);
+    },
+    [scrollRef, virtualizerHandleRef],
+  );
+
+  useAuiEvent("thread.initialize", () => {
+    scrollToBottom("instant");
+  });
+
+  useAuiEvent("threadListItem.switchedTo", () => {
+    scrollToBottom("instant");
+  });
+
+  useAuiEvent("thread.runStart", () => {
+    const handle = virtualizerHandleRef.current;
+    if (!handle) return;
+    // At runStart, the just-sent user message is at messages.length - 1.
+    // The assistant placeholder is appended shortly after, so when the
+    // assistant row arrives our user message will naturally be one up.
+    const targetIndex = handle.getCount() - 1;
+    scrollIndexToTop(targetIndex, "smooth");
+  });
+
+  return null;
+};
+
+/**
+ * Replacement for the hover tracking that `MessagePrimitive.Root` normally wires
+ * up (via ThreadPrimitiveViewportSlack). Without this, ActionBarPrimitive
+ * autohide="not-last" and MessagePrimitive.If lastOrHover would be permanently
+ * hidden on non-last messages. We forward hover state into the aui message
+ * client directly, which is what MessageRoot does under the hood.
+ */
+const useMessageHoverHandlers = () => {
+  const aui = useAui();
+  const onMouseEnter = useCallback(() => {
+    aui?.message()?.setIsHovering?.(true);
+  }, [aui]);
+  const onMouseLeave = useCallback(() => {
+    aui?.message()?.setIsHovering?.(false);
+  }, [aui]);
+  return { onMouseEnter, onMouseLeave };
+};
+
+interface VirtualizedMessagesProps {
+  scrollRef: RefObject<HTMLDivElement | null>;
+  virtualizerHandleRef: MutableRefObject<VirtualizerHandle | null>;
+}
+
+const ROW_ESTIMATE_SIZE = 350;
+
+const VirtualizedMessages: FC<VirtualizedMessagesProps> = ({
+  scrollRef,
+  virtualizerHandleRef,
+}) => {
   const messageCount = useAuiState((s) => s.thread.messages.length);
 
   const virtualizer = useVirtualizer({
     count: messageCount,
     getScrollElement: () => scrollRef.current,
-    estimateSize: () => 350,
+    estimateSize: () => ROW_ESTIMATE_SIZE,
     overscan: 5,
   });
+
+  // Publish imperative handle for ThreadScrollController.
+  useEffect(() => {
+    virtualizerHandleRef.current = {
+      getRowOffset: (index) => {
+        const items = virtualizer.getVirtualItems();
+        const found = items.find((v) => v.index === index);
+        return found ? found.start : null;
+      },
+      getCount: () => messageCount,
+      getEstimatedSize: () => ROW_ESTIMATE_SIZE,
+    };
+    return () => {
+      virtualizerHandleRef.current = null;
+    };
+  }, [virtualizer, messageCount, virtualizerHandleRef]);
 
   if (messageCount === 0) return null;
 
@@ -1185,37 +1335,40 @@ const MessageError: FC = () => {
 };
 
 const AssistantMessage: FC = () => {
+  const message = useMessage();
+  const hover = useMessageHoverHandlers();
   return (
-    <MessagePrimitive.Root asChild>
-      <div
-        className="aui-assistant-message-root relative mx-auto w-full max-w-[var(--thread-max-width)] animate-in pb-4 duration-150 ease-out fade-in slide-in-from-bottom-1 last:mb-4"
-        data-role="assistant"
-      >
-        <div className="aui-assistant-message-content mx-2 leading-7 break-words text-foreground">
-          <AssistantLoader />
-          <MessagePrimitive.Parts
-            components={{
-              Text: MarkdownText,
-              File: FileComponent,
-              Source: Sources,
-              Image,
-              Reasoning: Reasoning,
-              ReasoningGroup: ReasoningGroup,
-              ToolGroup,
-              tools: {
-                Fallback: ToolFallback,
-              },
-            }}
-          />
-          <MessageError />
-        </div>
-
-        <div className="aui-assistant-message-footer mt-2 ml-2 flex">
-          <BranchPicker />
-          <AssistantActionBar />
-        </div>
+    <div
+      className="aui-assistant-message-root relative mx-auto w-full max-w-[var(--thread-max-width)] animate-in pb-4 duration-150 ease-out fade-in slide-in-from-bottom-1 last:mb-4"
+      data-role="assistant"
+      data-message-id={message.id}
+      onMouseEnter={hover.onMouseEnter}
+      onMouseLeave={hover.onMouseLeave}
+    >
+      <div className="aui-assistant-message-content mx-2 leading-7 break-words text-foreground">
+        <AssistantLoader />
+        <MessagePrimitive.Parts
+          components={{
+            Text: MarkdownText,
+            File: FileComponent,
+            Source: Sources,
+            Image,
+            Reasoning: Reasoning,
+            ReasoningGroup: ReasoningGroup,
+            ToolGroup,
+            tools: {
+              Fallback: ToolFallback,
+            },
+          }}
+        />
+        <MessageError />
       </div>
-    </MessagePrimitive.Root>
+
+      <div className="aui-assistant-message-footer mt-2 ml-2 flex">
+        <BranchPicker />
+        <AssistantActionBar />
+      </div>
+    </div>
   );
 };
 
@@ -1311,55 +1464,58 @@ const UserMessage: FC = () => {
     [expanded, showExpand],
   );
 
+  const hover = useMessageHoverHandlers();
+
   return (
-    <MessagePrimitive.Root asChild>
-      <div
-        className="aui-user-message-root mx-auto grid w-full max-w-[var(--thread-max-width)] animate-breathe-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] gap-y-2 px-2 pt-4 pb-1 last:mb-5 [&:where(>*)]:col-start-2"
-        data-role="user"
-      >
-        {/* Attachments display */}
-        <UserMessageAttachments />
+    <div
+      className="aui-user-message-root mx-auto grid w-full max-w-[var(--thread-max-width)] animate-breathe-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] gap-y-2 px-2 pt-4 pb-1 last:mb-5 [&:where(>*)]:col-start-2"
+      data-role="user"
+      data-message-id={message.id}
+      onMouseEnter={hover.onMouseEnter}
+      onMouseLeave={hover.onMouseLeave}
+    >
+      {/* Attachments display */}
+      <UserMessageAttachments />
 
-        <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
-          <MessageContextBadges />
-          <UserMessageTruncateContext.Provider value={truncateCtxValue}>
-            <div className="aui-user-message-content relative rounded-lg bg-muted px-3 py-2 break-words text-foreground text-sm">
-              <MessagePrimitive.Parts
-                components={{
-                  Text: UserMessageText,
-                  File: FileComponent,
-                }}
-              />
-              {showExpand && (
-                <div className="flex justify-end pt-1.5 mt-1.5">
-                  <button
-                    type="button"
-                    onClick={() => setExpanded((e) => !e)}
-                    className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-                    aria-label={expanded ? "Show less" : "Show more"}
-                  >
-                    {expanded ? (
-                      <ChevronUp className="size-3.5" />
-                    ) : (
-                      <ChevronDown className="size-3.5" />
-                    )}
-                    {expanded ? "Show less" : "Show more"}
-                  </button>
-                </div>
-              )}
-            </div>
-          </UserMessageTruncateContext.Provider>
-        </div>
-
-        <div className="aui-user-message-footer ml-2 flex justify-end col-start-2 relative min-h-[20px]">
-          <div className="absolute right-0">
-            <UserActionBar />
+      <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
+        <MessageContextBadges />
+        <UserMessageTruncateContext.Provider value={truncateCtxValue}>
+          <div className="aui-user-message-content relative rounded-lg bg-muted px-3 py-2 break-words text-foreground text-sm">
+            <MessagePrimitive.Parts
+              components={{
+                Text: UserMessageText,
+                File: FileComponent,
+              }}
+            />
+            {showExpand && (
+              <div className="flex justify-end pt-1.5 mt-1.5">
+                <button
+                  type="button"
+                  onClick={() => setExpanded((e) => !e)}
+                  className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  aria-label={expanded ? "Show less" : "Show more"}
+                >
+                  {expanded ? (
+                    <ChevronUp className="size-3.5" />
+                  ) : (
+                    <ChevronDown className="size-3.5" />
+                  )}
+                  {expanded ? "Show less" : "Show more"}
+                </button>
+              </div>
+            )}
           </div>
-        </div>
-
-        <BranchPicker className="aui-user-branch-picker col-span-full col-start-1 row-start-3 -mr-1 justify-end" />
+        </UserMessageTruncateContext.Provider>
       </div>
-    </MessagePrimitive.Root>
+
+      <div className="aui-user-message-footer ml-2 flex justify-end col-start-2 relative min-h-[20px]">
+        <div className="absolute right-0">
+          <UserActionBar />
+        </div>
+      </div>
+
+      <BranchPicker className="aui-user-branch-picker col-span-full col-start-1 row-start-3 -mr-1 justify-end" />
+    </div>
   );
 };
 

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -40,14 +40,9 @@ import {
   useMessagePartText,
   useAuiState,
 } from "@assistant-ui/react";
-import {
-  defaultRangeExtractor,
-  useVirtualizer,
-  type Range,
-  type Virtualizer,
-} from "@tanstack/react-virtual";
+import { Virtualizer, type VirtualizerHandle } from "virtua";
 
-import type { FC, MutableRefObject, RefObject } from "react";
+import type { FC, RefObject } from "react";
 import { createContext, useContext } from "react";
 import { useEffect, useRef, useState, useMemo, useCallback } from "react";
 
@@ -121,35 +116,12 @@ interface ThreadProps {
   items?: Item[];
 }
 
-// Shared type: the @tanstack/react-virtual instance. Lifted to Thread so the
-// scroll controller can call scrollToIndex directly.
-type ThreadVirtualizer = Virtualizer<HTMLDivElement, HTMLDivElement>;
-
-// Default row height before the virtualizer measures actual sizes.
-const ROW_ESTIMATE_SIZE = 350;
-// Breathing room above a user message when scrollToIndex(align:'start').
-const SCROLL_PADDING_START = 16;
-// Bottom slack — extra space appended to the virtualized region so a freshly
-// sent user message can be anchored at the top of the viewport even when
-// the assistant hasn't streamed any content below it yet. Without this,
-// scrollToIndex(lastIndex, { align: 'start' }) clamps because the last
-// message is also the bottom of the scrollable area.
-const BOTTOM_SLACK_PX = 800;
-// Rows kept mounted outside the viewport for smooth scrolling.
-const OVERSCAN = 5;
+type ThreadVirtualizer = VirtualizerHandle;
 
 export const Thread: FC<ThreadProps> = ({ items = [] }) => {
   const viewportRef = useRef<HTMLDivElement>(null);
-  // Lifted so ThreadScrollController can imperatively scroll to an index
-  // without a separate "handle" abstraction.
   const virtualizerRef = useRef<ThreadVirtualizer | null>(null);
-
-  // Gate useVirtualizer behind mount so SSR/first-paint doesn't compute a
-  // range against a null scroll element (TanStack's `enabled` option).
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => {
-    setMounted(true);
-  }, []);
+  const captureBlankRef = useRef<(() => void) | null>(null);
 
   return (
     <ThreadPrimitive.Root
@@ -160,19 +132,13 @@ export const Thread: FC<ThreadProps> = ({ items = [] }) => {
     >
       {/*
         Custom scroll container — intentionally NOT ThreadPrimitive.Viewport.
-        assistant-ui's Viewport installs a ResizeObserver + subtree MutationObserver
-        that fights @tanstack/react-virtual. We own scroll behavior here instead.
-        • contain:strict = independent layout/paint root, cuts reflow during streaming
-        • overflow-anchor:none = disables browser scroll anchoring (fights the virtualizer)
+        assistant-ui's Viewport installs a ResizeObserver + subtree
+        MutationObserver that fights any virtualizer. We own scroll behavior.
       */}
       <div
         ref={viewportRef}
         className="aui-thread-viewport relative flex min-h-0 flex-1 flex-col overflow-x-auto overflow-y-scroll px-4"
-        style={{
-          contain: "strict",
-          overflowAnchor: "none",
-          scrollPaddingTop: `${SCROLL_PADDING_START}px`,
-        }}
+        style={{ contain: "strict", overflowAnchor: "none" }}
       >
         <AuiIf condition={({ thread }) => thread.isLoading}>
           <ThreadLoadingSkeleton />
@@ -184,9 +150,12 @@ export const Thread: FC<ThreadProps> = ({ items = [] }) => {
         <VirtualizedMessages
           scrollRef={viewportRef}
           virtualizerRef={virtualizerRef}
-          enabled={mounted}
+          captureBlankRef={captureBlankRef}
         />
-        <ThreadScrollController virtualizerRef={virtualizerRef} />
+        <ThreadScrollController
+          virtualizerRef={virtualizerRef}
+          captureBlankRef={captureBlankRef}
+        />
       </div>
 
       <div className="aui-thread-composer-wrapper mx-auto flex w-full max-w-[var(--thread-max-width)] flex-shrink-0 flex-col gap-4 overflow-visible rounded-t-3xl bg-sidebar px-4 pb-3 md:pb-4">
@@ -197,104 +166,49 @@ export const Thread: FC<ThreadProps> = ({ items = [] }) => {
 };
 
 interface ThreadScrollControllerProps {
-  virtualizerRef: MutableRefObject<ThreadVirtualizer | null>;
+  virtualizerRef: RefObject<ThreadVirtualizer | null>;
+  captureBlankRef: RefObject<(() => void) | null>;
 }
 
-/**
- * Owns scroll behavior for the virtualized thread. Two concerns:
- *
- * 1. LOAD / THREAD-SWITCH -> bottom, instant. Tracked via `threadListItem.id`
- *    + `thread.messages.length`. A ref-backed "last scrolled for" guard
- *    ensures we only snap to bottom on thread identity changes — not on every
- *    message count tick. Reading `messageCount` as a dep is what lets us
- *    catch the initial hydration: the runtime emits `thread.initialize`
- *    BEFORE `repository.import()`, so at event time count is 0. By making
- *    the effect depend on count, it re-runs once messages land and we can
- *    commit the scroll.
- *
- *    Mirrors assistant-ui's upstream `useThreadViewportAutoScroll`, except
- *    we target the virtualizer's measurement ledger instead of the raw
- *    `el.scrollHeight`.
- *
- * 2. NEW USER MESSAGE (thread.runStart) -> anchor at top, smooth. Event-driven.
- *    The count is read imperatively from the store inside the handler, NOT
- *    from the `messageCount` subscription closure: runStart fires
- *    synchronously between the repository mutation and React's commit, so
- *    `useEffectEvent`'s ref still holds the stale closure with the old count.
- *    Organic growth during streaming is deliberately ignored — the user owns
- *    scroll once anchored.
- */
 const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
   virtualizerRef,
+  captureBlankRef,
 }) => {
   const aui = useAui();
-  // Reactive subscriptions: both drive the load/switch effect below. Using
-  // useAuiState over useAuiEvent lets us observe the settled state rather
-  // than racing event emission against React commits. `threadListItem.id`
-  // is the canonical thread identifier on the store proxy; `thread.threadId`
-  // only exists on the core runtime's ThreadState and isn't exposed here.
   const threadId = useAuiState((s) => s.threadListItem.id);
   const messageCount = useAuiState((s) => s.thread.messages.length);
 
-  const scrollToIndex = useCallback(
-    (count: number, align: "start" | "end", behavior: ScrollBehavior) => {
+  const scrollToLastIndex = useCallback(
+    (count: number, align: "start" | "end", smooth: boolean) => {
       if (count <= 0) return;
-      // Two RAFs: first lets react-virtual commit the new row count, second
-      // gives measureElement a chance to register row sizes before we scroll.
-      // scrollToIndex itself also retries internally for unmeasured rows.
       requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          virtualizerRef.current?.scrollToIndex(count - 1, { align, behavior });
-        });
+        virtualizerRef.current?.scrollToIndex(count - 1, { align, smooth });
       });
     },
     [virtualizerRef],
   );
 
-  // Track the thread we're currently "settled" on. Reset whenever the id
-  // changes so that visiting A → B → A re-scrolls A's bottom.
   const settledThreadIdRef = useRef<string | null>(null);
 
   useEffect(() => {
-    // Reset settle marker whenever the visible thread id changes; this makes
-    // A → B → A trigger a bottom-scroll on the second visit to A.
     if (settledThreadIdRef.current !== threadId) {
       settledThreadIdRef.current = null;
     }
-    // Wait for messages to land before committing the "settled" marker —
-    // ensureInitialized() fires before repository.import(), so on first
-    // mount messageCount is 0 and flips to N on the next commit.
     if (messageCount <= 0) return;
     if (settledThreadIdRef.current === threadId) return;
     settledThreadIdRef.current = threadId;
-    scrollToIndex(messageCount, "end", "instant");
-  }, [threadId, messageCount, scrollToIndex]);
+    scrollToLastIndex(messageCount, "end", false);
+  }, [threadId, messageCount, scrollToLastIndex]);
 
-  // New user message sent -> anchor at top with smooth animation. Event-driven
-  // because we need to react on the transition, not the steady state. We must
-  // read the count *imperatively from the store* here, not from the
-  // `messageCount` closure: `runStart` is emitted synchronously inside the
-  // runtime's append->startRun path, AFTER `repository.addOrUpdateMessage`
-  // appends the user message but BEFORE React commits the re-render. At that
-  // moment `useEffectEvent`'s ref (updated in useInsertionEffect, commit-phase)
-  // still points at the previous closure with the old count, so using the
-  // subscription value here would scroll to the last *previous* message.
-  // Reading `aui.thread().getState().messages.length` bypasses that window.
   useAuiEvent("thread.runStart", () => {
+    captureBlankRef.current?.();
     const liveCount = aui?.thread()?.getState()?.messages.length ?? 0;
-    scrollToIndex(liveCount, "start", "smooth");
+    scrollToLastIndex(liveCount, "start", true);
   });
 
   return null;
 };
 
-/**
- * Forwards hover state to the aui message client — the only side-effect of
- * MessagePrimitive.Root we still need (powers ActionBarPrimitive autohide and
- * MessagePrimitive.If lastOrHover). We dropped MessagePrimitive.Root itself
- * because its ThreadViewportSlack wrapper injects inline min-height that the
- * virtualizer's measureElement reads as the row size.
- */
 const useMessageHoverHandlers = () => {
   const aui = useAui();
   const onMouseEnter = useCallback(() => {
@@ -308,108 +222,102 @@ const useMessageHoverHandlers = () => {
 
 interface VirtualizedMessagesProps {
   scrollRef: RefObject<HTMLDivElement | null>;
-  virtualizerRef: MutableRefObject<ThreadVirtualizer | null>;
-  enabled: boolean;
+  virtualizerRef: RefObject<ThreadVirtualizer | null>;
+  captureBlankRef: RefObject<(() => void) | null>;
 }
 
 const VirtualizedMessages: FC<VirtualizedMessagesProps> = ({
   scrollRef,
   virtualizerRef,
-  enabled,
+  captureBlankRef,
 }) => {
   const aui = useAui();
-  // Subscribing to length + isRunning (both primitives) is enough to drive
-  // re-renders. getItemKey reads ids lazily from live aui state, so we don't
-  // need to subscribe to the whole messages array (which would allocate a
-  // new array identity on every streaming token).
   const messageCount = useAuiState((s) => s.thread.messages.length);
   const isRunning = useAuiState((s) => s.thread.isRunning);
+  const [blankSize, setBlankSize] = useState(0);
+  const [lastUserSize, setLastUserSize] = useState(0);
+  const [measuredUserElement, setMeasuredUserElement] =
+    useState<HTMLDivElement | null>(null);
 
-  // Pin the streaming assistant message into the rendered range even when the
-  // user has scrolled away. Without this, scrolling up during a stream would
-  // unmount the message — stopping useMessagePartText from receiving chunks
-  // and flipping hover/last state. Only active while thread.isRunning.
-  const pinnedIndex = isRunning && messageCount > 0 ? messageCount - 1 : -1;
-  const rangeExtractor = useCallback(
-    (range: Range) => {
-      const base = defaultRangeExtractor(range);
-      if (pinnedIndex < 0 || base.includes(pinnedIndex)) return base;
-      // Keep ascending order so react-virtual's internal diff is linear.
-      return [...base, pinnedIndex].sort((a, b) => a - b);
-    },
-    [pinnedIndex],
-  );
-
-  const virtualizer = useVirtualizer<HTMLDivElement, HTMLDivElement>({
-    count: messageCount,
-    getScrollElement: () => scrollRef.current,
-    estimateSize: () => ROW_ESTIMATE_SIZE,
-    overscan: OVERSCAN,
-    enabled,
-    // Stable keys by aui message id prevent measurementsCache invalidation
-    // on branch flips / reorders. Read live from aui state so this selector
-    // doesn't need to subscribe to the full messages array.
-    getItemKey: (index) =>
-      aui?.thread()?.getState()?.messages[index]?.id ?? index,
-    // Breathing room above a user message when scrollToIndex(align:'start').
-    scrollPaddingStart: SCROLL_PADDING_START,
-    // Bottom slack — padding appended after the last row so scrollToIndex(
-    // lastIndex, { align: 'start' }) can land the new user message at the top
-    // even when the assistant hasn't streamed content below it yet. Without
-    // this padding, getMaxScrollOffset clamps the scroll mid-viewport.
-    paddingEnd: BOTTOM_SLACK_PX,
-    // Native scrollend event on modern browsers skips TanStack's polling.
-    useScrollendEvent: true,
-    rangeExtractor,
-  });
-
-  // Publish the instance up to Thread so ThreadScrollController can reach it
-  // without threading props through every render.
   useEffect(() => {
-    virtualizerRef.current = virtualizer;
-    return () => {
-      virtualizerRef.current = null;
+    captureBlankRef.current = () => {
+      setBlankSize(virtualizerRef.current?.viewportSize ?? 0);
     };
-  }, [virtualizer, virtualizerRef]);
+    return () => {
+      captureBlankRef.current = null;
+    };
+  }, [captureBlankRef, virtualizerRef]);
+
+  useEffect(() => {
+    if (!isRunning && blankSize !== 0) {
+      setBlankSize(0);
+    }
+  }, [isRunning, blankSize]);
+
+  useEffect(() => {
+    if (!isRunning && lastUserSize !== 0) {
+      setLastUserSize(0);
+    }
+  }, [isRunning, lastUserSize]);
+
+  useEffect(() => {
+    if (!measuredUserElement) return;
+    const update = () => {
+      setLastUserSize(measuredUserElement.getBoundingClientRect().height);
+    };
+    update();
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(measuredUserElement);
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [measuredUserElement]);
+
+  const measureUserMessageRef = useCallback((el: HTMLDivElement | null) => {
+    setMeasuredUserElement(el);
+  }, []);
+
+  const streamingAssistantIndex = isRunning ? messageCount - 1 : -1;
+  const measuredUserIndex = isRunning ? messageCount - 2 : -1;
+  const assistantMinHeight =
+    streamingAssistantIndex >= 0 ? Math.max(0, blankSize - lastUserSize) : 0;
 
   if (messageCount === 0) return null;
 
-  // Per-row absolute positioning (not the single-wrapper translate shown in
-  // TanStack's "dynamic" docs example). The wrapper-translate pattern assumes
-  // items is a CONTIGUOUS index range, but our rangeExtractor pins the
-  // streaming last assistant message so items can look like [5,6,7,...,42]
-  // while the user scrolls up. Translating per-row keeps each row at its true
-  // virtualRow.start regardless of gaps.
-  const items = virtualizer.getVirtualItems();
-
   return (
-    <div
-      style={{
-        height: `${virtualizer.getTotalSize()}px`,
-        width: "100%",
-        position: "relative",
-      }}
+    <Virtualizer
+      ref={virtualizerRef}
+      scrollRef={scrollRef}
+      keepMounted={
+        streamingAssistantIndex >= 0 ? [streamingAssistantIndex] : undefined
+      }
     >
-      {items.map((virtualRow) => (
-        <div
-          key={virtualRow.key}
-          data-index={virtualRow.index}
-          ref={virtualizer.measureElement}
-          style={{
-            position: "absolute",
-            top: 0,
-            left: 0,
-            width: "100%",
-            transform: `translateY(${virtualRow.start}px)`,
-          }}
-        >
-          <ThreadPrimitive.MessageByIndex
-            index={virtualRow.index}
-            components={MESSAGE_COMPONENTS}
-          />
-        </div>
-      ))}
-    </div>
+      {Array.from({ length: messageCount }, (_, index) => {
+        const message = aui?.thread()?.getState()?.messages[index];
+        const id = message?.id ?? index;
+        const role = message?.role;
+        const isStreamingAssistant =
+          role === "assistant" && index === streamingAssistantIndex;
+        const isMeasuredUser = role === "user" && index === measuredUserIndex;
+
+        return (
+          <div
+            key={id}
+            ref={isMeasuredUser ? measureUserMessageRef : undefined}
+            style={
+              isStreamingAssistant
+                ? { minHeight: `${assistantMinHeight}px` }
+                : undefined
+            }
+          >
+            <ThreadPrimitive.MessageByIndex
+              index={index}
+              components={MESSAGE_COMPONENTS}
+            />
+          </div>
+        );
+      })}
+    </Virtualizer>
   );
 };
 

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -265,31 +265,44 @@ const VirtualizedMessages: FC<VirtualizedMessagesProps> = ({
   const aui = useAui();
   const messageCount = useAuiState((s) => s.thread.messages.length);
   const isRunning = useAuiState((s) => s.thread.isRunning);
+  // Slack state lives for the lifetime of an entire turn (not just while
+  // streaming). We pin it to the specific assistant index that owns the
+  // blank so the space stays allocated after isRunning flips false, and
+  // only gets released when the NEXT turn starts or the thread changes
+  // identity (count shrinks below the pinned index).
   const [blankSize, setBlankSize] = useState(0);
   const [lastUserSize, setLastUserSize] = useState(0);
+  const [pinnedAssistantIndex, setPinnedAssistantIndex] = useState(-1);
+  const [pinnedUserIndex, setPinnedUserIndex] = useState(-1);
   const [measuredUserElement, setMeasuredUserElement] =
     useState<HTMLDivElement | null>(null);
 
   useEffect(() => {
     captureBlankRef.current = () => {
+      // Read the current count imperatively; the subscription may not have
+      // ticked yet inside the isRunning effect that triggers this call.
+      const count = aui?.thread()?.getState()?.messages.length ?? 0;
       setBlankSize(virtualizerRef.current?.viewportSize ?? 0);
+      // Pin the indexes for this turn. The assistant row is the last row,
+      // the user row is the one before it.
+      setPinnedAssistantIndex(count - 1);
+      setPinnedUserIndex(count - 2);
     };
     return () => {
       captureBlankRef.current = null;
     };
-  }, [captureBlankRef, virtualizerRef]);
+  }, [aui, captureBlankRef, virtualizerRef]);
 
+  // Release slack when the pinned indexes no longer exist in the list
+  // (thread cleared, switched, or messages deleted).
   useEffect(() => {
-    if (!isRunning && blankSize !== 0) {
+    if (pinnedAssistantIndex >= messageCount && pinnedAssistantIndex !== -1) {
       setBlankSize(0);
-    }
-  }, [isRunning, blankSize]);
-
-  useEffect(() => {
-    if (!isRunning && lastUserSize !== 0) {
       setLastUserSize(0);
+      setPinnedAssistantIndex(-1);
+      setPinnedUserIndex(-1);
     }
-  }, [isRunning, lastUserSize]);
+  }, [messageCount, pinnedAssistantIndex]);
 
   useEffect(() => {
     if (!measuredUserElement) return;
@@ -308,10 +321,8 @@ const VirtualizedMessages: FC<VirtualizedMessagesProps> = ({
     setMeasuredUserElement(el);
   }, []);
 
-  const streamingAssistantIndex = isRunning ? messageCount - 1 : -1;
-  const measuredUserIndex = isRunning ? messageCount - 2 : -1;
   const assistantMinHeight =
-    streamingAssistantIndex >= 0 ? Math.max(0, blankSize - lastUserSize) : 0;
+    pinnedAssistantIndex >= 0 ? Math.max(0, blankSize - lastUserSize) : 0;
 
   // Always mount the Virtualizer — even when messageCount is 0 — so
   // `virtualizerRef.current.viewportSize` is readable the moment the first
@@ -321,24 +332,32 @@ const VirtualizedMessages: FC<VirtualizedMessagesProps> = ({
     <Virtualizer
       ref={virtualizerRef}
       scrollRef={scrollRef}
+      // Only keep the assistant row force-mounted while it's actively
+      // streaming. Once isRunning flips false we still apply minHeight to
+      // the pinned row (so the slack persists) but we don't need to pin it
+      // against virtualization — it'll unmount normally once it scrolls
+      // out of the viewport.
       keepMounted={
-        streamingAssistantIndex >= 0 ? [streamingAssistantIndex] : undefined
+        isRunning && pinnedAssistantIndex >= 0
+          ? [pinnedAssistantIndex]
+          : undefined
       }
     >
       {Array.from({ length: messageCount }, (_, index) => {
         const message = aui?.thread()?.getState()?.messages[index];
         const id = message?.id ?? index;
         const role = message?.role;
-        const isStreamingAssistant =
-          role === "assistant" && index === streamingAssistantIndex;
-        const isMeasuredUser = role === "user" && index === measuredUserIndex;
+        const isPinnedAssistant =
+          role === "assistant" && index === pinnedAssistantIndex;
+        const isMeasuredUser =
+          role === "user" && index === pinnedUserIndex;
 
         return (
           <div
             key={id}
             ref={isMeasuredUser ? measureUserMessageRef : undefined}
             style={
-              isStreamingAssistant
+              isPinnedAssistant
                 ? { minHeight: `${assistantMinHeight}px` }
                 : undefined
             }

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -40,7 +40,11 @@ import {
   useMessagePartText,
   useAuiState,
 } from "@assistant-ui/react";
-import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+  defaultRangeExtractor,
+  useVirtualizer,
+  type Virtualizer,
+} from "@tanstack/react-virtual";
 
 import type { FC, MutableRefObject, RefObject } from "react";
 import { createContext, useContext } from "react";
@@ -116,9 +120,35 @@ interface ThreadProps {
   items?: Item[];
 }
 
+// Shared type alias: the @tanstack/react-virtual instance used throughout this
+// file. We lift it to Thread so the scroll controller can call scrollToIndex
+// directly without going through a handle wrapper.
+type ThreadVirtualizer = Virtualizer<HTMLDivElement, HTMLDivElement>;
+
+// Estimated row height used before the virtualizer measures a row's actual
+// size. Matches the previous value — tuned for a typical assistant turn with
+// some markdown and a tool call.
+const ROW_ESTIMATE_SIZE = 350;
+// Breathing room above a user message when we scrollToIndex(..., { align: 'start' }).
+// Without this the message is flush against the viewport's top edge, which
+// looks wrong and hides MessageContextBadges on touch.
+const SCROLL_PADDING_START = 16;
+// Rows kept mounted outside the visible viewport (above and below) so smooth
+// scrolling doesn't flash blank regions. 5 matches TanStack's own docs example.
+const OVERSCAN = 5;
+
 export const Thread: FC<ThreadProps> = ({ items = [] }) => {
   const viewportRef = useRef<HTMLDivElement>(null);
-  const virtualizerHandleRef = useRef<VirtualizerHandle | null>(null);
+  // Lifted so ThreadScrollController can imperatively scroll to an index
+  // without a separate "handle" abstraction.
+  const virtualizerRef = useRef<ThreadVirtualizer | null>(null);
+
+  // Gate useVirtualizer behind mount so SSR/first-paint doesn't compute a
+  // range against a null scroll element (TanStack's `enabled` option).
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   return (
     <ThreadPrimitive.Root
@@ -132,13 +162,21 @@ export const Thread: FC<ThreadProps> = ({ items = [] }) => {
         assistant-ui's Viewport installs a ResizeObserver + subtree MutationObserver
         on the scroll container and MessagePrimitive.Root injects inline min-height
         on the last assistant message via ThreadViewportSlack. Both fight our
-        @tanstack/react-virtual virtualizer (observers fire constantly, Slack's
-        injected min-height is read by measureElement as the row size). We own
-        scroll behavior via ThreadScrollController below.
+        @tanstack/react-virtual virtualizer. We own scroll behavior here.
+
+        - `contain: strict` lets the browser treat this subtree as an independent
+          layout/paint root, cutting reflow cost during streaming.
+        - `overflow-anchor: none` disables the browser's native scroll-anchoring,
+          which otherwise fights the virtualizer when row sizes change.
       */}
       <div
         ref={viewportRef}
         className="aui-thread-viewport relative flex min-h-0 flex-1 flex-col overflow-x-auto overflow-y-scroll px-4"
+        style={{
+          contain: "strict",
+          overflowAnchor: "none",
+          scrollPaddingTop: `${SCROLL_PADDING_START}px`,
+        }}
       >
         <AuiIf condition={({ thread }) => thread.isLoading}>
           <ThreadLoadingSkeleton />
@@ -149,12 +187,10 @@ export const Thread: FC<ThreadProps> = ({ items = [] }) => {
 
         <VirtualizedMessages
           scrollRef={viewportRef}
-          virtualizerHandleRef={virtualizerHandleRef}
+          virtualizerRef={virtualizerRef}
+          enabled={mounted}
         />
-        <ThreadScrollController
-          scrollRef={viewportRef}
-          virtualizerHandleRef={virtualizerHandleRef}
-        />
+        <ThreadScrollController virtualizerRef={virtualizerRef} />
       </div>
 
       <div className="aui-thread-composer-wrapper mx-auto flex w-full max-w-[var(--thread-max-width)] flex-shrink-0 flex-col gap-4 overflow-visible rounded-t-3xl bg-sidebar px-4 pb-3 md:pb-4">
@@ -164,27 +200,8 @@ export const Thread: FC<ThreadProps> = ({ items = [] }) => {
   );
 };
 
-/**
- * Imperative handle exposed by VirtualizedMessages so ThreadScrollController
- * can position the viewport on a specific message index. We delegate to
- * TanStack Virtual's own `scrollToIndex` so unmeasured rows use the internal
- * size ledger (instead of reimplementing offset math ourselves).
- */
-interface VirtualizerHandle {
-  /**
-   * Scroll so the row at `index` aligns according to `align`.
-   * Uses virtualizer.scrollToIndex internally, which retries across frames
-   * for rows whose size hasn't been measured yet.
-   */
-  scrollToIndex: (
-    index: number,
-    options?: { align?: "start" | "center" | "end" | "auto"; behavior?: ScrollBehavior },
-  ) => void;
-}
-
 interface ThreadScrollControllerProps {
-  scrollRef: RefObject<HTMLDivElement | null>;
-  virtualizerHandleRef: MutableRefObject<VirtualizerHandle | null>;
+  virtualizerRef: MutableRefObject<ThreadVirtualizer | null>;
 }
 
 /**
@@ -194,59 +211,50 @@ interface ThreadScrollControllerProps {
  * Behavior:
  * - thread.initialize (history first load) → bottom, instant.
  * - threadListItem.switchedTo (thread switch) → bottom, instant.
- * - thread.runStart (new user message sent) → anchor that user message at the top
- *   of the viewport, smooth. The "new user message" is messages.length - 1 at runStart.
+ * - thread.runStart (new user message sent) → anchor that user message at the
+ *   top of the viewport with scrollPaddingStart breathing room, smooth.
  * - Streaming: no auto-scroll. User owns scroll.
  *
- * We never install ResizeObserver/MutationObserver on the scroll container —
- * that loop is exactly what was fighting the virtualizer.
+ * Everything goes through virtualizer.scrollToIndex so unmeasured rows use
+ * the internal size ledger and built-in retry logic.
  */
 const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
-  scrollRef,
-  virtualizerHandleRef,
+  virtualizerRef,
 }) => {
   const aui = useAui();
 
-  const scrollToBottom = useCallback(
-    (behavior: ScrollBehavior) => {
+  const scrollToLastIndex = useCallback(
+    (align: "start" | "end", behavior: ScrollBehavior) => {
+      const count = aui?.thread()?.getState()?.messages.length ?? 0;
+      if (count <= 0) return;
+      // Read the live count from aui state instead of any closure so we're
+      // safe against sibling effect ordering (VirtualizedMessages may not
+      // have committed the new count when this event fires).
+      const targetIndex = count - 1;
+      // rAF lets react-virtual see the new row count in its next commit
+      // before we scroll; scrollToIndex itself then retries internally for
+      // rows whose size hasn't been measured yet.
       requestAnimationFrame(() => {
-        const el = scrollRef.current;
-        if (!el) return;
-        el.scrollTo({ top: el.scrollHeight, behavior });
+        virtualizerRef.current?.scrollToIndex(targetIndex, { align, behavior });
       });
     },
-    [scrollRef],
+    [aui, virtualizerRef],
   );
 
   useAuiEvent("thread.initialize", () => {
-    scrollToBottom("instant");
+    scrollToLastIndex("end", "instant");
   });
 
   useAuiEvent("threadListItem.switchedTo", () => {
-    scrollToBottom("instant");
+    scrollToLastIndex("end", "instant");
   });
 
   useAuiEvent("thread.runStart", () => {
-    const handle = virtualizerHandleRef.current;
-    if (!handle) return;
-    // Read the live message count from the aui thread state at event time.
-    // Going through the handle's closure over `messageCount` is unsafe because
-    // React sibling effects may not have committed the new count yet when the
-    // event fires — we'd then scroll to the previous message.
-    const liveCount = aui?.thread()?.getState()?.messages.length ?? 0;
-    if (liveCount <= 0) return;
-    // The just-sent user message is at messages.length - 1 at runStart time.
-    // When the assistant row arrives the user message naturally ends up one up.
-    const targetIndex = liveCount - 1;
-    // scrollToIndex uses the virtualizer's internal size ledger (including
-    // previously measured heights) and retries internally for unmeasured rows.
-    // Wrap in rAF so react-virtual sees the new row count before we scroll.
-    requestAnimationFrame(() => {
-      virtualizerHandleRef.current?.scrollToIndex(targetIndex, {
-        align: "start",
-        behavior: "smooth",
-      });
-    });
+    // At runStart the just-sent user message is at messages.length - 1.
+    // Anchoring it at the top mirrors the top-turnAnchor feel we previously
+    // got from assistant-ui, without the min-height injection that was
+    // fighting our virtualizer.
+    scrollToLastIndex("start", "smooth");
   });
 
   return null;
@@ -272,36 +280,75 @@ const useMessageHoverHandlers = () => {
 
 interface VirtualizedMessagesProps {
   scrollRef: RefObject<HTMLDivElement | null>;
-  virtualizerHandleRef: MutableRefObject<VirtualizerHandle | null>;
+  virtualizerRef: MutableRefObject<ThreadVirtualizer | null>;
+  enabled: boolean;
 }
-
-const ROW_ESTIMATE_SIZE = 350;
 
 const VirtualizedMessages: FC<VirtualizedMessagesProps> = ({
   scrollRef,
-  virtualizerHandleRef,
+  virtualizerRef,
+  enabled,
 }) => {
-  const messageCount = useAuiState((s) => s.thread.messages.length);
+  // Two separate subscriptions so a prolonged streaming session doesn't force
+  // a re-render for every token on selectors we don't care about.
+  const messageIds = useAuiState((s) => s.thread.messages.map((m) => m.id));
+  const messageCount = messageIds.length;
+  const isRunning = useAuiState((s) => s.thread.isRunning);
 
-  const virtualizer = useVirtualizer({
+  // Pin the streaming assistant message into the rendered range even when the
+  // user has scrolled away. Without this, scrolling up during a stream would
+  // unmount the message — which stops useMessagePartText from receiving chunks
+  // and flips hover/last state. Only active while thread.isRunning so we don't
+  // permanently pin once the run finishes.
+  const pinnedIndex = isRunning && messageCount > 0 ? messageCount - 1 : -1;
+  const rangeExtractor = useCallback(
+    (range: Parameters<typeof defaultRangeExtractor>[0]) => {
+      const base = defaultRangeExtractor(range);
+      if (pinnedIndex < 0 || base.includes(pinnedIndex)) return base;
+      // Insert while preserving ascending order so react-virtual renders them
+      // in DOM order (it otherwise re-orders absolutely-positioned rows
+      // naturally, but keeping the array sorted is cheaper for its internal
+      // diffing).
+      const next = [...base, pinnedIndex].sort((a, b) => a - b);
+      return next;
+    },
+    [pinnedIndex],
+  );
+
+  const virtualizer = useVirtualizer<HTMLDivElement, HTMLDivElement>({
     count: messageCount,
     getScrollElement: () => scrollRef.current,
     estimateSize: () => ROW_ESTIMATE_SIZE,
-    overscan: 5,
+    overscan: OVERSCAN,
+    enabled,
+    // Stable keys prevent measurementsCache invalidation when branches flip or
+    // messages are inserted/reordered.
+    getItemKey: (index) => messageIds[index] ?? index,
+    // Leave ROW_ESTIMATE_SIZE-worth of breathing room at the top when we
+    // scrollToIndex(..., { align: 'start' }). This is what makes the new user
+    // message sit nicely under any header/padding instead of the viewport edge.
+    scrollPaddingStart: SCROLL_PADDING_START,
+    // Modern browsers expose a native `scrollend` event; opting into it lets
+    // TanStack skip its polling fallback for isScrolling.
+    useScrollendEvent: true,
+    rangeExtractor,
   });
 
-  // Publish imperative handle for ThreadScrollController. We expose the
-  // virtualizer's own scrollToIndex so callers don't have to recompute offsets.
+  // Publish the instance up to Thread so ThreadScrollController can reach it
+  // without threading props through every render.
   useEffect(() => {
-    virtualizerHandleRef.current = {
-      scrollToIndex: (index, options) => virtualizer.scrollToIndex(index, options),
-    };
+    virtualizerRef.current = virtualizer;
     return () => {
-      virtualizerHandleRef.current = null;
+      virtualizerRef.current = null;
     };
-  }, [virtualizer, virtualizerHandleRef]);
+  }, [virtualizer, virtualizerRef]);
 
   if (messageCount === 0) return null;
+
+  // Docs pattern: translate the *wrapper* once by items[0].start, and render
+  // rows in natural document order inside it. That's cheaper than translating
+  // every row individually and plays nicely with contain:strict on the parent.
+  const items = virtualizer.getVirtualItems();
 
   return (
     <div
@@ -311,25 +358,28 @@ const VirtualizedMessages: FC<VirtualizedMessagesProps> = ({
         position: "relative",
       }}
     >
-      {virtualizer.getVirtualItems().map((virtualRow) => (
-        <div
-          key={virtualRow.key}
-          data-index={virtualRow.index}
-          ref={virtualizer.measureElement}
-          style={{
-            position: "absolute",
-            top: 0,
-            left: 0,
-            width: "100%",
-            transform: `translateY(${virtualRow.start}px)`,
-          }}
-        >
-          <ThreadPrimitive.MessageByIndex
-            index={virtualRow.index}
-            components={MESSAGE_COMPONENTS}
-          />
-        </div>
-      ))}
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: "100%",
+          transform: `translateY(${items[0]?.start ?? 0}px)`,
+        }}
+      >
+        {items.map((virtualRow) => (
+          <div
+            key={virtualRow.key}
+            data-index={virtualRow.index}
+            ref={virtualizer.measureElement}
+          >
+            <ThreadPrimitive.MessageByIndex
+              index={virtualRow.index}
+              components={MESSAGE_COMPONENTS}
+            />
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -216,15 +216,18 @@ interface ThreadScrollControllerProps {
  *    we target the virtualizer's measurement ledger instead of the raw
  *    `el.scrollHeight`.
  *
- * 2. NEW USER MESSAGE (thread.runStart) -> anchor at top, smooth. Event-driven
- *    because we need the transition, not the steady state. Reads the latest
- *    `messageCount` from the subscription via `useEffectEvent` semantics of
- *    `useAuiEvent`. Organic growth during streaming is deliberately ignored —
- *    the user owns scroll once anchored.
+ * 2. NEW USER MESSAGE (thread.runStart) -> anchor at top, smooth. Event-driven.
+ *    The count is read imperatively from the store inside the handler, NOT
+ *    from the `messageCount` subscription closure: runStart fires
+ *    synchronously between the repository mutation and React's commit, so
+ *    `useEffectEvent`'s ref still holds the stale closure with the old count.
+ *    Organic growth during streaming is deliberately ignored — the user owns
+ *    scroll once anchored.
  */
 const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
   virtualizerRef,
 }) => {
+  const aui = useAui();
   // Reactive subscriptions: both drive the load/switch effect below. Using
   // useAuiState over useAuiEvent lets us observe the settled state rather
   // than racing event emission against React commits. `threadListItem.id`
@@ -268,12 +271,18 @@ const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
   }, [threadId, messageCount, scrollToIndex]);
 
   // New user message sent -> anchor at top with smooth animation. Event-driven
-  // because we need to react on the transition, not the steady state. The
-  // handler reads `messageCount` via useEffectEvent (always latest), and
-  // since runStart fires after the user message is appended to the store,
-  // `messageCount` already reflects the new row.
+  // because we need to react on the transition, not the steady state. We must
+  // read the count *imperatively from the store* here, not from the
+  // `messageCount` closure: `runStart` is emitted synchronously inside the
+  // runtime's append->startRun path, AFTER `repository.addOrUpdateMessage`
+  // appends the user message but BEFORE React commits the re-render. At that
+  // moment `useEffectEvent`'s ref (updated in useInsertionEffect, commit-phase)
+  // still points at the previous closure with the old count, so using the
+  // subscription value here would scroll to the last *previous* message.
+  // Reading `aui.thread().getState().messages.length` bypasses that window.
   useAuiEvent("thread.runStart", () => {
-    scrollToIndex(messageCount, "start", "smooth");
+    const liveCount = aui?.thread()?.getState()?.messages.length ?? 0;
+    scrollToIndex(liveCount, "start", "smooth");
   });
 
   return null;

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -166,15 +166,20 @@ export const Thread: FC<ThreadProps> = ({ items = [] }) => {
 
 /**
  * Imperative handle exposed by VirtualizedMessages so ThreadScrollController
- * can translate message indices into scrollTop offsets via @tanstack/react-virtual.
+ * can position the viewport on a specific message index. We delegate to
+ * TanStack Virtual's own `scrollToIndex` so unmeasured rows use the internal
+ * size ledger (instead of reimplementing offset math ourselves).
  */
 interface VirtualizerHandle {
-  /** Returns the virtualRow.start for the given message index, or null if not currently mounted/measured. */
-  getRowOffset: (index: number) => number | null;
-  /** Returns current message count. */
-  getCount: () => number;
-  /** Returns the estimateSize() value used by the virtualizer (fallback for unmounted rows). */
-  getEstimatedSize: () => number;
+  /**
+   * Scroll so the row at `index` aligns according to `align`.
+   * Uses virtualizer.scrollToIndex internally, which retries across frames
+   * for rows whose size hasn't been measured yet.
+   */
+  scrollToIndex: (
+    index: number,
+    options?: { align?: "start" | "center" | "end" | "auto"; behavior?: ScrollBehavior },
+  ) => void;
 }
 
 interface ThreadScrollControllerProps {
@@ -200,6 +205,8 @@ const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
   scrollRef,
   virtualizerHandleRef,
 }) => {
+  const aui = useAui();
+
   const scrollToBottom = useCallback(
     (behavior: ScrollBehavior) => {
       requestAnimationFrame(() => {
@@ -209,32 +216,6 @@ const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
       });
     },
     [scrollRef],
-  );
-
-  const scrollIndexToTop = useCallback(
-    (targetIndex: number, behavior: ScrollBehavior) => {
-      // React-virtual may not have measured the new row yet. Retry across a few
-      // frames using the measured offset when available, falling back to
-      // estimateSize * index so we at least land close.
-      let attempts = 0;
-      const attempt = () => {
-        attempts += 1;
-        const el = scrollRef.current;
-        const handle = virtualizerHandleRef.current;
-        if (!el || !handle) return;
-        if (targetIndex < 0 || targetIndex >= handle.getCount()) return;
-
-        const measured = handle.getRowOffset(targetIndex);
-        const top = measured ?? targetIndex * handle.getEstimatedSize();
-        el.scrollTo({ top, behavior });
-
-        if (measured === null && attempts < 3) {
-          requestAnimationFrame(attempt);
-        }
-      };
-      requestAnimationFrame(attempt);
-    },
-    [scrollRef, virtualizerHandleRef],
   );
 
   useAuiEvent("thread.initialize", () => {
@@ -248,11 +229,24 @@ const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
   useAuiEvent("thread.runStart", () => {
     const handle = virtualizerHandleRef.current;
     if (!handle) return;
-    // At runStart, the just-sent user message is at messages.length - 1.
-    // The assistant placeholder is appended shortly after, so when the
-    // assistant row arrives our user message will naturally be one up.
-    const targetIndex = handle.getCount() - 1;
-    scrollIndexToTop(targetIndex, "smooth");
+    // Read the live message count from the aui thread state at event time.
+    // Going through the handle's closure over `messageCount` is unsafe because
+    // React sibling effects may not have committed the new count yet when the
+    // event fires — we'd then scroll to the previous message.
+    const liveCount = aui?.thread()?.getState()?.messages.length ?? 0;
+    if (liveCount <= 0) return;
+    // The just-sent user message is at messages.length - 1 at runStart time.
+    // When the assistant row arrives the user message naturally ends up one up.
+    const targetIndex = liveCount - 1;
+    // scrollToIndex uses the virtualizer's internal size ledger (including
+    // previously measured heights) and retries internally for unmeasured rows.
+    // Wrap in rAF so react-virtual sees the new row count before we scroll.
+    requestAnimationFrame(() => {
+      virtualizerHandleRef.current?.scrollToIndex(targetIndex, {
+        align: "start",
+        behavior: "smooth",
+      });
+    });
   });
 
   return null;
@@ -296,21 +290,16 @@ const VirtualizedMessages: FC<VirtualizedMessagesProps> = ({
     overscan: 5,
   });
 
-  // Publish imperative handle for ThreadScrollController.
+  // Publish imperative handle for ThreadScrollController. We expose the
+  // virtualizer's own scrollToIndex so callers don't have to recompute offsets.
   useEffect(() => {
     virtualizerHandleRef.current = {
-      getRowOffset: (index) => {
-        const items = virtualizer.getVirtualItems();
-        const found = items.find((v) => v.index === index);
-        return found ? found.start : null;
-      },
-      getCount: () => messageCount,
-      getEstimatedSize: () => ROW_ESTIMATE_SIZE,
+      scrollToIndex: (index, options) => virtualizer.scrollToIndex(index, options),
     };
     return () => {
       virtualizerHandleRef.current = null;
     };
-  }, [virtualizer, messageCount, virtualizerHandleRef]);
+  }, [virtualizer, virtualizerHandleRef]);
 
   if (messageCount === 0) return null;
 

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -43,6 +43,7 @@ import {
 import {
   defaultRangeExtractor,
   useVirtualizer,
+  type Range,
   type Virtualizer,
 } from "@tanstack/react-virtual";
 
@@ -120,21 +121,15 @@ interface ThreadProps {
   items?: Item[];
 }
 
-// Shared type alias: the @tanstack/react-virtual instance used throughout this
-// file. We lift it to Thread so the scroll controller can call scrollToIndex
-// directly without going through a handle wrapper.
+// Shared type: the @tanstack/react-virtual instance. Lifted to Thread so the
+// scroll controller can call scrollToIndex directly.
 type ThreadVirtualizer = Virtualizer<HTMLDivElement, HTMLDivElement>;
 
-// Estimated row height used before the virtualizer measures a row's actual
-// size. Matches the previous value — tuned for a typical assistant turn with
-// some markdown and a tool call.
+// Default row height before the virtualizer measures actual sizes.
 const ROW_ESTIMATE_SIZE = 350;
-// Breathing room above a user message when we scrollToIndex(..., { align: 'start' }).
-// Without this the message is flush against the viewport's top edge, which
-// looks wrong and hides MessageContextBadges on touch.
+// Breathing room above a user message when scrollToIndex(align:'start').
 const SCROLL_PADDING_START = 16;
-// Rows kept mounted outside the visible viewport (above and below) so smooth
-// scrolling doesn't flash blank regions. 5 matches TanStack's own docs example.
+// Rows kept mounted outside the viewport for smooth scrolling.
 const OVERSCAN = 5;
 
 export const Thread: FC<ThreadProps> = ({ items = [] }) => {
@@ -160,14 +155,9 @@ export const Thread: FC<ThreadProps> = ({ items = [] }) => {
       {/*
         Custom scroll container — intentionally NOT ThreadPrimitive.Viewport.
         assistant-ui's Viewport installs a ResizeObserver + subtree MutationObserver
-        on the scroll container and MessagePrimitive.Root injects inline min-height
-        on the last assistant message via ThreadViewportSlack. Both fight our
-        @tanstack/react-virtual virtualizer. We own scroll behavior here.
-
-        - `contain: strict` lets the browser treat this subtree as an independent
-          layout/paint root, cutting reflow cost during streaming.
-        - `overflow-anchor: none` disables the browser's native scroll-anchoring,
-          which otherwise fights the virtualizer when row sizes change.
+        that fights @tanstack/react-virtual. We own scroll behavior here instead.
+        • contain:strict = independent layout/paint root, cuts reflow during streaming
+        • overflow-anchor:none = disables browser scroll anchoring (fights the virtualizer)
       */}
       <div
         ref={viewportRef}
@@ -205,18 +195,11 @@ interface ThreadScrollControllerProps {
 }
 
 /**
- * Owns scroll behavior for the virtualized thread. Replaces assistant-ui's
- * ThreadPrimitive.Viewport + turnAnchor + ViewportSlack entirely.
- *
- * Behavior:
- * - thread.initialize (history first load) → bottom, instant.
- * - threadListItem.switchedTo (thread switch) → bottom, instant.
- * - thread.runStart (new user message sent) → anchor that user message at the
- *   top of the viewport with scrollPaddingStart breathing room, smooth.
- * - Streaming: no auto-scroll. User owns scroll.
- *
- * Everything goes through virtualizer.scrollToIndex so unmeasured rows use
- * the internal size ledger and built-in retry logic.
+ * Owns scroll behavior for the virtualized thread.
+ * • thread.initialize → bottom, instant
+ * • threadListItem.switchedTo → bottom, instant
+ * • thread.runStart → anchor the new user message at the top, smooth
+ * • Streaming: user owns scroll
  */
 const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
   virtualizerRef,
@@ -225,47 +208,33 @@ const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
 
   const scrollToLastIndex = useCallback(
     (align: "start" | "end", behavior: ScrollBehavior) => {
+      // Read live count from aui state; closure-based counts are unsafe
+      // against sibling-effect ordering (VirtualizedMessages may not have
+      // committed yet when the event fires).
       const count = aui?.thread()?.getState()?.messages.length ?? 0;
       if (count <= 0) return;
-      // Read the live count from aui state instead of any closure so we're
-      // safe against sibling effect ordering (VirtualizedMessages may not
-      // have committed the new count when this event fires).
-      const targetIndex = count - 1;
-      // rAF lets react-virtual see the new row count in its next commit
-      // before we scroll; scrollToIndex itself then retries internally for
-      // rows whose size hasn't been measured yet.
+      // rAF so react-virtual sees the new row count before we scroll;
+      // scrollToIndex retries internally for unmeasured rows.
       requestAnimationFrame(() => {
-        virtualizerRef.current?.scrollToIndex(targetIndex, { align, behavior });
+        virtualizerRef.current?.scrollToIndex(count - 1, { align, behavior });
       });
     },
     [aui, virtualizerRef],
   );
 
-  useAuiEvent("thread.initialize", () => {
-    scrollToLastIndex("end", "instant");
-  });
-
-  useAuiEvent("threadListItem.switchedTo", () => {
-    scrollToLastIndex("end", "instant");
-  });
-
-  useAuiEvent("thread.runStart", () => {
-    // At runStart the just-sent user message is at messages.length - 1.
-    // Anchoring it at the top mirrors the top-turnAnchor feel we previously
-    // got from assistant-ui, without the min-height injection that was
-    // fighting our virtualizer.
-    scrollToLastIndex("start", "smooth");
-  });
+  useAuiEvent("thread.initialize", () => scrollToLastIndex("end", "instant"));
+  useAuiEvent("threadListItem.switchedTo", () => scrollToLastIndex("end", "instant"));
+  useAuiEvent("thread.runStart", () => scrollToLastIndex("start", "smooth"));
 
   return null;
 };
 
 /**
- * Replacement for the hover tracking that `MessagePrimitive.Root` normally wires
- * up (via ThreadPrimitiveViewportSlack). Without this, ActionBarPrimitive
- * autohide="not-last" and MessagePrimitive.If lastOrHover would be permanently
- * hidden on non-last messages. We forward hover state into the aui message
- * client directly, which is what MessageRoot does under the hood.
+ * Forwards hover state to the aui message client — the only side-effect of
+ * MessagePrimitive.Root we still need (powers ActionBarPrimitive autohide and
+ * MessagePrimitive.If lastOrHover). We dropped MessagePrimitive.Root itself
+ * because its ThreadViewportSlack wrapper injects inline min-height that the
+ * virtualizer's measureElement reads as the row size.
  */
 const useMessageHoverHandlers = () => {
   const aui = useAui();
@@ -289,28 +258,25 @@ const VirtualizedMessages: FC<VirtualizedMessagesProps> = ({
   virtualizerRef,
   enabled,
 }) => {
-  // Two separate subscriptions so a prolonged streaming session doesn't force
-  // a re-render for every token on selectors we don't care about.
-  const messageIds = useAuiState((s) => s.thread.messages.map((m) => m.id));
-  const messageCount = messageIds.length;
+  const aui = useAui();
+  // Subscribing to length + isRunning (both primitives) is enough to drive
+  // re-renders. getItemKey reads ids lazily from live aui state, so we don't
+  // need to subscribe to the whole messages array (which would allocate a
+  // new array identity on every streaming token).
+  const messageCount = useAuiState((s) => s.thread.messages.length);
   const isRunning = useAuiState((s) => s.thread.isRunning);
 
   // Pin the streaming assistant message into the rendered range even when the
   // user has scrolled away. Without this, scrolling up during a stream would
-  // unmount the message — which stops useMessagePartText from receiving chunks
-  // and flips hover/last state. Only active while thread.isRunning so we don't
-  // permanently pin once the run finishes.
+  // unmount the message — stopping useMessagePartText from receiving chunks
+  // and flipping hover/last state. Only active while thread.isRunning.
   const pinnedIndex = isRunning && messageCount > 0 ? messageCount - 1 : -1;
   const rangeExtractor = useCallback(
-    (range: Parameters<typeof defaultRangeExtractor>[0]) => {
+    (range: Range) => {
       const base = defaultRangeExtractor(range);
       if (pinnedIndex < 0 || base.includes(pinnedIndex)) return base;
-      // Insert while preserving ascending order so react-virtual renders them
-      // in DOM order (it otherwise re-orders absolutely-positioned rows
-      // naturally, but keeping the array sorted is cheaper for its internal
-      // diffing).
-      const next = [...base, pinnedIndex].sort((a, b) => a - b);
-      return next;
+      // Keep ascending order so react-virtual's internal diff is linear.
+      return [...base, pinnedIndex].sort((a, b) => a - b);
     },
     [pinnedIndex],
   );
@@ -321,15 +287,14 @@ const VirtualizedMessages: FC<VirtualizedMessagesProps> = ({
     estimateSize: () => ROW_ESTIMATE_SIZE,
     overscan: OVERSCAN,
     enabled,
-    // Stable keys prevent measurementsCache invalidation when branches flip or
-    // messages are inserted/reordered.
-    getItemKey: (index) => messageIds[index] ?? index,
-    // Leave ROW_ESTIMATE_SIZE-worth of breathing room at the top when we
-    // scrollToIndex(..., { align: 'start' }). This is what makes the new user
-    // message sit nicely under any header/padding instead of the viewport edge.
+    // Stable keys by aui message id prevent measurementsCache invalidation
+    // on branch flips / reorders. Read live from aui state so this selector
+    // doesn't need to subscribe to the full messages array.
+    getItemKey: (index) =>
+      aui?.thread()?.getState()?.messages[index]?.id ?? index,
+    // Breathing room above a user message when scrollToIndex(align:'start').
     scrollPaddingStart: SCROLL_PADDING_START,
-    // Modern browsers expose a native `scrollend` event; opting into it lets
-    // TanStack skip its polling fallback for isScrolling.
+    // Native scrollend event on modern browsers skips TanStack's polling.
     useScrollendEvent: true,
     rangeExtractor,
   });
@@ -345,9 +310,9 @@ const VirtualizedMessages: FC<VirtualizedMessagesProps> = ({
 
   if (messageCount === 0) return null;
 
-  // Docs pattern: translate the *wrapper* once by items[0].start, and render
-  // rows in natural document order inside it. That's cheaper than translating
-  // every row individually and plays nicely with contain:strict on the parent.
+  // Docs pattern: translate the wrapper once by items[0].start, render rows
+  // in natural document order inside. Cheaper than per-row transforms, works
+  // well with contain:strict on the parent.
   const items = virtualizer.getVirtualItems();
 
   return (

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -310,9 +310,12 @@ const VirtualizedMessages: FC<VirtualizedMessagesProps> = ({
 
   if (messageCount === 0) return null;
 
-  // Docs pattern: translate the wrapper once by items[0].start, render rows
-  // in natural document order inside. Cheaper than per-row transforms, works
-  // well with contain:strict on the parent.
+  // Per-row absolute positioning (not the single-wrapper translate shown in
+  // TanStack's "dynamic" docs example). The wrapper-translate pattern assumes
+  // items is a CONTIGUOUS index range, but our rangeExtractor pins the
+  // streaming last assistant message so items can look like [5,6,7,...,42]
+  // while the user scrolls up. Translating per-row keeps each row at its true
+  // virtualRow.start regardless of gaps.
   const items = virtualizer.getVirtualItems();
 
   return (
@@ -323,28 +326,25 @@ const VirtualizedMessages: FC<VirtualizedMessagesProps> = ({
         position: "relative",
       }}
     >
-      <div
-        style={{
-          position: "absolute",
-          top: 0,
-          left: 0,
-          width: "100%",
-          transform: `translateY(${items[0]?.start ?? 0}px)`,
-        }}
-      >
-        {items.map((virtualRow) => (
-          <div
-            key={virtualRow.key}
-            data-index={virtualRow.index}
-            ref={virtualizer.measureElement}
-          >
-            <ThreadPrimitive.MessageByIndex
-              index={virtualRow.index}
-              components={MESSAGE_COMPONENTS}
-            />
-          </div>
-        ))}
-      </div>
+      {items.map((virtualRow) => (
+        <div
+          key={virtualRow.key}
+          data-index={virtualRow.index}
+          ref={virtualizer.measureElement}
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+            transform: `translateY(${virtualRow.start}px)`,
+          }}
+        >
+          <ThreadPrimitive.MessageByIndex
+            index={virtualRow.index}
+            components={MESSAGE_COMPONENTS}
+          />
+        </div>
+      ))}
     </div>
   );
 };

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -35,7 +35,6 @@ import {
   MessagePrimitive,
   ThreadPrimitive,
   useAui,
-  useAuiEvent,
   useMessage,
   useMessagePartText,
   useAuiState,
@@ -170,6 +169,25 @@ interface ThreadScrollControllerProps {
   captureBlankRef: RefObject<(() => void) | null>;
 }
 
+/**
+ * Owns scroll behavior for the virtualized thread. Three concerns:
+ *
+ * 1. LOAD / THREAD-SWITCH -> bottom, instant. Keyed on threadListItem.id +
+ *    messages.length. `settledThreadIdRef` guards against streaming-token
+ *    count ticks re-triggering the bottom-scroll.
+ *
+ * 2. NEW USER MESSAGE -> user pinned at top of viewport, smooth.
+ *    Driven by the `isRunning` state transition (false -> true) via a
+ *    post-commit effect rather than the `thread.runStart` event.
+ *    WHY: assistant-ui emits `runStart` synchronously inside the runtime's
+ *    repository mutation, BEFORE React commits the render that mounts the
+ *    new rows. At that moment `virtualizerRef.current` can still be null
+ *    (first message of a thread) and `viewportSize` can read 0. Waiting
+ *    for the post-commit effect guarantees the Virtualizer is mounted and
+ *    the new row is in the DOM.
+ *
+ * 3. STREAMING -> user owns scroll. Neither effect fires during a run.
+ */
 const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
   virtualizerRef,
   captureBlankRef,
@@ -177,6 +195,7 @@ const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
   const aui = useAui();
   const threadId = useAuiState((s) => s.threadListItem.id);
   const messageCount = useAuiState((s) => s.thread.messages.length);
+  const isRunning = useAuiState((s) => s.thread.isRunning);
 
   const scrollToLastIndex = useCallback(
     (count: number, align: "start" | "end", smooth: boolean) => {
@@ -188,8 +207,8 @@ const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
     [virtualizerRef],
   );
 
+  // 1. Thread load/switch: snap to bottom once messages land.
   const settledThreadIdRef = useRef<string | null>(null);
-
   useEffect(() => {
     if (settledThreadIdRef.current !== threadId) {
       settledThreadIdRef.current = null;
@@ -200,11 +219,23 @@ const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
     scrollToLastIndex(messageCount, "end", false);
   }, [threadId, messageCount, scrollToLastIndex]);
 
-  useAuiEvent("thread.runStart", () => {
+  // 2. isRunning false -> true: capture viewport blank + smooth-scroll the
+  // newly committed user message to the top. Effect-driven because by this
+  // point React has committed, the Virtualizer is mounted, and the row is
+  // in the DOM with a real measured height. `hasScrolledForRunRef` dedupes
+  // when message-count ticks during the run re-fire the effect.
+  const hasScrolledForRunRef = useRef(false);
+  useEffect(() => {
+    if (!isRunning) {
+      hasScrolledForRunRef.current = false;
+      return;
+    }
+    if (hasScrolledForRunRef.current) return;
+    hasScrolledForRunRef.current = true;
     captureBlankRef.current?.();
     const liveCount = aui?.thread()?.getState()?.messages.length ?? 0;
     scrollToLastIndex(liveCount, "start", true);
-  });
+  }, [isRunning, aui, captureBlankRef, scrollToLastIndex]);
 
   return null;
 };
@@ -282,8 +313,10 @@ const VirtualizedMessages: FC<VirtualizedMessagesProps> = ({
   const assistantMinHeight =
     streamingAssistantIndex >= 0 ? Math.max(0, blankSize - lastUserSize) : 0;
 
-  if (messageCount === 0) return null;
-
+  // Always mount the Virtualizer — even when messageCount is 0 — so
+  // `virtualizerRef.current.viewportSize` is readable the moment the first
+  // message lands and `runStart` fires. The empty-state UI (ThreadWelcome /
+  // skeleton) is rendered by sibling AuiIf wrappers in Thread, not here.
   return (
     <Virtualizer
       ref={virtualizerRef}

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -201,29 +201,40 @@ interface ThreadScrollControllerProps {
 }
 
 /**
- * Owns scroll behavior for the virtualized thread.
- * • thread.initialize → bottom, instant (first hydration of a thread runtime)
- * • thread id change → bottom, instant (covers switching to a previously
- *   loaded thread, where thread.initialize won't fire again)
- * • thread.runStart → anchor the new user message at the top, smooth
- * • Streaming: user owns scroll
+ * Owns scroll behavior for the virtualized thread. Two concerns:
+ *
+ * 1. LOAD / THREAD-SWITCH -> bottom, instant. Tracked via `threadListItem.id`
+ *    + `thread.messages.length`. A ref-backed "last scrolled for" guard
+ *    ensures we only snap to bottom on thread identity changes — not on every
+ *    message count tick. Reading `messageCount` as a dep is what lets us
+ *    catch the initial hydration: the runtime emits `thread.initialize`
+ *    BEFORE `repository.import()`, so at event time count is 0. By making
+ *    the effect depend on count, it re-runs once messages land and we can
+ *    commit the scroll.
+ *
+ *    Mirrors assistant-ui's upstream `useThreadViewportAutoScroll`, except
+ *    we target the virtualizer's measurement ledger instead of the raw
+ *    `el.scrollHeight`.
+ *
+ * 2. NEW USER MESSAGE (thread.runStart) -> anchor at top, smooth. Event-driven
+ *    because we need the transition, not the steady state. Reads the latest
+ *    `messageCount` from the subscription via `useEffectEvent` semantics of
+ *    `useAuiEvent`. Organic growth during streaming is deliberately ignored —
+ *    the user owns scroll once anchored.
  */
 const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
   virtualizerRef,
 }) => {
-  const aui = useAui();
-  // Track the current thread id via the threadListItem.switchedTo event
-  // payload. We can't read it from thread state (no id field there) and we
-  // can't scroll inside the event itself because the new thread's messages
-  // haven't been imported yet \u2014 so we stash the id and react in an effect.
-  const [activeThreadId, setActiveThreadId] = useState<string | null>(null);
+  // Reactive subscriptions: both drive the load/switch effect below. Using
+  // useAuiState over useAuiEvent lets us observe the settled state rather
+  // than racing event emission against React commits. `threadListItem.id`
+  // is the canonical thread identifier on the store proxy; `thread.threadId`
+  // only exists on the core runtime's ThreadState and isn't exposed here.
+  const threadId = useAuiState((s) => s.threadListItem.id);
+  const messageCount = useAuiState((s) => s.thread.messages.length);
 
-  const scrollToLastIndex = useCallback(
-    (align: "start" | "end", behavior: ScrollBehavior) => {
-      // Read live count from aui state; closure-based counts are unsafe
-      // against sibling-effect ordering (VirtualizedMessages may not have
-      // committed yet when this fires).
-      const count = aui?.thread()?.getState()?.messages.length ?? 0;
+  const scrollToIndex = useCallback(
+    (count: number, align: "start" | "end", behavior: ScrollBehavior) => {
       if (count <= 0) return;
       // Two RAFs: first lets react-virtual commit the new row count, second
       // gives measureElement a chance to register row sizes before we scroll.
@@ -234,25 +245,36 @@ const ThreadScrollController: FC<ThreadScrollControllerProps> = ({
         });
       });
     },
-    [aui, virtualizerRef],
+    [virtualizerRef],
   );
 
-  // First hydration of a thread runtime (per-instance event, fires once).
-  useAuiEvent("thread.initialize", () => scrollToLastIndex("end", "instant"));
+  // Track the thread we're currently "settled" on. Reset whenever the id
+  // changes so that visiting A → B → A re-scrolls A's bottom.
+  const settledThreadIdRef = useRef<string | null>(null);
 
-  // Switching to a previously loaded thread does NOT re-fire thread.initialize
-  // (each thread runtime caches _isInitialized). Capture the threadId here, then
-  // react in an effect after React commits the new messages array.
-  useAuiEvent("threadListItem.switchedTo", ({ threadId }) => {
-    setActiveThreadId(threadId);
-  });
   useEffect(() => {
-    if (!activeThreadId) return;
-    scrollToLastIndex("end", "instant");
-  }, [activeThreadId, scrollToLastIndex]);
+    // Reset settle marker whenever the visible thread id changes; this makes
+    // A → B → A trigger a bottom-scroll on the second visit to A.
+    if (settledThreadIdRef.current !== threadId) {
+      settledThreadIdRef.current = null;
+    }
+    // Wait for messages to land before committing the "settled" marker —
+    // ensureInitialized() fires before repository.import(), so on first
+    // mount messageCount is 0 and flips to N on the next commit.
+    if (messageCount <= 0) return;
+    if (settledThreadIdRef.current === threadId) return;
+    settledThreadIdRef.current = threadId;
+    scrollToIndex(messageCount, "end", "instant");
+  }, [threadId, messageCount, scrollToIndex]);
 
-  // New user message sent \u2192 anchor at top with smooth animation.
-  useAuiEvent("thread.runStart", () => scrollToLastIndex("start", "smooth"));
+  // New user message sent -> anchor at top with smooth animation. Event-driven
+  // because we need to react on the transition, not the steady state. The
+  // handler reads `messageCount` via useEffectEvent (always latest), and
+  // since runStart fires after the user message is appended to the store,
+  // `messageCount` already reflects the new row.
+  useAuiEvent("thread.runStart", () => {
+    scrollToIndex(messageCount, "start", "smooth");
+  });
 
   return null;
 };


### PR DESCRIPTION
Removes `ThreadPrimitive.Viewport` and `MessagePrimitive.Root` from the virtualized thread to eliminate ResizeObserver/MutationObserver thrashing and Slack min-height injection that fight `@tanstack/react-virtual`. Owns scroll behavior explicitly with a lightweight `ThreadScrollController` that hooks into `thread.initialize`, `threadListItem.switchedTo`, and `thread.runStart` events.

- **src/components/assistant-ui/thread.tsx**: Replace `ThreadPrimitive.Viewport` with plain `<div>` scroll container; add `useAuiEvent` from `@assistant-ui/react` for scroll event handling; implement `ThreadScrollController` that scrolls to bottom on thread init/switch (instant) and anchors the new user message at the top on `thread.runStart` (smooth); remove `MessagePrimitive.Root` wrappers, replace with direct divs and `useMessageHoverHandlers` to preserve ActionBar autohide via `message.setIsHovering`; expose `VirtualizerHandle` from `VirtualizedMessages` so scroll controller can translate indices into virtual row offsets; preserve all existing styling, loading states, and composer logic.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/2ba1e697-f46f-4f47-a71e-bb96453a289f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-025" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/2ba1e697-f46f-4f47-a71e-bb96453a289f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-025&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-025"><img alt="ENG-025" src="https://capy.ai/api/badge/thread.svg?label=ENG-025"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Smoother, more reliable scrolling in conversation threads; avoids unintended jumps during streaming and when switching threads.
* **Performance**
  * Reduced jank and faster rendering for long conversations; streaming assistant messages remain responsive and stable.
* **UX**
  * More consistent hover interactions on messages and improved bottom-snapping behavior when new messages arrive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->