### PR TITLE
fix: bump cookiePrefix to clear stale sessions after secret rotation

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -102,6 +102,10 @@ export const auth = betterAuth({
   },
   // Advanced cookie security configuration
   advanced: {
+    // Bump this prefix whenever cookie scope (domain/path) or the signing
+    // secret changes so orphaned cookies in existing browsers can't collide
+    // with freshly issued ones and produce stuck sessions.
+    cookiePrefix: "thinkex-v1",
     // Force secure cookies (HTTPS only) - critical for preventing session hijacking
     useSecureCookies: process.env.NODE_ENV === "production",
     crossSubDomainCookies: {


### PR DESCRIPTION
Fixes the stuck workspace loader caused by cookie collisions after `BETTER_AUTH_SECRET` rotation.

When the secret was rotated and `crossSubDomainCookies` was enabled, users ended up with two cookies named `__Secure-better-auth.session_token`:
- An old host-only cookie (from before `crossSubDomainCookies`)
- A new cookie with `Domain=.thinkex.app`

The browser sends both on every request; the server reads the stale one first, session returns null, `/api/zero/query` returns 401, and `<ZeroProvider>` hangs in loading state.

**Fix**: Set `cookiePrefix: "thinkex-v1"` in Better Auth config. Old cookies are now completely ignored by the server. Affected users re-authenticate once with a one-click Google sign-in, and new sessions use the new cookie name with no collision risk.

```diff
+    // Bump this prefix whenever cookie scope (domain/path) or the signing
+    // secret changes so orphaned cookies in existing browsers can't collide
+    // with freshly issued ones and produce stuck sessions.
+    cookiePrefix: "thinkex-v1",
```

**src/lib/auth.ts**
- Add `cookiePrefix: "thinkex-v1"` in advanced options to invalidate legacy cookie names

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/0548e0d8-937c-4025-9de3-dc240bd4976c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-034" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/0548e0d8-937c-4025-9de3-dc240bd4976c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-034&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-034"><img alt="ENG-034" src="https://capy.ai/api/badge/thread.svg?label=ENG-034"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication session cookie configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->