### PR TITLE
Feat: Flashcard edit modal with Tiptap and zoom controls

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -353,6 +353,7 @@ function DashboardContent({
             state={state}
             addItem={operations.createItem}
             updateItem={operations.updateItem}
+            updateItemData={operations.updateItemData}
             deleteItem={operations.deleteItem}
             updateAllItems={operations.updateAllItems}
             isChatMaximized={isChatMaximized}

--- a/src/components/workspace-canvas/FlashcardContent.tsx
+++ b/src/components/workspace-canvas/FlashcardContent.tsx
@@ -119,8 +119,53 @@ export function FlashcardContent({ item, onUpdateData }: FlashcardContentProps) 
     side: "front" | "back";
   } | null>(null);
 
+  // Local drafts override stale `card.front`/`card.back` while `onUpdateData`
+  // is debounced (~500ms). Without this, re-entering a side within the
+  // debounce window would mount the editor with the stale props value and
+  // silently drop the queued keystrokes when the user types again. Drafts
+  // also prevent the read-only preview from flickering back to old content
+  // between Done and flush.
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const draftKey = (cardId: string, side: "front" | "back") =>
+    `${cardId}:${side}`;
+
+  const resolveMarkdown = useCallback(
+    (card: { id: string; front: string; back: string }, side: "front" | "back"): string => {
+      const draft = drafts[draftKey(card.id, side)];
+      const source = side === "front" ? card.front : card.back;
+      return draft ?? source;
+    },
+    [drafts],
+  );
+
+  // Drop a draft once the authoritative source (item.data) catches up, so
+  // future remote edits via realtime sync aren't masked by a stale local
+  // override.
+  useEffect(() => {
+    setDrafts((prev) => {
+      let changed = false;
+      const next: Record<string, string> = {};
+      for (const [key, value] of Object.entries(prev)) {
+        const [cardId, side] = key.split(":") as [string, "front" | "back"];
+        const card = cards.find((c) => c.id === cardId);
+        if (!card) {
+          changed = true;
+          continue;
+        }
+        const source = side === "front" ? card.front : card.back;
+        if (source === value) {
+          changed = true;
+          continue;
+        }
+        next[key] = value;
+      }
+      return changed ? next : prev;
+    });
+  }, [cards]);
+
   const handleChange = useCallback(
     (cardId: string, side: "front" | "back", markdown: string) => {
+      setDrafts((prev) => ({ ...prev, [draftKey(cardId, side)]: markdown }));
       onUpdateData((prev) => {
         const prevFc = prev as FlashcardData;
         return {
@@ -158,7 +203,7 @@ export function FlashcardContent({ item, onUpdateData }: FlashcardContentProps) 
                 <div className="space-y-6">
                   <FlashcardSideEditable
                     title="Front"
-                    markdown={card.front}
+                    markdown={resolveMarkdown(card, "front")}
                     emptyLabel="No front content"
                     isEditing={
                       editing?.cardId === card.id && editing.side === "front"
@@ -175,7 +220,7 @@ export function FlashcardContent({ item, onUpdateData }: FlashcardContentProps) 
 
                   <FlashcardSideEditable
                     title="Back"
-                    markdown={card.back}
+                    markdown={resolveMarkdown(card, "back")}
                     emptyLabel="No back content"
                     isEditing={
                       editing?.cardId === card.id && editing.side === "back"

--- a/src/components/workspace-canvas/FlashcardContent.tsx
+++ b/src/components/workspace-canvas/FlashcardContent.tsx
@@ -1,37 +1,101 @@
 "use client";
 
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Check } from "lucide-react";
+import { DocumentEditor } from "@/components/editor/DocumentEditor";
 import type {
   Item,
   ItemData,
   FlashcardData,
 } from "@/lib/workspace-state/types";
 import { StreamdownMarkdown } from "@/components/ui/streamdown-markdown";
+import { cn } from "@/lib/utils";
 
 interface FlashcardContentProps {
   item: Item;
   onUpdateData: (updater: (prev: ItemData) => ItemData) => void;
 }
 
-function FlashcardSidePreview({
+function FlashcardSideEditable({
   title,
   markdown,
   emptyLabel,
+  isEditing,
+  onStartEditing,
+  onStopEditing,
+  onChange,
+  cardName,
 }: {
   title: string;
   markdown: string;
   emptyLabel: string;
+  isEditing: boolean;
+  onStartEditing: () => void;
+  onStopEditing: () => void;
+  onChange: (markdown: string) => void;
+  cardName?: string;
 }) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!isEditing) return;
+    const el = containerRef.current;
+    if (!el) return;
+
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      e.stopPropagation();
+      onStopEditing();
+    };
+
+    el.addEventListener("keydown", handler);
+    return () => el.removeEventListener("keydown", handler);
+  }, [isEditing, onStopEditing]);
+
   return (
-    <div>
-      <div className="mb-2 block text-sm font-medium text-foreground/70 dark:text-white/70">
-        {title}
+    <div ref={containerRef}>
+      <div className="mb-2 flex items-center justify-between">
+        <div className="block text-sm font-medium text-foreground/70 dark:text-white/70">
+          {title}
+        </div>
+        {isEditing && (
+          <button
+            type="button"
+            onClick={onStopEditing}
+            className="inline-flex items-center gap-1 rounded-md border border-foreground/10 px-2 py-1 text-xs text-foreground/70 hover:bg-foreground/5 dark:border-white/10 dark:text-white/70 dark:hover:bg-white/5"
+          >
+            <Check className="h-3.5 w-3.5" />
+            Done
+          </button>
+        )}
       </div>
       <div
-        className="rounded-lg border border-foreground/10 bg-foreground/5 min-h-[150px] overflow-hidden dark:border-white/10 dark:bg-white/5"
+        className={cn(
+          "min-h-[150px] overflow-hidden rounded-lg border transition-colors",
+          isEditing
+            ? "border-foreground/30 bg-foreground/[0.03] dark:border-white/30 dark:bg-white/[0.03]"
+            : "cursor-text border-foreground/10 bg-foreground/5 hover:border-foreground/20 dark:border-white/10 dark:bg-white/5 dark:hover:border-white/20",
+        )}
         style={{ backdropFilter: "blur(8px)" }}
+        onClick={(e) => {
+          if (isEditing) return;
+          const target = e.target as HTMLElement;
+          if (target.closest("a")) return;
+          onStartEditing();
+        }}
       >
-        {!markdown.trim() ? (
+        {isEditing ? (
+          <DocumentEditor
+            autofocus={true}
+            cardName={cardName}
+            content={markdown || undefined}
+            contentType={markdown ? "markdown" : undefined}
+            embedded={true}
+            showThemeToggle={false}
+            onUpdate={({ markdown: nextMarkdown }) => onChange(nextMarkdown)}
+          />
+        ) : !markdown.trim() ? (
           <div className="p-3 text-sm text-foreground/40 dark:text-white/40">
             {emptyLabel}
           </div>
@@ -47,9 +111,28 @@ function FlashcardSidePreview({
   );
 }
 
-export function FlashcardContent({ item }: FlashcardContentProps) {
+export function FlashcardContent({ item, onUpdateData }: FlashcardContentProps) {
   const flashcardData = item.data as FlashcardData;
   const cards = useMemo(() => flashcardData.cards ?? [], [flashcardData.cards]);
+  const [editing, setEditing] = useState<{
+    cardId: string;
+    side: "front" | "back";
+  } | null>(null);
+
+  const handleChange = useCallback(
+    (cardId: string, side: "front" | "back", markdown: string) => {
+      onUpdateData((prev) => {
+        const prevFc = prev as FlashcardData;
+        return {
+          ...prevFc,
+          cards: (prevFc.cards ?? []).map((c) =>
+            c.id === cardId ? { ...c, [side]: markdown } : c,
+          ),
+        } as FlashcardData;
+      });
+    },
+    [onUpdateData],
+  );
 
   return (
     <div className="flex-1 overflow-y-auto modal-scrollable">
@@ -73,16 +156,38 @@ export function FlashcardContent({ item }: FlashcardContentProps) {
                 </div>
 
                 <div className="space-y-6">
-                  <FlashcardSidePreview
+                  <FlashcardSideEditable
                     title="Front"
                     markdown={card.front}
                     emptyLabel="No front content"
+                    isEditing={
+                      editing?.cardId === card.id && editing.side === "front"
+                    }
+                    onStartEditing={() =>
+                      setEditing({ cardId: card.id, side: "front" })
+                    }
+                    onStopEditing={() => setEditing(null)}
+                    onChange={(markdown) =>
+                      handleChange(card.id, "front", markdown)
+                    }
+                    cardName={item.name}
                   />
 
-                  <FlashcardSidePreview
+                  <FlashcardSideEditable
                     title="Back"
                     markdown={card.back}
                     emptyLabel="No back content"
+                    isEditing={
+                      editing?.cardId === card.id && editing.side === "back"
+                    }
+                    onStartEditing={() =>
+                      setEditing({ cardId: card.id, side: "back" })
+                    }
+                    onStopEditing={() => setEditing(null)}
+                    onChange={(markdown) =>
+                      handleChange(card.id, "back", markdown)
+                    }
+                    cardName={item.name}
                   />
                 </div>
               </div>

--- a/src/components/workspace-canvas/FlashcardWorkspaceCard.tsx
+++ b/src/components/workspace-canvas/FlashcardWorkspaceCard.tsx
@@ -19,6 +19,7 @@ import { PiMouseScrollFill, PiMouseScrollBold } from "react-icons/pi";
 import { useTheme } from "next-themes";
 import type {
   Item,
+  ItemData,
   FlashcardData,
   FlashcardItem,
 } from "@/lib/workspace-state/types";
@@ -72,6 +73,16 @@ interface FlashcardWorkspaceCardProps {
   workspaceIcon?: string | null;
   workspaceColor?: string | null;
   onUpdateItem: (itemId: string, updates: Partial<Item>) => void;
+  /**
+   * Optional updater-style data patcher. Preferred for patching individual
+   * fields inside `data` (e.g. `zoom`) because it composes with other
+   * in-flight `updateItemData` updaters instead of overwriting the whole
+   * blob the way `onUpdateItem({ data })` does.
+   */
+  onUpdateItemData?: (
+    itemId: string,
+    updater: (prev: ItemData) => ItemData,
+  ) => void;
   onDeleteItem: (itemId: string) => void;
   onOpenModal: (itemId: string) => void;
   onMoveItem?: (itemId: string, folderId: string | null) => void; // Callback to move item to folder
@@ -162,6 +173,7 @@ export function FlashcardWorkspaceCard({
   workspaceIcon,
   workspaceColor,
   onUpdateItem,
+  onUpdateItemData,
   onDeleteItem,
   onOpenModal,
   onMoveItem,
@@ -214,11 +226,21 @@ export function FlashcardWorkspaceCard({
     (next: number) => {
       const clamped = clampZoom(next);
       setLocalZoom(clamped);
+      if (onUpdateItemData) {
+        // Preferred path: compose with any in-flight `updateItemData` updaters
+        // for this item so we never clobber pending Tiptap edits.
+        onUpdateItemData(item.id, (prev) => ({
+          ...(prev as FlashcardData),
+          zoom: clamped,
+        }));
+        return;
+      }
+      // Fallback (legacy wiring): full `data` replacement via updateItem.
       onUpdateItem(item.id, {
         data: { ...(item.data as FlashcardData), zoom: clamped },
       });
     },
-    [item.id, item.data, onUpdateItem],
+    [item.id, item.data, onUpdateItem, onUpdateItemData],
   );
 
   // Persist index change (optional debounce?)

--- a/src/components/workspace-canvas/FlashcardWorkspaceCard.tsx
+++ b/src/components/workspace-canvas/FlashcardWorkspaceCard.tsx
@@ -7,6 +7,8 @@ import {
   Trash2,
   CheckCircle2,
   Pencil,
+  ZoomIn,
+  ZoomOut,
   Palette,
   ChevronLeft,
   ChevronRight,
@@ -83,10 +85,15 @@ const EMPTY_FLASHCARD_PLACEHOLDER: FlashcardItem = {
   back: "",
 };
 
+const ZOOM_MIN = 0.5;
+const ZOOM_MAX = 2.5;
+const ZOOM_STEP = 0.1;
+const ZOOM_DEFAULT = 1;
+
 /** Center all markdown blocks on the card; keep code blocks full-width and left-aligned. */
 const FLASHCARD_STREAMDOWN_CLASS = cn(
   // Fluid type: size comes from the nearest [container-type:size] ancestor (card face)
-  "font-medium max-w-none text-center leading-[1.45] text-[length:clamp(0.82rem,0.42rem+3cqmin,2.85rem)]",
+  "font-medium max-w-none text-center leading-[1.45] text-[length:calc(clamp(0.82rem,0.42rem+3cqmin,2.85rem)*var(--flashcard-zoom,1))]",
   // globals.css fixes .streamdown-content at 0.875rem — inherit this wrapper’s fluid size instead
   "[&_.streamdown-content]:!text-inherit [&_.streamdown-content]:![font-size:1em]",
   "[&_.streamdown-content_p]:!text-inherit [&_.streamdown-content_li]:!text-inherit [&_.streamdown-content_td]:!text-inherit [&_.streamdown-content_th]:!text-inherit",
@@ -129,7 +136,7 @@ const FlashcardSideMarkdownView = memo(
         >
           <div className="w-full max-w-full min-w-0 text-center">
             {!markdown.trim() ? (
-              <div className="text-center text-muted-foreground px-2 text-[length:clamp(0.72rem,0.3rem+2cqmin,1.05rem)]">
+              <div className="text-center text-muted-foreground px-2 text-[length:calc(clamp(0.72rem,0.3rem+2cqmin,1.05rem)*var(--flashcard-zoom,1))]">
                 Ask the AI or click the pencil icon to add flashcards
               </div>
             ) : (
@@ -177,6 +184,9 @@ export function FlashcardWorkspaceCard({
     (state) => state.toggleItemScrollLocked,
   );
   const flashcardData = item.data as FlashcardData;
+  const persistedZoom =
+    (flashcardData as FlashcardData & { zoom?: number }).zoom ?? ZOOM_DEFAULT;
+  const [localZoom, setLocalZoom] = useState<number>(persistedZoom);
 
   // Navigation State
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -192,6 +202,24 @@ export function FlashcardWorkspaceCard({
       setCurrentIndex(0);
     }
   }, [cards.length, currentIndex]);
+
+  useEffect(() => {
+    setLocalZoom(persistedZoom);
+  }, [persistedZoom]);
+
+  const clampZoom = (z: number) =>
+    Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, Math.round(z * 10) / 10));
+
+  const applyZoom = useCallback(
+    (next: number) => {
+      const clamped = clampZoom(next);
+      setLocalZoom(clamped);
+      onUpdateItem(item.id, {
+        data: { ...(item.data as FlashcardData), zoom: clamped },
+      });
+    },
+    [item.id, item.data, onUpdateItem],
+  );
 
   // Persist index change (optional debounce?)
   const handleIndexChange = useCallback((newIndex: number) => {
@@ -485,7 +513,7 @@ export function FlashcardWorkspaceCard({
         <div
           id={`item-${item.id}`}
           className="group size-full relative rounded-md"
-          style={{}}
+          style={{ ["--flashcard-zoom" as string]: String(localZoom) }}
           onMouseDown={handleMouseDown}
           onClick={handleClick}
         >
@@ -530,6 +558,62 @@ export function FlashcardWorkspaceCard({
                 {isScrollLocked ? "Scroll" : "Lock"}
               </span>
             </button>
+
+            <div
+              className="flashcard-control-button inline-flex h-8 items-center overflow-hidden rounded-xl text-white/90"
+              style={getControlStyle(neutralControlBg)}
+            >
+              <button
+                type="button"
+                aria-label="Zoom out"
+                title="Zoom out"
+                disabled={localZoom <= ZOOM_MIN + 1e-6}
+                className="inline-flex h-8 w-8 items-center justify-center cursor-pointer hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+                onMouseDown={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  applyZoom(localZoom - ZOOM_STEP);
+                }}
+              >
+                <ZoomOut className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                aria-label={`Zoom: ${Math.round(localZoom * 100)}% — click to reset`}
+                title={`Zoom: ${Math.round(localZoom * 100)}% — click to reset`}
+                className="cursor-pointer select-none px-2 text-xs font-medium tabular-nums tracking-tight hover:text-white"
+                onMouseDown={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  applyZoom(ZOOM_DEFAULT);
+                }}
+              >
+                {Math.round(localZoom * 100)}%
+              </button>
+              <button
+                type="button"
+                aria-label="Zoom in"
+                title="Zoom in"
+                disabled={localZoom >= ZOOM_MAX - 1e-6}
+                className="inline-flex h-8 w-8 items-center justify-center cursor-pointer hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+                onMouseDown={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  applyZoom(localZoom + ZOOM_STEP);
+                }}
+              >
+                <ZoomIn className="h-4 w-4" />
+              </button>
+            </div>
 
             <button
               type="button"

--- a/src/components/workspace-canvas/WorkspaceContent.tsx
+++ b/src/components/workspace-canvas/WorkspaceContent.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useWorkspaceStore } from "@/lib/stores/workspace-store";
 import { Plus, Upload } from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
-import type { Item, CardType } from "@/lib/workspace-state/types";
+import type { Item, ItemData, CardType } from "@/lib/workspace-state/types";
 import { filterItemsByFolder } from "@/lib/workspace-state/search";
 import { useAutoScroll } from "@/hooks/ui/use-auto-scroll";
 import { transcriptSegmentsQueryKey } from "@/hooks/workspace/use-transcript-segments";
@@ -26,6 +26,10 @@ interface WorkspaceContentProps {
     initialData?: Partial<Item["data"]>,
   ) => string;
   updateItem: (itemId: string, updates: Partial<Item>) => void;
+  updateItemData: (
+    itemId: string,
+    updater: (prev: ItemData) => ItemData,
+  ) => void;
   deleteItem: (itemId: string) => void;
   updateAllItems: (items: Item[]) => void;
   openWorkspaceItem: (itemId: string | null) => void;
@@ -46,6 +50,7 @@ export default function WorkspaceContent({
   viewState,
   addItem,
   updateItem,
+  updateItemData,
   deleteItem,
   updateAllItems,
   openWorkspaceItem,
@@ -335,6 +340,7 @@ export default function WorkspaceContent({
           onDragStart={handleDragStart}
           onDragStop={handleDragStop}
           onUpdateItem={handleUpdateItem}
+          onUpdateItemData={updateItemData}
           onDeleteItem={handleDeleteItem}
           onUpdateAllItems={handleUpdateAllItems}
           onOpenModal={handleOpenModal}

--- a/src/components/workspace-canvas/WorkspaceGrid.tsx
+++ b/src/components/workspace-canvas/WorkspaceGrid.tsx
@@ -3,7 +3,7 @@ import { wrapCompactor, fastVerticalCompactor } from "react-grid-layout/extras";
 import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useMemo, useCallback, useRef, useEffect, useState } from "react";
 import React from "react";
-import type { Item } from "@/lib/workspace-state/types";
+import type { Item, ItemData } from "@/lib/workspace-state/types";
 import { itemsToLayout, generateMissingLayouts, updateItemsWithLayout } from "@/lib/workspace-state/grid-layout-helpers";
 import { isDescendantOf } from "@/lib/workspace-state/search";
 import { WorkspaceCard } from "./WorkspaceCard";
@@ -35,6 +35,10 @@ interface WorkspaceGridProps {
   onDragStart: () => void;
   onDragStop: (layout: LayoutItem[]) => void;
   onUpdateItem: (itemId: string, updates: Partial<Item>) => void;
+  onUpdateItemData?: (
+    itemId: string,
+    updater: (prev: ItemData) => ItemData,
+  ) => void;
   onDeleteItem: (itemId: string) => void;
   onUpdateAllItems: (items: Item[]) => void;
   onOpenModal: (itemId: string) => void;
@@ -61,6 +65,7 @@ function WorkspaceGridComponent({
   onDragStart,
   onDragStop,
   onUpdateItem,
+  onUpdateItemData,
   onDeleteItem,
   onUpdateAllItems,
   onOpenModal,
@@ -662,6 +667,7 @@ function WorkspaceGridComponent({
             workspaceIcon={workspaceIcon}
             workspaceColor={workspaceColor}
             onUpdateItem={handleUpdateItem}
+            onUpdateItemData={onUpdateItemData}
             onDeleteItem={handleDeleteItem}
             onOpenModal={handleOpenModal}
             onMoveItem={onMoveItem}
@@ -685,6 +691,7 @@ function WorkspaceGridComponent({
     allItems,
     displayItems,
     handleUpdateItem,
+    onUpdateItemData,
     handleDeleteItem,
     handleOpenModal,
     onMoveItem,

--- a/src/components/workspace-canvas/WorkspaceSection.tsx
+++ b/src/components/workspace-canvas/WorkspaceSection.tsx
@@ -1,6 +1,6 @@
 import React, { RefObject, useState, useCallback } from "react";
 import { toast } from "sonner";
-import type { Item, CardType } from "@/lib/workspace-state/types";
+import type { Item, ItemData, CardType } from "@/lib/workspace-state/types";
 import { DEFAULT_CARD_DIMENSIONS } from "@/lib/workspace-state/grid-layout-helpers";
 import type { WorkspaceOperations } from "@/hooks/workspace/use-workspace-operations";
 import WorkspaceContent from "./WorkspaceContent";
@@ -79,6 +79,10 @@ interface WorkspaceSectionProps {
     initialData?: Partial<Item["data"]>,
   ) => string;
   updateItem: (itemId: string, updates: Partial<Item>) => void;
+  updateItemData: (
+    itemId: string,
+    updater: (prev: ItemData) => ItemData,
+  ) => void;
   deleteItem: (itemId: string) => void;
   updateAllItems: (items: Item[]) => void;
 
@@ -119,6 +123,7 @@ export function WorkspaceSection({
   state,
   addItem,
   updateItem,
+  updateItemData,
   deleteItem,
   updateAllItems,
   isChatMaximized,
@@ -526,6 +531,7 @@ export function WorkspaceSection({
                   viewState={state}
                   addItem={addItem}
                   updateItem={updateItem}
+                  updateItemData={updateItemData}
                   deleteItem={deleteItem}
                   updateAllItems={updateAllItems}
                   openWorkspaceItem={openWorkspaceItem}

--- a/src/lib/workspace-state/item-data-schemas.ts
+++ b/src/lib/workspace-state/item-data-schemas.ts
@@ -28,6 +28,7 @@ export const flashcardCardInputSchema = z.object({
 
 export const flashcardDataSchema = z.object({
   cards: z.array(flashcardItemSchema).default([]),
+  zoom: z.number().min(0.5).max(2.5).default(1).optional(),
 });
 
 export const quizQuestionSchema = z.object({

--- a/src/lib/workspace-state/item-data-schemas.ts
+++ b/src/lib/workspace-state/item-data-schemas.ts
@@ -28,7 +28,7 @@ export const flashcardCardInputSchema = z.object({
 
 export const flashcardDataSchema = z.object({
   cards: z.array(flashcardItemSchema).default([]),
-  zoom: z.number().min(0.5).max(2.5).default(1).optional(),
+  zoom: z.number().min(0.5).max(2.5).default(1),
 });
 
 export const quizQuestionSchema = z.object({


### PR DESCRIPTION
This PR integrates click-to-edit Tiptap editing in the flashcard modal and adds a zoom control on hover, both backed by a schema extension.

**Schema changes**
- src/lib/workspace-state/item-data-schemas.ts: Add optional `zoom` field (0.5-2.5, default=1) to `flashcardDataSchema`

**Modal editing**
- src/components/workspace-canvas/FlashcardContent.tsx: Replace static previews with `FlashcardSideEditable` component supporting click-to-enter edit mode
- src/components/workspace-canvas/FlashcardContent.tsx: Integrate `DocumentEditor` with autofocus, markdown content type, and debounced `onUpdateData` writes
- src/components/workspace-canvas/FlashcardContent.tsx: Add edit state tracking (`{cardId, side}`) and Escape/Done handlers with stopPropagation

**Zoom controls**
- src/components/workspace-canvas/FlashcardWorkspaceCard.tsx: Add zoom constants (MIN/MAX/STEP/DEFAULT) and local state sync from persisted `item.data.zoom`
- src/components/workspace-canvas/FlashcardWorkspaceCard.tsx: Insert zoom pill (`- / NN% / +`) between scroll-lock and edit buttons in hover controls
- src/components/workspace-canvas/FlashcardWorkspaceCard.tsx: Apply zoom via CSS variable `--flashcard-zoom` on card root, scaling markdown and empty-state font sizes
- src/components/workspace-canvas/FlashcardWorkspaceCard.tsx: Add `ZoomIn`/`ZoomOut` to imports and persist changes via debounced `onUpdateItem`

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/50f799d5-e333-4973-86ed-aab609f25c8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-051" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/50f799d5-e333-4973-86ed-aab609f25c8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-051&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-051"><img alt="ENG-051" src="https://capy.ai/api/badge/thread.svg?label=ENG-051"></picture></a>
<!-- capy-pr-badge:end -->