### PR TITLE
Feat: raffle badge click reopens details popup

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -143,6 +143,9 @@ function DashboardContent({
   const [showWorkspaceSettings, setShowWorkspaceSettings] = useState(false);
   const [showWorkspaceShare, setShowWorkspaceShare] = useState(false);
 
+  // Manual open state for the raffle popup (re-opened via the share-count badge).
+  const [showRafflePopup, setShowRafflePopup] = useState(false);
+
   const showSignInPrompt =
     !!session?.user?.isAnonymous &&
     !isLoadingWorkspace &&
@@ -289,6 +292,8 @@ function DashboardContent({
         currentWorkspaceId={currentWorkspaceId}
         isLoadingWorkspace={isLoadingWorkspace}
         onOpenFullShare={() => setShowWorkspaceShare(true)}
+        manuallyOpen={showRafflePopup}
+        onManuallyClose={() => setShowRafflePopup(false)}
       />
       <DashboardLayout
         currentWorkspaceId={currentWorkspaceId}
@@ -353,6 +358,7 @@ function DashboardContent({
               }
               googleLoginHint={session?.user?.email ?? null}
               isWorkspaceOwner={isWorkspaceOwner}
+              onShowRaffleDetails={() => setShowRafflePopup(true)}
             />
           ) : undefined
         }

--- a/src/components/modals/RafflePopup.tsx
+++ b/src/components/modals/RafflePopup.tsx
@@ -23,6 +23,10 @@ interface RafflePopupProps {
   currentWorkspaceId: string | null;
   isLoadingWorkspace: boolean;
   onOpenFullShare?: () => void;
+  /** Force the popup open regardless of dismissal state (e.g. user clicked the share-count badge). */
+  manuallyOpen?: boolean;
+  /** Called when a manually-opened popup is closed; parent should clear its manual-open state. */
+  onManuallyClose?: () => void;
 }
 
 const FEATURE_KEY = "midterms-raffle-2026-04";
@@ -33,6 +37,8 @@ export function RafflePopup({
   currentWorkspaceId,
   isLoadingWorkspace,
   onOpenFullShare,
+  manuallyOpen = false,
+  onManuallyClose,
 }: RafflePopupProps) {
   const { data: session } = useSession();
   const { isNew, dismiss } = useNewFeature({
@@ -46,16 +52,17 @@ export function RafflePopup({
   const [isLoadingShareLink, setIsLoadingShareLink] = useState(false);
   const [copied, setCopied] = useState(false);
 
-  const canRender =
+  const canShowPopup =
     !!currentWorkspaceId &&
     !isLoadingWorkspace &&
     !!workspace &&
     session?.user?.isAnonymous !== true &&
-    workspace?.userId === session?.user?.id &&
-    isNew;
+    workspace?.userId === session?.user?.id;
+
+  const isOpen = canShowPopup && (isNew || manuallyOpen);
 
   useEffect(() => {
-    if (!canRender || !workspace) return;
+    if (!isOpen || !workspace) return;
 
     const controller = new AbortController();
     setIsLoadingShareLink(true);
@@ -81,11 +88,16 @@ export function RafflePopup({
     return () => {
       controller.abort();
     };
-  }, [canRender, workspace]);
+  }, [isOpen, workspace]);
 
-  if (!canRender || !workspace) {
+  if (!canShowPopup || !workspace) {
     return null;
   }
+
+  const handleClose = () => {
+    if (isNew) dismiss();
+    onManuallyClose?.();
+  };
 
   const deepCopyUrl = `${typeof window !== "undefined" ? window.location.origin : ""}/share-copy/${workspace.id}`;
   const activeUrl = linkMode === "collaborate" ? shareLinkUrl : deepCopyUrl;
@@ -106,9 +118,9 @@ export function RafflePopup({
 
   return (
     <Dialog
-      open={isNew}
+      open={isOpen}
       onOpenChange={(next) => {
-        if (!next) dismiss();
+        if (!next) handleClose();
       }}
     >
       <DialogContent className="sm:max-w-md" overlayClassName="bg-black/70">
@@ -199,7 +211,7 @@ export function RafflePopup({
               type="button"
               variant="outline"
               onClick={() => {
-                dismiss();
+                handleClose();
                 onOpenFullShare();
               }}
             >
@@ -209,7 +221,7 @@ export function RafflePopup({
           ) : (
             <span />
           )}
-          <Button type="button" onClick={dismiss}>
+          <Button type="button" onClick={handleClose}>
             Got it
           </Button>
         </DialogFooter>

--- a/src/components/workspace-canvas/WorkspaceHeader.tsx
+++ b/src/components/workspace-canvas/WorkspaceHeader.tsx
@@ -255,6 +255,8 @@ interface WorkspaceHeaderProps {
   // Workspace actions
   onOpenSettings?: () => void;
   onOpenShare?: () => void;
+  /** Open the raffle details popup (reopens the "Win a $50 Amazon gift card" dialog). */
+  onShowRaffleDetails?: () => void;
 
   /** Item shown in the fullscreen workspace viewer (`openMode === "single"`) — breadcrumbs + header actions */
   activeOpenWorkspaceItem?: Item | null;
@@ -286,6 +288,7 @@ export function WorkspaceHeader({
   onRenameFolder,
   onOpenSettings,
   onOpenShare,
+  onShowRaffleDetails,
 
   activeOpenWorkspaceItem = null,
   onCloseActiveItem,
@@ -1240,10 +1243,10 @@ export function WorkspaceHeader({
               Feedback
             </button>
 
-            {isWorkspaceOwner && currentWorkspaceId && onOpenShare && (
+            {isWorkspaceOwner && currentWorkspaceId && (
               <ShareCountBadge
                 workspaceId={currentWorkspaceId}
-                onClick={onOpenShare}
+                onClick={onShowRaffleDetails}
               />
             )}
             {onOpenShare && (


### PR DESCRIPTION
This PR adds support for manually re-opening the raffle details popup when the owner clicks the share-count badge (X/5). Previously, clicking the badge would open the full share dialog; now it re-opens the one-time raffle popup with the copy-to-clipboard UI.

**Changes**
- src/components/modals/RafflePopup.tsx: Add `manuallyOpen` and `onManuallyClose` props; keep dismissal tracking separate from manual open state so already-dismissed users can still re-open via badge click
- src/components/workspace-canvas/WorkspaceHeader.tsx: Add `onShowRaffleDetails` prop; wire ShareCountBadge onClick to this instead of `onOpenShare`
- src/app/dashboard/page.tsx: Add `showRafflePopup` state; pass to RafflePopup as `manuallyOpen` and to header as `onShowRaffleDetails` callback

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/3e405721-2a8a-4f82-97f9-8a97e94a8644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-050" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/3e405721-2a8a-4f82-97f9-8a97e94a8644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-050&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-050"><img alt="ENG-050" src="https://capy.ai/api/badge/thread.svg?label=ENG-050"></picture></a>
<!-- capy-pr-badge:end -->