### PR TITLE
Refactor: Exact name matching + filesystem-style name validation

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -53,6 +53,7 @@ import {
   getDocumentUploadPartialMessage,
   getDocumentUploadSuccessMessage,
 } from "@/lib/uploads/upload-feedback";
+import { logger } from "@/lib/utils/logger";
 
 // Main dashboard content component
 interface DashboardContentProps {
@@ -237,9 +238,19 @@ function DashboardContent({
       const pdfCardDefinitions =
         buildWorkspaceItemDefinitionsFromAssets(uploads);
 
-      const createdIds = operations.createItems(pdfCardDefinitions, {
-        showSuccessToast: false,
-      });
+      let createdIds: string[];
+      try {
+        createdIds = operations.createItems(pdfCardDefinitions, {
+          showSuccessToast: false,
+        });
+      } catch (error) {
+        logger.error("[DASHBOARD] Failed to create uploaded items:", error);
+        toast.dismiss(uploadToastId);
+        toast.error(
+          `Could not create items: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
+        return;
+      }
       handleCreatedItems(createdIds);
 
       void startAssetProcessing({

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -40,6 +40,7 @@ import {
   useAuiState,
 } from "@assistant-ui/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { logger } from "@/lib/utils/logger";
 
 import type { FC, RefObject } from "react";
 import { createContext, useContext } from "react";
@@ -825,9 +826,21 @@ const Composer: FC<ComposerProps> = ({ items }) => {
       if (uploads.length > 0) {
         const pdfCardDefinitions =
           buildWorkspaceItemDefinitionsFromAssets(uploads);
-        const createdIds = operations.createItems(pdfCardDefinitions, {
-          showSuccessToast: false,
-        });
+        let createdIds: string[];
+        try {
+          createdIds = operations.createItems(pdfCardDefinitions, {
+            showSuccessToast: false,
+          });
+        } catch (error) {
+          logger.error(
+            "[ASSISTANT_THREAD] Failed to create uploaded PDF items:",
+            error,
+          );
+          toast.error(
+            `Could not create items: ${error instanceof Error ? error.message : "Unknown error"}`,
+          );
+          return;
+        }
 
         void startAssetProcessing({
           workspaceId,

--- a/src/components/modals/RenameDialog.tsx
+++ b/src/components/modals/RenameDialog.tsx
@@ -31,6 +31,7 @@ export default function RenameDialog({
   onRename,
 }: RenameDialogProps) {
   const [renameValue, setRenameValue] = useState(currentName || "Untitled");
+  const [touched, setTouched] = useState(false);
   const renameInputRef = useRef<HTMLInputElement>(null);
   const formId = useId();
   const validation = useMemo(
@@ -41,7 +42,12 @@ export default function RenameDialog({
   // Sync rename value when current name changes
   useEffect(() => {
     setRenameValue(currentName || "Untitled");
+    setTouched(false);
   }, [currentName]);
+
+  useEffect(() => {
+    if (open) setTouched(false);
+  }, [open]);
 
   // Auto-focus and select all text when dialog opens
   // Use setTimeout to ensure the element is fully rendered and focusable after dialog animation completes
@@ -111,7 +117,10 @@ export default function RenameDialog({
               ref={renameInputRef}
               autoFocus
               value={renameValue}
-              onChange={(e) => setRenameValue(e.target.value)}
+              onChange={(e) => {
+                setRenameValue(e.target.value);
+                setTouched(true);
+              }}
               onKeyDown={(e) => {
                 if (e.key === "Escape") {
                   onOpenChange(false);
@@ -119,7 +128,7 @@ export default function RenameDialog({
               }}
               placeholder={getPlaceholder()}
             />
-            {!validation.valid && renameValue.length > 0 && (
+            {touched && !validation.valid && (
               <p className="text-xs text-destructive mt-2">
                 {validation.error}
               </p>

--- a/src/components/modals/RenameDialog.tsx
+++ b/src/components/modals/RenameDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback, useId } from "react";
+import { useState, useEffect, useRef, useCallback, useId, useMemo } from "react";
 import {
   Dialog,
   DialogClose,
@@ -13,6 +13,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import type { CardType } from "@/lib/workspace-state/types";
+import { validateItemName } from "@/lib/workspace/name-rules";
 
 interface RenameDialogProps {
   open: boolean;
@@ -32,6 +33,10 @@ export default function RenameDialog({
   const [renameValue, setRenameValue] = useState(currentName || "Untitled");
   const renameInputRef = useRef<HTMLInputElement>(null);
   const formId = useId();
+  const validation = useMemo(
+    () => validateItemName(renameValue),
+    [renameValue],
+  );
 
   // Sync rename value when current name changes
   useEffect(() => {
@@ -55,11 +60,10 @@ export default function RenameDialog({
   }, [open]);
 
   const handleRename = useCallback(() => {
-    if (renameValue.trim()) {
-      onRename(renameValue.trim());
-      onOpenChange(false);
-    }
-  }, [renameValue, onRename, onOpenChange]);
+    if (!validation.valid) return;
+    onRename(validation.normalized);
+    onOpenChange(false);
+  }, [validation, onRename, onOpenChange]);
 
   const getItemTypeLabel = () => {
     switch (itemType) {
@@ -115,6 +119,11 @@ export default function RenameDialog({
               }}
               placeholder={getPlaceholder()}
             />
+            {!validation.valid && renameValue.length > 0 && (
+              <p className="text-xs text-destructive mt-2">
+                {validation.error}
+              </p>
+            )}
           </div>
         </form>
         <DialogFooter>
@@ -123,7 +132,7 @@ export default function RenameDialog({
               Cancel
             </Button>
           </DialogClose>
-          <Button type="submit" form={formId} disabled={!renameValue.trim()}>
+          <Button type="submit" form={formId} disabled={!validation.valid}>
             Rename
           </Button>
         </DialogFooter>

--- a/src/components/workspace-canvas/WorkspaceCanvasDropzone.tsx
+++ b/src/components/workspace-canvas/WorkspaceCanvasDropzone.tsx
@@ -29,6 +29,7 @@ import {
   WORKSPACE_FILE_UPLOAD_ACCEPT,
   WORKSPACE_FILE_UPLOAD_DESCRIPTION,
 } from "@/lib/uploads/workspace-upload-config";
+import { logger } from "@/lib/utils/logger";
 
 interface WorkspaceCanvasDropzoneProps {
   children: React.ReactNode;
@@ -140,9 +141,19 @@ export function WorkspaceCanvasDropzone({ children }: WorkspaceCanvasDropzonePro
           const itemDefinitions = buildWorkspaceItemDefinitionsFromAssets(uploads, {
             imageLayout: DEFAULT_CARD_DIMENSIONS.image,
           });
-          const createdIds = operations.createItems(itemDefinitions, {
-            showSuccessToast: false,
-          });
+          let createdIds: string[];
+          try {
+            createdIds = operations.createItems(itemDefinitions, {
+              showSuccessToast: false,
+            });
+          } catch (error) {
+            logger.error("[WORKSPACE_DROPZONE] Failed to create uploaded items:", error);
+            toast.dismiss(loadingToastId);
+            toast.error(
+              `Could not create items: ${error instanceof Error ? error.message : "Unknown error"}`,
+            );
+            return;
+          }
           handleCreatedItems(createdIds);
 
           toast.dismiss(loadingToastId);

--- a/src/components/workspace-canvas/WorkspaceHeader.tsx
+++ b/src/components/workspace-canvas/WorkspaceHeader.tsx
@@ -222,6 +222,7 @@ function GoogleIcon(props: React.SVGProps<SVGSVGElement>) {
 }
 import { useWorkspaceFilePicker } from "@/hooks/workspace/use-workspace-file-picker";
 import { startAudioProcessing } from "@/lib/audio/start-audio-processing";
+import { validateItemName } from "@/lib/workspace/name-rules";
 
 interface WorkspaceHeaderProps {
   onOpenSearch?: () => void;
@@ -313,6 +314,10 @@ export function WorkspaceHeader({
   const openAudioDialog = useAudioRecordingStore((s) => s.openDialog);
   const closeAudioDialog = useAudioRecordingStore((s) => s.closeDialog);
   const renameInputRef = useRef<HTMLInputElement>(null);
+  const renameValidation = useMemo(
+    () => validateItemName(renameValue),
+    [renameValue],
+  );
   const pathname = usePathname();
   const isWorkspaceRoute = pathname.startsWith("/workspace");
 
@@ -438,19 +443,26 @@ export function WorkspaceHeader({
 
   // Handle rename
   const handleRename = useCallback(() => {
-    if (!renamingTarget || !renameValue.trim()) return;
+    if (!renamingTarget || !renameValidation.valid) return;
 
     if (renamingTarget.type === "folder" && onRenameFolder) {
-      onRenameFolder(renamingTarget.id, renameValue.trim());
+      onRenameFolder(renamingTarget.id, renameValidation.normalized);
       toast.success("Folder renamed");
     } else if (renamingTarget.type === "item" && onUpdateActiveItem) {
-      onUpdateActiveItem(renamingTarget.id, { name: renameValue.trim() });
+      onUpdateActiveItem(renamingTarget.id, {
+        name: renameValidation.normalized,
+      });
       toast.success("Item renamed");
     }
 
     setShowRenameDialog(false);
     setRenamingTarget(null);
-  }, [onRenameFolder, onUpdateActiveItem, renamingTarget, renameValue]);
+  }, [
+    onRenameFolder,
+    onUpdateActiveItem,
+    renamingTarget,
+    renameValidation,
+  ]);
 
   const openItemRenameDialog = useCallback(
     (itemId: string, itemName: string) => {
@@ -1396,7 +1408,7 @@ export function WorkspaceHeader({
                 value={renameValue}
                 onChange={(e) => setRenameValue(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter" && renameValue.trim()) {
+                  if (e.key === "Enter" && renameValidation.valid) {
                     handleRename();
                   } else if (e.key === "Escape") {
                     setShowRenameDialog(false);
@@ -1408,6 +1420,11 @@ export function WorkspaceHeader({
                     : "Item name"
                 }
               />
+              {!renameValidation.valid && renameValue.length > 0 && (
+                <p className="text-xs text-destructive mt-2">
+                  {renameValidation.error}
+                </p>
+              )}
             </div>
             <DialogFooter>
               <Button
@@ -1416,7 +1433,7 @@ export function WorkspaceHeader({
               >
                 Cancel
               </Button>
-              <Button onClick={handleRename} disabled={!renameValue.trim()}>
+              <Button onClick={handleRename} disabled={!renameValidation.valid}>
                 Rename
               </Button>
             </DialogFooter>

--- a/src/components/workspace-canvas/WorkspaceHeader.tsx
+++ b/src/components/workspace-canvas/WorkspaceHeader.tsx
@@ -74,6 +74,7 @@ import { useAudioRecordingStore } from "@/lib/stores/audio-recording-store";
 import { renderWorkspaceMenuItems } from "./workspace-menu-items";
 import { WorkspaceFeedbackDialog } from "./WorkspaceFeedbackDialog";
 import { PromptBuilderDialog } from "@/components/assistant-ui/PromptBuilderDialog";
+import { logger } from "@/lib/utils/logger";
 const EMPTY_ITEMS: Item[] = [];
 const EMPTY_RESPONSIVE_BREADCRUMBS = {
   visibleTailKeys: [] as string[],
@@ -301,6 +302,7 @@ export function WorkspaceHeader({
     type: "folder" | "item";
   } | null>(null);
   const [renameValue, setRenameValue] = useState("");
+  const [renameTouched, setRenameTouched] = useState(false);
   const [showYouTubeDialog, setShowYouTubeDialog] = useState(false);
   const [showWebsiteDialog, setShowWebsiteDialog] = useState(false);
   const [showQuizDialog, setShowQuizDialog] = useState(false);
@@ -426,6 +428,7 @@ export function WorkspaceHeader({
         if (folder) {
           setRenamingTarget({ id: folderId, type: "folder" });
           setRenameValue(folder.name);
+          setRenameTouched(false);
           setShowRenameDialog(true);
         }
       } else {
@@ -468,6 +471,7 @@ export function WorkspaceHeader({
     (itemId: string, itemName: string) => {
       setRenamingTarget({ id: itemId, type: "item" });
       setRenameValue(itemName);
+      setRenameTouched(false);
       setShowRenameDialog(true);
     },
     [],
@@ -863,6 +867,12 @@ export function WorkspaceHeader({
     }
   }, [showRenameDialog]);
 
+  useEffect(() => {
+    if (showRenameDialog) {
+      setRenameTouched(false);
+    }
+  }, [showRenameDialog]);
+
   // Listen for drag hover events on breadcrumb elements
   useEffect(() => {
     const handleDragHover = (e: Event) => {
@@ -915,8 +925,15 @@ export function WorkspaceHeader({
 
   const handleYouTubeCreate = useCallback(
     (url: string, name: string, thumbnail?: string) => {
-      if (addItem) {
+      if (!addItem) return;
+      try {
         addItem("youtube", name, { url, thumbnail });
+      } catch (error) {
+        logger.error("[WORKSPACE_HEADER] Failed to create YouTube item:", error);
+        toast.error(
+          error instanceof Error ? error.message : "Could not create YouTube item",
+        );
+        return;
       }
       setIsNewMenuOpen(false);
     },
@@ -995,12 +1012,20 @@ export function WorkspaceHeader({
   const handleWebsiteCreate = useCallback(
     (url: string, name: string, favicon?: string) => {
       if (!addItem) return;
-      addItem(
-        "website",
-        name,
-        { url, favicon },
-        DEFAULT_CARD_DIMENSIONS.website,
-      );
+      try {
+        addItem(
+          "website",
+          name,
+          { url, favicon },
+          DEFAULT_CARD_DIMENSIONS.website,
+        );
+      } catch (error) {
+        logger.error("[WORKSPACE_HEADER] Failed to create website item:", error);
+        toast.error(
+          error instanceof Error ? error.message : "Could not create website item",
+        );
+        return;
+      }
       setIsNewMenuOpen(false);
     },
     [addItem],
@@ -1406,7 +1431,10 @@ export function WorkspaceHeader({
               <Input
                 ref={renameInputRef}
                 value={renameValue}
-                onChange={(e) => setRenameValue(e.target.value)}
+                onChange={(e) => {
+                  setRenameValue(e.target.value);
+                  setRenameTouched(true);
+                }}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" && renameValidation.valid) {
                     handleRename();
@@ -1420,7 +1448,7 @@ export function WorkspaceHeader({
                     : "Item name"
                 }
               />
-              {!renameValidation.valid && renameValue.length > 0 && (
+              {renameTouched && !renameValidation.valid && (
                 <p className="text-xs text-destructive mt-2">
                   {renameValidation.error}
                 </p>

--- a/src/components/workspace-canvas/WorkspaceSection.tsx
+++ b/src/components/workspace-canvas/WorkspaceSection.tsx
@@ -61,6 +61,7 @@ import {
   getDocumentUploadPartialMessage,
   getDocumentUploadSuccessMessage,
 } from "@/lib/uploads/upload-feedback";
+import { logger } from "@/lib/utils/logger";
 
 interface WorkspaceSectionProps {
   // Loading states
@@ -167,7 +168,15 @@ export function WorkspaceSection({
   const handleYouTubeCreate = useCallback(
     (url: string, name: string, thumbnail?: string) => {
       if (addItem) {
-        addItem("youtube", name, { url, thumbnail });
+        try {
+          addItem("youtube", name, { url, thumbnail });
+        } catch (error) {
+          logger.error("[WORKSPACE_SECTION] Failed to create YouTube item:", error);
+          toast.error(
+            error instanceof Error ? error.message : "Could not create YouTube item",
+          );
+          return;
+        }
       }
     },
     [addItem],
@@ -176,14 +185,21 @@ export function WorkspaceSection({
   const handleWebsiteCreate = useCallback(
     (url: string, name: string, favicon?: string) => {
       if (!operations) return;
-      operations.createItems([
-        {
-          type: "website",
-          name,
-          initialData: { url, favicon },
-          initialLayout: DEFAULT_CARD_DIMENSIONS.website,
-        },
-      ]);
+      try {
+        operations.createItems([
+          {
+            type: "website",
+            name,
+            initialData: { url, favicon },
+            initialLayout: DEFAULT_CARD_DIMENSIONS.website,
+          },
+        ]);
+      } catch (error) {
+        logger.error("[WORKSPACE_SECTION] Failed to create website item:", error);
+        toast.error(
+          error instanceof Error ? error.message : "Could not create item",
+        );
+      }
     },
     [operations],
   );
@@ -323,7 +339,18 @@ export function WorkspaceSection({
     }
 
     // Create folder with items atomically in a single event
-    operations.createFolderWithItems("New Folder", safeItemIds);
+    try {
+      operations.createFolderWithItems("New Folder", safeItemIds);
+    } catch (error) {
+      logger.error(
+        "[WORKSPACE_SECTION] Failed to create folder from selection:",
+        error,
+      );
+      toast.error(
+        error instanceof Error ? error.message : "Could not create folder",
+      );
+      return;
+    }
 
     // Clear the selection
     clearCardSelection();
@@ -386,9 +413,19 @@ export function WorkspaceSection({
         imageLayout: DEFAULT_CARD_DIMENSIONS.image,
       });
 
-      const createdIds = operations.createItems(itemDefinitions, {
-        showSuccessToast: false,
-      });
+      let createdIds: string[];
+      try {
+        createdIds = operations.createItems(itemDefinitions, {
+          showSuccessToast: false,
+        });
+      } catch (error) {
+        logger.error("[WORKSPACE_SECTION] Failed to create uploaded items:", error);
+        toast.dismiss(uploadToastId);
+        toast.error(
+          `Could not create items: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
+        return;
+      }
       handleCreatedItems(createdIds);
 
       void startAssetProcessing({

--- a/src/hooks/workspace/use-workspace-operations.ts
+++ b/src/hooks/workspace/use-workspace-operations.ts
@@ -403,7 +403,7 @@ export function useWorkspaceOperations(
         const validation = validateItemName(name);
         if (!validation.valid) {
           toast.error(validation.error);
-          return "";
+          throw new Error(validation.error);
         }
         finalName = validation.normalized;
       } else {
@@ -490,6 +490,15 @@ export function useWorkspaceOperations(
       const itemsForLayout = [...itemsInCurrentView];
       const itemsSoFar: Item[] = [];
 
+      for (const { name } of items) {
+        if (name === undefined) continue;
+        const validation = validateItemName(name);
+        if (!validation.valid) {
+          toast.error(`Invalid item name: ${validation.error}`);
+          throw new Error(validation.error);
+        }
+      }
+
       const createdItems: Item[] = items
         .map(({ type, name, initialData, initialLayout }) => {
           const validTypes: CardType[] = [
@@ -508,11 +517,7 @@ export function useWorkspaceOperations(
           const folderId = activeFolderId ?? null;
           let finalName: string;
           if (name !== undefined) {
-            const validation = validateItemName(name);
-            if (!validation.valid) {
-              return null;
-            }
-            finalName = validation.normalized;
+            finalName = name.trim();
           } else {
             const allItemsSoFar = [...itemsInCurrentView, ...itemsSoFar];
             finalName = getNextUniqueDefaultName(
@@ -784,11 +789,10 @@ export function useWorkspaceOperations(
         const validation = validateItemName(name);
         if (!validation.valid) {
           toast.error(validation.error);
-          return null;
+          throw new Error(validation.error);
         }
         return validation.normalized;
       })();
-      if (resolvedName === null) return "";
 
       const folderId = crypto.randomUUID();
       const activeFolderId = useUIStore.getState().activeFolderId;
@@ -833,11 +837,10 @@ export function useWorkspaceOperations(
         const validation = validateItemName(name);
         if (!validation.valid) {
           toast.error(validation.error);
-          return null;
+          throw new Error(validation.error);
         }
         return validation.normalized;
       })();
-      if (resolvedName === null) return "";
 
       const activeFolderId = useUIStore.getState().activeFolderId;
       const safeItemIds = filterItemIdsForFolderCreation(

--- a/src/hooks/workspace/use-workspace-operations.ts
+++ b/src/hooks/workspace/use-workspace-operations.ts
@@ -22,6 +22,7 @@ import {
   hasDuplicateName,
   getNextUniqueDefaultName,
 } from "@/lib/workspace/unique-name";
+import { validateItemName } from "@/lib/workspace/name-rules";
 import { filterItemIdsForFolderCreation } from "@/lib/workspace-state/search";
 import {
   sanitizeWorkspaceItemChanges,
@@ -230,6 +231,17 @@ export function useWorkspaceOperations(
         return;
       }
 
+      if ("name" in finalChanges && finalChanges.name !== undefined) {
+        const validation = validateItemName(finalChanges.name);
+        if (!validation.valid) {
+          toast.error(validation.error);
+          pendingItemChangesRef.current.delete(itemId);
+          updateItemDebouncerRef.current.delete(itemId);
+          return;
+        }
+        finalChanges.name = validation.normalized;
+      }
+
       const newName = finalChanges.name ?? item.name;
       const newType = finalChanges.type ?? item.type;
       const folderId = finalChanges.folderId ?? item.folderId ?? null;
@@ -386,9 +398,21 @@ export function useWorkspaceOperations(
       const id = crypto.randomUUID();
       const activeFolderId = useUIStore.getState().activeFolderId;
       const folderId = activeFolderId ?? null;
-      const finalName =
-        name ||
-        getNextUniqueDefaultName(currentItemsRef.current, validType, folderId);
+      let finalName: string;
+      if (name !== undefined) {
+        const validation = validateItemName(name);
+        if (!validation.valid) {
+          toast.error(validation.error);
+          return "";
+        }
+        finalName = validation.normalized;
+      } else {
+        finalName = getNextUniqueDefaultName(
+          currentItemsRef.current,
+          validType,
+          folderId,
+        );
+      }
 
       const baseData = defaultDataFor(validType);
       const mergedData = initialData
@@ -482,10 +506,23 @@ export function useWorkspaceOperations(
           const validType = validTypes.includes(type) ? type : "document";
           const id = crypto.randomUUID();
           const folderId = activeFolderId ?? null;
+          let finalName: string;
+          if (name !== undefined) {
+            const validation = validateItemName(name);
+            if (!validation.valid) {
+              return null;
+            }
+            finalName = validation.normalized;
+          } else {
+            const allItemsSoFar = [...itemsInCurrentView, ...itemsSoFar];
+            finalName = getNextUniqueDefaultName(
+              allItemsSoFar,
+              validType,
+              folderId,
+            );
+          }
+
           const allItemsSoFar = [...itemsInCurrentView, ...itemsSoFar];
-          const finalName =
-            name ||
-            getNextUniqueDefaultName(allItemsSoFar, validType, folderId);
 
           if (
             name &&
@@ -742,12 +779,23 @@ export function useWorkspaceOperations(
 
   const createFolder = useCallback(
     (name: string, color?: CardColor): string => {
+      const resolvedName = (() => {
+        if (!name || !name.trim()) return "New Folder";
+        const validation = validateItemName(name);
+        if (!validation.valid) {
+          toast.error(validation.error);
+          return null;
+        }
+        return validation.normalized;
+      })();
+      if (resolvedName === null) return "";
+
       const folderId = crypto.randomUUID();
       const activeFolderId = useUIStore.getState().activeFolderId;
       const folder = sanitizeWorkspaceItemForPersistence({
         id: folderId,
         type: "folder",
-        name: name || "New Folder",
+        name: resolvedName,
         subtitle: "",
         data: defaultDataFor("folder") as ItemData,
         color: color || getRandomCardColor(),
@@ -780,6 +828,17 @@ export function useWorkspaceOperations(
 
   const createFolderWithItems = useCallback(
     (name: string, itemIds: string[], color?: CardColor): string => {
+      const resolvedName = (() => {
+        if (!name || !name.trim()) return "New Folder";
+        const validation = validateItemName(name);
+        if (!validation.valid) {
+          toast.error(validation.error);
+          return null;
+        }
+        return validation.normalized;
+      })();
+      if (resolvedName === null) return "";
+
       const activeFolderId = useUIStore.getState().activeFolderId;
       const safeItemIds = filterItemIdsForFolderCreation(
         itemIds,
@@ -798,7 +857,7 @@ export function useWorkspaceOperations(
       const folder = sanitizeWorkspaceItemForPersistence({
         id: folderId,
         type: "folder",
-        name: name || "New Folder",
+        name: resolvedName,
         subtitle: "",
         data: defaultDataFor("folder") as ItemData,
         color: color || getRandomCardColor(),

--- a/src/lib/ai/tools/__tests__/edit-item-tool.test.ts
+++ b/src/lib/ai/tools/__tests__/edit-item-tool.test.ts
@@ -52,7 +52,7 @@ describe("createEditItemTool", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockLoadStateForTool.mockResolvedValue({ success: true, state: { items: [documentItem] } });
-    mockResolveItem.mockReturnValue(documentItem);
+    mockResolveItem.mockReturnValue({ ok: true, item: documentItem });
     mockWorkspaceWorker.mockResolvedValue({ success: true, itemId: "doc-1", message: "ok" });
     mockGetVirtualPath.mockReturnValue("documents/My Document.md");
   });
@@ -74,7 +74,7 @@ describe("createEditItemTool", () => {
   });
 
   it("returns item not found message when resolveItem misses", async () => {
-    mockResolveItem.mockReturnValueOnce(undefined);
+    mockResolveItem.mockReturnValueOnce({ ok: false, reason: "not-found" });
     const tool: any = createEditItemTool(ctx);
     const result = await tool.execute({ itemName: "Unknown", edits: [{ oldText: "a", newText: "b" }] });
     expect(result.success).toBe(false);
@@ -87,7 +87,11 @@ describe("createEditItemTool", () => {
       success: true,
       state: { items: [documentItem, duplicate] },
     });
-    mockResolveItem.mockReturnValueOnce(documentItem);
+    mockResolveItem.mockReturnValueOnce({
+      ok: false,
+      reason: "ambiguous",
+      matches: [documentItem, duplicate],
+    });
     mockGetVirtualPath
       .mockReturnValueOnce("documents/My Document.md")
       .mockReturnValueOnce("folder/My Document.md");
@@ -101,7 +105,7 @@ describe("createEditItemTool", () => {
 
   it("rejects non-editable item types", async () => {
     const imageItem = { id: "img-1", type: "image", name: "Figure", data: {} };
-    mockResolveItem.mockReturnValueOnce(imageItem);
+    mockResolveItem.mockReturnValueOnce({ ok: true, item: imageItem });
     mockLoadStateForTool.mockResolvedValueOnce({ success: true, state: { items: [imageItem] } });
 
     const tool: any = createEditItemTool(ctx);
@@ -112,7 +116,7 @@ describe("createEditItemTool", () => {
 
   it("allows PDF rename-only and rejects PDF content edits", async () => {
     const pdfItem = { id: "pdf-1", type: "pdf", name: "Syllabus.pdf", data: { fileUrl: "x", filename: "Syllabus.pdf" } };
-    mockResolveItem.mockReturnValueOnce(pdfItem);
+    mockResolveItem.mockReturnValueOnce({ ok: true, item: pdfItem });
     mockLoadStateForTool.mockResolvedValueOnce({ success: true, state: { items: [pdfItem] } });
 
     const tool: any = createEditItemTool(ctx);
@@ -120,7 +124,7 @@ describe("createEditItemTool", () => {
     expect(contentEditResult.success).toBe(false);
     expect(contentEditResult.message).toMatch(/rename only|can only be renamed/i);
 
-    mockResolveItem.mockReturnValueOnce(pdfItem);
+    mockResolveItem.mockReturnValueOnce({ ok: true, item: pdfItem });
     mockLoadStateForTool.mockResolvedValueOnce({ success: true, state: { items: [pdfItem] } });
     mockWorkspaceWorker.mockResolvedValueOnce({ success: true, itemId: "pdf-1", message: "Renamed PDF" });
 

--- a/src/lib/ai/tools/edit-item-tool.ts
+++ b/src/lib/ai/tools/edit-item-tool.ts
@@ -29,7 +29,7 @@ export function createEditItemTool(ctx: WorkspaceToolContext) {
                 .object({
                     itemName: z
                         .string()
-                        .describe("Exact name (case-insensitive) or virtual path of the item to edit. If multiple items share the same name, pass a virtual path to disambiguate."),
+                        .describe("Exact name (case-insensitive) or virtual path of a document, flashcard deck, quiz, or PDF. Folders and other non-editable types are ignored. If multiple editable items share the same name, pass a virtual path to disambiguate."),
                     edits: z.array(z.object({
                         oldText: z.string().describe("Exact text to find in the original content. Must be unique. Copy from workspace_read as-is."),
                         newText: z.string().describe("Replacement text for this edit."),
@@ -95,7 +95,10 @@ export function createEditItemTool(ctx: WorkspaceToolContext) {
                 }
 
                 const state = normalizeWorkspaceItems(accessResult.state);
-                const resolved = resolveItem(state, itemName);
+                const editableItems = state.filter((i) =>
+                    EDITABLE_TYPES.includes(i.type as (typeof EDITABLE_TYPES)[number]),
+                );
+                const resolved = resolveItem(editableItems, itemName);
                 if (!resolved.ok) {
                     if (resolved.reason === "ambiguous") {
                         const paths = resolved.matches

--- a/src/lib/ai/tools/edit-item-tool.ts
+++ b/src/lib/ai/tools/edit-item-tool.ts
@@ -29,7 +29,7 @@ export function createEditItemTool(ctx: WorkspaceToolContext) {
                 .object({
                     itemName: z
                         .string()
-                        .describe("Name of the item to edit (document, flashcard deck, quiz, or PDF; matched by fuzzy search)"),
+                        .describe("Exact name (case-insensitive) or virtual path of the item to edit. If multiple items share the same name, pass a virtual path to disambiguate."),
                     edits: z.array(z.object({
                         oldText: z.string().describe("Exact text to find in the original content. Must be unique. Copy from workspace_read as-is."),
                         newText: z.string().describe("Replacement text for this edit."),
@@ -95,9 +95,17 @@ export function createEditItemTool(ctx: WorkspaceToolContext) {
                 }
 
                 const state = normalizeWorkspaceItems(accessResult.state);
-                const matchedItem = resolveItem(state, itemName);
-
-                if (!matchedItem) {
+                const resolved = resolveItem(state, itemName);
+                if (!resolved.ok) {
+                    if (resolved.reason === "ambiguous") {
+                        const paths = resolved.matches
+                            .map((m) => getVirtualPath(m, state))
+                            .join(", ");
+                        return {
+                            success: false,
+                            message: `Multiple items named "${itemName}". Disambiguate using path: ${paths}`,
+                        };
+                    }
                     const sample = state
                         .filter((i) => i.type !== "folder")
                         .slice(0, 5)
@@ -108,18 +116,7 @@ export function createEditItemTool(ctx: WorkspaceToolContext) {
                         message: `Could not find item "${itemName}". ${sample ? `Example items: ${sample}` : "Workspace may be empty."}`,
                     };
                 }
-
-                const contentItems = state.filter((i) => i.type !== "folder");
-                const sameNameCandidates = contentItems.filter(
-                    (i) => i.name.toLowerCase().trim() === matchedItem.name.toLowerCase().trim()
-                );
-                if (sameNameCandidates.length > 1) {
-                    const paths = sameNameCandidates.map((c) => getVirtualPath(c, state)).join(", ");
-                    return {
-                        success: false,
-                        message: `Multiple items named "${matchedItem.name}". Disambiguate using path: ${paths}`,
-                    };
-                }
+                const matchedItem = resolved.item;
 
                 if (!EDITABLE_TYPES.includes(matchedItem.type as (typeof EDITABLE_TYPES)[number])) {
                     return {
@@ -135,7 +132,7 @@ export function createEditItemTool(ctx: WorkspaceToolContext) {
                     };
                 }
 
-                logger.debug("🎯 [EDIT-ITEM] Found item via fuzzy match:", {
+                logger.debug("🎯 [EDIT-ITEM] Resolved item for edit:", {
                     searchedName: itemName,
                     matchedName: matchedItem.name,
                     matchedId: matchedItem.id,

--- a/src/lib/ai/tools/read-workspace.ts
+++ b/src/lib/ai/tools/read-workspace.ts
@@ -1,7 +1,6 @@
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
-import { loadStateForTool } from "./tool-utils";
-import { fuzzyMatchItem } from "./tool-utils";
+import { loadStateForTool, resolveItem } from "./tool-utils";
 import { resolveItemByPath } from "./workspace-search-utils";
 import { formatItemContent } from "@/lib/utils/format-workspace-context";
 import { getVirtualPath } from "@/lib/utils/workspace-fs";
@@ -57,7 +56,7 @@ export function createReadWorkspaceTool(ctx: WorkspaceToolContext) {
                     .string()
                     .optional()
                     .describe(
-                        "Name for fuzzy match — use when path unknown; if multiple items share the name, use path instead"
+                        "Exact name (case-insensitive). If multiple items share the same name, use path to disambiguate. Pass a virtual path for unambiguous resolution."
                     ),
                 lineStart: z
                     .number()
@@ -108,25 +107,16 @@ export function createReadWorkspaceTool(ctx: WorkspaceToolContext) {
             }
 
             if (!item && itemName?.trim()) {
-                const exactMatches = items.filter(
-                    (i) =>
-                        i.type !== "folder" &&
-                        i.name.toLowerCase().trim() === itemName.toLowerCase().trim()
-                );
-                if (exactMatches.length > 1) {
-                    const paths = exactMatches.map((m) => getVirtualPath(m, items)).join(", ");
+                const contentItems = items.filter((i) => i.type !== "folder");
+                const resolved = resolveItem(contentItems, itemName.trim());
+                if (resolved.ok) {
+                    item = resolved.item;
+                } else if (resolved.reason === "ambiguous") {
+                    const paths = resolved.matches.map((m) => getVirtualPath(m, items)).join(", ");
                     return {
                         success: false,
                         message: `Multiple items named "${itemName}". Use path to disambiguate: ${paths}`,
                     };
-                }
-                if (exactMatches.length === 1) {
-                    item = exactMatches[0]!;
-                } else {
-                    item = fuzzyMatchItem(
-                        items.filter((i) => i.type !== "folder"),
-                        itemName.trim()
-                    );
                 }
             }
 

--- a/src/lib/ai/tools/tool-utils.ts
+++ b/src/lib/ai/tools/tool-utils.ts
@@ -69,65 +69,48 @@ export async function loadStateForTool(
   return { success: true, state };
 }
 
+export type ResolveItemResult =
+  | { ok: true; item: Item }
+  | { ok: false; reason: "empty"; matches?: never }
+  | { ok: false; reason: "not-found"; matches?: never }
+  | { ok: false; reason: "ambiguous"; matches: Item[] };
+
 /**
- * Resolve an item by virtual path or fuzzy name match.
- * Tries virtual path first when input looks like a path (contains /),
- * then falls back to fuzzyMatchItem for plain names.
- * If itemType is provided, only returns items of that type.
+ * Resolve a workspace item from a path OR exact (case-insensitive) name.
+ *
+ * Resolution order:
+ *   1. If input contains "/", try virtual-path match via resolveItemByPath.
+ *   2. Otherwise (or on path miss), match by exact name, case-insensitive after trim.
+ *
+ * When itemType is given, only items of that type are considered.
+ * When itemType is omitted, folders are included (item_delete may target folders).
+ *
+ * Returns ambiguity explicitly when two or more items share the same name —
+ * callers should surface the virtual paths and require the caller to disambiguate.
  */
 export function resolveItem(
   items: Item[],
   input: string,
   itemType?: Item["type"],
-): Item | undefined {
+): ResolveItemResult {
   const trimmed = input.trim();
-  if (!trimmed) return undefined;
+  if (!trimmed) return { ok: false, reason: "empty" };
 
-  // 1. Try virtual path first when input looks like a path
+  const typeOk = (i: Item) => !itemType || i.type === itemType;
+
   if (trimmed.includes("/")) {
     const byPath = resolveItemByPath(items, trimmed);
-    if (byPath && (!itemType || byPath.type === itemType)) return byPath;
+    if (byPath && typeOk(byPath)) return { ok: true, item: byPath };
   }
 
-  // 2. Fall back to fuzzy name match
-  return fuzzyMatchItem(items, trimmed, itemType);
-}
-
-/**
- * Fuzzy match an item by name within a list of items
- * Tries: exact match -> contains match -> reverse contains match
- * If itemType is provided, only matches items of that type
- */
-export function fuzzyMatchItem(
-  items: Item[],
-  searchName: string,
-  itemType?: Item["type"],
-): Item | undefined {
-  const normalizedSearch = searchName.toLowerCase().trim();
-  const filteredItems = itemType
-    ? items.filter((item) => item.type === itemType)
-    : items;
-
-  // 1. Exact match
-  let matched = filteredItems.find(
-    (item) => item.name.toLowerCase().trim() === normalizedSearch,
+  const normalized = trimmed.toLowerCase();
+  const matches = items.filter(
+    (i) => typeOk(i) && i.name.toLowerCase().trim() === normalized,
   );
 
-  // 2. Contains match (item name contains search)
-  if (!matched) {
-    matched = filteredItems.find((item) =>
-      item.name.toLowerCase().includes(normalizedSearch),
-    );
-  }
-
-  // 3. Reverse contains match (search contains item name)
-  if (!matched) {
-    matched = filteredItems.find((item) =>
-      normalizedSearch.includes(item.name.toLowerCase().trim()),
-    );
-  }
-
-  return matched;
+  if (matches.length === 1) return { ok: true, item: matches[0] };
+  if (matches.length > 1) return { ok: false, reason: "ambiguous", matches };
+  return { ok: false, reason: "not-found" };
 }
 
 /**

--- a/src/lib/ai/tools/workspace-tools.ts
+++ b/src/lib/ai/tools/workspace-tools.ts
@@ -2,10 +2,10 @@ import { tool, zodSchema } from "ai";
 import { z } from "zod";
 import { logger } from "@/lib/utils/logger";
 import { workspaceWorker } from "@/lib/ai/workers";
-import type { Item } from "@/lib/workspace-state/types";
-import { loadStateForTool, resolveItem, getAvailableItemsList, withSanitizedModelOutput } from "./tool-utils";
+import { loadStateForTool, resolveItem, withSanitizedModelOutput } from "./tool-utils";
 import { normalizeWorkspaceItems } from "@/lib/workspace-state/state";
 import { sourceSchema } from "@/lib/workspace-state/item-data-schemas";
+import { getVirtualPath } from "@/lib/utils/workspace-fs";
 
 // Note: Edit functionality is in edit-item-tool.ts (item_edit)
 
@@ -74,7 +74,7 @@ export function createDocumentTool(ctx: WorkspaceToolContext) {
  */
 export function createDeleteItemTool(ctx: WorkspaceToolContext) {
     return withSanitizedModelOutput(tool({
-        description: "Delete a workspace item by name. This permanently removes it from the workspace.",
+        description: "Delete a workspace item by exact name or virtual path (e.g. pdfs/Report.pdf). Names are matched case-insensitively and must be exact. If multiple items share the same name, pass a virtual path instead.",
         inputSchema: zodSchema(
             z.object({
                 itemName: z.string().describe("Item name or virtual path (e.g. pdfs/Report.pdf) to delete"),
@@ -100,18 +100,26 @@ export function createDeleteItemTool(ctx: WorkspaceToolContext) {
 
                 const state = normalizeWorkspaceItems(accessResult.state);
 
-                // Resolve by virtual path or fuzzy name match (any type)
-                const matchedItem = resolveItem(state, itemName);
-
-                if (!matchedItem) {
+                const resolved = resolveItem(state, itemName);
+                if (!resolved.ok) {
+                    if (resolved.reason === "ambiguous") {
+                        const paths = resolved.matches
+                            .map((m) => `"${getVirtualPath(m, state)}"`)
+                            .join(", ");
+                        return {
+                            success: false,
+                            message: `Multiple items named "${itemName}". Pass a virtual path to disambiguate: ${paths}`,
+                        };
+                    }
                     const availableItems = state.map(i => `"${i.name}" (${i.type})`).slice(0, 5).join(", ");
                     return {
                         success: false,
                         message: `Could not find item "${itemName}". ${availableItems ? `Available items: ${availableItems}` : 'No items found in workspace.'}`,
                     };
                 }
+                const matchedItem = resolved.item;
 
-                logger.debug("🎯 [DELETE-ITEM] Found item via fuzzy match:", {
+                logger.debug("🎯 [DELETE-ITEM] Resolved item:", {
                     searchedName: itemName,
                     matchedName: matchedItem.name,
                     matchedId: matchedItem.id,

--- a/src/lib/ai/workers/workspace-worker.ts
+++ b/src/lib/ai/workers/workspace-worker.ts
@@ -34,6 +34,7 @@ import {
   upsertWorkspaceItem,
 } from "@/lib/workspace/workspace-item-write";
 import { sanitizeWorkspaceItemForPersistence } from "@/lib/workspace/workspace-item-sanitize";
+import { validateItemName } from "@/lib/workspace/name-rules";
 
 /** Create params for a single item (used by create and bulkCreate). Exported for autogen. */
 export type CreateItemParams = {
@@ -85,6 +86,14 @@ export type CreateItemParams = {
 async function buildItemFromCreateParams(p: CreateItemParams): Promise<Item> {
   const itemId = p.id || crypto.randomUUID();
   const itemType = p.itemType || "document";
+  let providedTitle: string | undefined;
+  if (p.title !== undefined) {
+    const validation = validateItemName(p.title);
+    if (!validation.valid) {
+      throw new Error(`Invalid item name: ${validation.error}`);
+    }
+    providedTitle = validation.normalized;
+  }
 
   let itemData: any;
 
@@ -173,7 +182,7 @@ async function buildItemFromCreateParams(p: CreateItemParams): Promise<Item> {
   return {
     id: itemId,
     type: itemType,
-    name: p.title || defaultNames[itemType] || "New Document",
+    name: providedTitle || defaultNames[itemType] || "New Document",
     subtitle: "",
     data: itemData,
     color: getRandomCardColor(),
@@ -445,9 +454,14 @@ export async function workspaceWorker(
           const changes: any = hasQuestions ? { data: updatedData } : {};
 
           if (params.title) {
+            const validation = validateItemName(params.title);
+            if (!validation.valid) {
+              return { success: false, message: validation.error };
+            }
+            const normalizedTitle = validation.normalized;
             const dupError = checkDuplicateName(
               currentState,
-              params.title,
+              normalizedTitle,
               existingItem.type,
               existingItem.folderId ?? null,
               params.itemId,
@@ -455,7 +469,7 @@ export async function workspaceWorker(
             if (dupError) {
               return { success: false, message: dupError };
             }
-            changes.name = params.title;
+            changes.name = normalizedTitle;
           }
 
           await updateWorkspaceItem(
@@ -524,9 +538,14 @@ export async function workspaceWorker(
           const changes: Partial<Item> = { data: updatedData };
 
           if (params.title) {
+            const validation = validateItemName(params.title);
+            if (!validation.valid) {
+              return { success: false, message: validation.error };
+            }
+            const normalizedTitle = validation.normalized;
             const dupError = checkDuplicateName(
               currentState,
-              params.title,
+              normalizedTitle,
               existingItem.type,
               existingItem.folderId ?? null,
               params.itemId,
@@ -534,7 +553,7 @@ export async function workspaceWorker(
             if (dupError) {
               return { success: false, message: dupError };
             }
-            changes.name = params.title;
+            changes.name = normalizedTitle;
           }
 
           await updateWorkspaceItem(
@@ -695,9 +714,14 @@ export async function workspaceWorker(
               data: { ...data, cards: newCards } as FlashcardData,
             };
             if (rename) {
+              const validation = validateItemName(rename);
+              if (!validation.valid) {
+                return { success: false, message: validation.error };
+              }
+              const normalizedRename = validation.normalized;
               const dupError = checkDuplicateName(
                 currentState,
-                rename,
+                normalizedRename,
                 "flashcard",
                 existingItem.folderId ?? null,
                 params.itemId,
@@ -705,7 +729,7 @@ export async function workspaceWorker(
               if (dupError) {
                 return { success: false, message: dupError };
               }
-              changes.name = rename;
+              changes.name = normalizedRename;
             }
 
             await updateWorkspaceItem(
@@ -796,9 +820,14 @@ export async function workspaceWorker(
 
             const changes: Partial<Item> = { data: updatedData };
             if (rename) {
+              const validation = validateItemName(rename);
+              if (!validation.valid) {
+                return { success: false, message: validation.error };
+              }
+              const normalizedRename = validation.normalized;
               const dupError = checkDuplicateName(
                 currentState,
-                rename,
+                normalizedRename,
                 "quiz",
                 existingItem.folderId ?? null,
                 params.itemId,
@@ -806,7 +835,7 @@ export async function workspaceWorker(
               if (dupError) {
                 return { success: false, message: dupError };
               }
-              changes.name = rename;
+              changes.name = normalizedRename;
             }
 
             await updateWorkspaceItem(
@@ -831,9 +860,14 @@ export async function workspaceWorker(
             const changes: Partial<Item> = {};
             const docData = existingItem.data as DocumentData;
             if (rename) {
+              const validation = validateItemName(rename);
+              if (!validation.valid) {
+                return { success: false, message: validation.error };
+              }
+              const normalizedRename = validation.normalized;
               const dupError = checkDuplicateName(
                 currentState,
-                rename,
+                normalizedRename,
                 "document",
                 existingItem.folderId ?? null,
                 params.itemId,
@@ -841,7 +875,7 @@ export async function workspaceWorker(
               if (dupError) {
                 return { success: false, message: dupError };
               }
-              changes.name = rename;
+              changes.name = normalizedRename;
             }
 
             let contentOld = "";
@@ -927,9 +961,14 @@ export async function workspaceWorker(
                   "PDFs can only be renamed. Use empty edits array [] with newName='new name'.",
               };
             }
+            const validation = validateItemName(rename);
+            if (!validation.valid) {
+              return { success: false, message: validation.error };
+            }
+            const normalizedRename = validation.normalized;
             const dupError = checkDuplicateName(
               currentState,
-              rename,
+              normalizedRename,
               "pdf",
               existingItem.folderId ?? null,
               params.itemId,
@@ -937,7 +976,7 @@ export async function workspaceWorker(
             if (dupError) {
               return { success: false, message: dupError };
             }
-            const changes: Partial<Item> = { name: rename };
+            const changes: Partial<Item> = { name: normalizedRename };
             await updateWorkspaceItem(
               params.workspaceId,
               params.itemId,
@@ -949,7 +988,7 @@ export async function workspaceWorker(
             return {
               success: true,
               itemId: params.itemId,
-              message: `Renamed PDF to "${rename}"`,
+              message: `Renamed PDF to "${normalizedRename}"`,
             };
           }
 

--- a/src/lib/uploads/uploaded-asset.ts
+++ b/src/lib/uploads/uploaded-asset.ts
@@ -5,6 +5,7 @@ import type {
 } from "@/lib/workspace-state/types";
 import type { OcrCandidate } from "@/lib/ocr/types";
 import { buildPdfDataFromUpload, getPdfSourceUrl } from "@/lib/pdf/pdf-item";
+import { INVALID_NAME_CHARS_REGEX_GLOBAL } from "@/lib/workspace/name-rules";
 
 export type UploadedAssetKind = "file" | "image" | "audio";
 
@@ -41,6 +42,14 @@ export type WorkspaceItemDefinition =
 
 function getBaseName(filename: string): string {
   return filename.replace(/\.[^/.]+$/, "");
+}
+
+function toItemName(raw: string): string {
+  const cleaned = raw.replace(INVALID_NAME_CHARS_REGEX_GLOBAL, "-").trim();
+  if (cleaned.length === 0 || cleaned === "." || cleaned === "..") {
+    return "Untitled";
+  }
+  return cleaned;
 }
 
 function getResolvedContentType(params: {
@@ -97,13 +106,15 @@ export function buildWorkspaceItemDefinitionFromAsset(
   asset: UploadedAsset,
   options?: { imageLayout?: { w: number; h: number } }
 ): WorkspaceItemDefinition {
+  const itemName = toItemName(asset.name);
+
   if (asset.kind === "image") {
     return {
       type: "image",
-      name: asset.name,
+      name: itemName,
       initialData: {
         url: asset.fileUrl,
-        altText: asset.name,
+        altText: itemName,
         ocrStatus: "processing",
         ocrPages: [],
       },
@@ -114,7 +125,7 @@ export function buildWorkspaceItemDefinitionFromAsset(
   if (asset.kind === "audio") {
     return {
       type: "audio",
-      name: asset.name,
+      name: itemName,
       initialData: {
         fileUrl: asset.fileUrl,
         filename: asset.filename,
@@ -127,7 +138,7 @@ export function buildWorkspaceItemDefinitionFromAsset(
 
   return {
     type: "pdf",
-    name: asset.name,
+    name: itemName,
     initialData: buildPdfDataFromUpload({
       fileUrl: asset.fileUrl,
       filename: asset.filename,

--- a/src/lib/workspace/__tests__/name-rules.test.ts
+++ b/src/lib/workspace/__tests__/name-rules.test.ts
@@ -93,6 +93,30 @@ describe("validateItemName", () => {
     });
   });
 
+  it("counts emoji by Unicode code point length", () => {
+    expect(validateItemName("📘".repeat(MAX_ITEM_NAME_LENGTH))).toEqual({
+      valid: true,
+      normalized: "📘".repeat(MAX_ITEM_NAME_LENGTH),
+    });
+    expect(validateItemName("📘".repeat(MAX_ITEM_NAME_LENGTH + 1))).toEqual({
+      valid: false,
+      error: `Name is too long (max ${MAX_ITEM_NAME_LENGTH} characters)`,
+    });
+  });
+
+  it("counts mixed ascii and emoji names by code points", () => {
+    expect(
+      validateItemName("a".repeat(MAX_ITEM_NAME_LENGTH - 1) + "📘"),
+    ).toEqual({
+      valid: true,
+      normalized: "a".repeat(MAX_ITEM_NAME_LENGTH - 1) + "📘",
+    });
+    expect(validateItemName("a".repeat(MAX_ITEM_NAME_LENGTH) + "📘")).toEqual({
+      valid: false,
+      error: `Name is too long (max ${MAX_ITEM_NAME_LENGTH} characters)`,
+    });
+  });
+
   it("keeps default names valid and unchanged", () => {
     for (const raw of [
       "New Document 1",

--- a/src/lib/workspace/__tests__/name-rules.test.ts
+++ b/src/lib/workspace/__tests__/name-rules.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_ITEM_NAME_LENGTH,
+  validateItemName,
+} from "@/lib/workspace/name-rules";
+
+describe("validateItemName", () => {
+  it("rejects empty after trim", () => {
+    expect(validateItemName("")).toEqual({
+      valid: false,
+      error: "Name cannot be empty",
+    });
+    expect(validateItemName("   hello   ")).toEqual({
+      valid: true,
+      normalized: "hello",
+    });
+  });
+
+  it("rejects whitespace-only names", () => {
+    expect(validateItemName("   ")).toEqual({
+      valid: false,
+      error: "Name cannot be empty",
+    });
+  });
+
+  it("rejects non-string input", () => {
+    expect(validateItemName(null)).toEqual({
+      valid: false,
+      error: "Name must be a string",
+    });
+    expect(validateItemName(123)).toEqual({
+      valid: false,
+      error: "Name must be a string",
+    });
+  });
+
+  it("rejects names longer than 255 characters", () => {
+    expect(validateItemName("a".repeat(MAX_ITEM_NAME_LENGTH + 1))).toEqual({
+      valid: false,
+      error: `Name is too long (max ${MAX_ITEM_NAME_LENGTH} characters)`,
+    });
+  });
+
+  it("rejects each banned character", () => {
+    for (const ch of ["/", "\\", "<", ">", ":", '"', "|", "?", "*", "\u0001"]) {
+      expect(validateItemName(`bad${ch}name`)).toEqual({
+        valid: false,
+        error: 'Name cannot contain: / \\ < > : " | ? * or control characters',
+      });
+    }
+  });
+
+  it("rejects reserved names", () => {
+    expect(validateItemName(".")).toEqual({
+      valid: false,
+      error: '"." is a reserved name',
+    });
+    expect(validateItemName("..")).toEqual({
+      valid: false,
+      error: '".." is a reserved name',
+    });
+  });
+
+  it("accepts plain ascii, unicode, emoji, and middle spaces unchanged", () => {
+    for (const raw of [
+      "Plain ASCII",
+      "Résumé notes",
+      "📘 Study Plan",
+      "name with middle spaces",
+    ]) {
+      expect(validateItemName(raw)).toEqual({
+        valid: true,
+        normalized: raw.trim(),
+      });
+    }
+  });
+
+  it("trims leading and trailing spaces", () => {
+    expect(validateItemName("  My Name  ")).toEqual({
+      valid: true,
+      normalized: "My Name",
+    });
+  });
+
+  it("accepts 255 characters and rejects 256", () => {
+    expect(validateItemName("a".repeat(MAX_ITEM_NAME_LENGTH))).toEqual({
+      valid: true,
+      normalized: "a".repeat(MAX_ITEM_NAME_LENGTH),
+    });
+    expect(validateItemName("a".repeat(MAX_ITEM_NAME_LENGTH + 1))).toEqual({
+      valid: false,
+      error: `Name is too long (max ${MAX_ITEM_NAME_LENGTH} characters)`,
+    });
+  });
+
+  it("keeps default names valid and unchanged", () => {
+    for (const raw of [
+      "New Document 1",
+      "New Quiz 3",
+      "New Flashcard 12",
+    ]) {
+      expect(validateItemName(raw)).toEqual({
+        valid: true,
+        normalized: raw,
+      });
+    }
+  });
+});

--- a/src/lib/workspace/name-rules.ts
+++ b/src/lib/workspace/name-rules.ts
@@ -1,0 +1,58 @@
+/**
+ * Filesystem-style naming rules for workspace items and folders.
+ *
+ * Design goals:
+ *  - Portable: reject characters that break on Windows, macOS, or URL-safe paths.
+ *  - Reversible: a name that passes validation round-trips through getVirtualPath
+ *    unchanged (no silent sanitization).
+ *  - Predictable for humans: trim whitespace, reject empty / reserved names.
+ *
+ * These rules apply at every rename/create entry point — UI inputs,
+ * AI rename via item_edit (workspace-worker), and bulk creation flows.
+ */
+
+export const MAX_ITEM_NAME_LENGTH = 255;
+
+// Characters that either break the POSIX path model or are reserved on
+// common consumer filesystems (Windows/NTFS). Rejecting them keeps the
+// item's raw name consistent with its virtual path representation.
+export const INVALID_NAME_CHARS_REGEX = /[\/\\\x00-\x1f<>:"|?*]/;
+
+export const RESERVED_NAMES: ReadonlySet<string> = new Set([".", ".."]);
+
+export type NameValidationResult =
+  | { valid: true; normalized: string }
+  | { valid: false; error: string };
+
+/**
+ * Validate and normalize a proposed item/folder name.
+ *
+ * The returned `normalized` value (on success) is always the caller-intended
+ * display string, with leading/trailing whitespace trimmed. Callers should
+ * persist `normalized`, not the raw input.
+ */
+export function validateItemName(rawName: unknown): NameValidationResult {
+  if (typeof rawName !== "string") {
+    return { valid: false, error: "Name must be a string" };
+  }
+  const normalized = rawName.trim();
+  if (normalized.length === 0) {
+    return { valid: false, error: "Name cannot be empty" };
+  }
+  if (normalized.length > MAX_ITEM_NAME_LENGTH) {
+    return {
+      valid: false,
+      error: `Name is too long (max ${MAX_ITEM_NAME_LENGTH} characters)`,
+    };
+  }
+  if (INVALID_NAME_CHARS_REGEX.test(normalized)) {
+    return {
+      valid: false,
+      error: 'Name cannot contain: / \\ < > : " | ? * or control characters',
+    };
+  }
+  if (RESERVED_NAMES.has(normalized)) {
+    return { valid: false, error: `"${normalized}" is a reserved name` };
+  }
+  return { valid: true, normalized };
+}

--- a/src/lib/workspace/name-rules.ts
+++ b/src/lib/workspace/name-rules.ts
@@ -17,6 +17,7 @@ export const MAX_ITEM_NAME_LENGTH = 255;
 // common consumer filesystems (Windows/NTFS). Rejecting them keeps the
 // item's raw name consistent with its virtual path representation.
 export const INVALID_NAME_CHARS_REGEX = /[\/\\\x00-\x1f<>:"|?*]/;
+export const INVALID_NAME_CHARS_REGEX_GLOBAL = /[\/\\\x00-\x1f<>:"|?*]/g;
 
 export const RESERVED_NAMES: ReadonlySet<string> = new Set([".", ".."]);
 
@@ -39,7 +40,8 @@ export function validateItemName(rawName: unknown): NameValidationResult {
   if (normalized.length === 0) {
     return { valid: false, error: "Name cannot be empty" };
   }
-  if (normalized.length > MAX_ITEM_NAME_LENGTH) {
+  const codePointLength = [...normalized].length;
+  if (codePointLength > MAX_ITEM_NAME_LENGTH) {
     return {
       valid: false,
       error: `Name is too long (max ${MAX_ITEM_NAME_LENGTH} characters)`,


### PR DESCRIPTION
This PR replaces fuzzy item-name matching used by AI tools with exact (case-insensitive) name matching plus virtual-path disambiguation, and adds a shared filesystem-style validation layer for rename/create that applies uniformly to user UI actions and AI-initiated renames.

- **AI tools**: `resolveItem` in `tool-utils.ts` now returns a discriminated result (`ok: true | {reason: "ambiguous"|"not-found"|"empty"}`); `fuzzyMatchItem` is removed. `item_delete`, `item_edit`, and `workspace_read` were updated to surface virtual paths when multiple items share the same name and to reject non-exact name queries.
- **Name validation**: New `validateItemName` in `src/lib/workspace/name-rules.ts` enforces portable, reversible naming: rejects invalid characters (`/\\<>:"|?*` and control chars), reserved names (`.`/`..`), empty/whitespace-only, and length >255. Trims and normalizes whitespace.
- **UI enforcement**: `commitPendingItemUpdate`, `createItem`, `createItems`, `createFolder`, and `createFolderWithItems` in `use-workspace-operations.ts` now validate and normalize names before duplicate checks or persistence. Default-naming (`New Document N`) is untouched.
- **Server enforcement**: `workspace-worker.ts` validates `buildItemFromCreateParams` titles, `updateQuiz`/`updatePdfContent` titles, and rename paths in `edit` actions (flashcard/quiz/document/pdf) before duplicate checks and assignment.
- **Dialog UX**: `RenameDialog` and `WorkspaceHeader`'s inline rename dialog now show live validation errors and disable the `Rename` button/Enter key while the name is invalid.
- **Tests**: Added `name-rules.test.ts` covering empty/trimmed, reserved names, invalid chars, unicode/emoji, max length, and default-name regression. Updated `edit-item-tool.test.ts` mocks for the discriminated `resolveItem` result shape.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/70f4e5c6-6e51-4838-b747-ca6207f39d30?inapp="><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-042" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/70f4e5c6-6e51-4838-b747-ca6207f39d30?inapp="><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-042&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-042"><img alt="ENG-042" src="https://capy.ai/api/badge/thread.svg?label=ENG-042"></picture></a>
<!-- capy-pr-badge:end -->