### PR TITLE
fix: collapse home-page dead space when demo video is hidden

### DIFF
--- a/src/components/home/HomeContent.tsx
+++ b/src/components/home/HomeContent.tsx
@@ -430,7 +430,10 @@ export function HomeContent({ showDemoVideo, initialAuth }: HomeContentProps) {
 
             <div
               ref={workspacesRef}
-              className="relative z-10 px-6 pb-8 pt-8 min-h-screen bg-gradient-to-b from-transparent via-background to-background"
+              className={cn(
+                "relative z-10 px-6 pb-8 pt-8 bg-gradient-to-b from-transparent via-background to-background",
+                effectiveShowDemo && "min-h-screen",
+              )}
             >
               <div className="w-full max-w-6xl mx-auto h-full">
                 {effectiveShowDemo ? (


### PR DESCRIPTION
## Problem
On `/home` after sign-in, the workspaces section reserves 100vh of vertical space regardless of how many workspaces the user has. The workspace grid is content-sized (~150px for a few cards), but the wrapper around it forces a 100vh minimum — so the footer renders ~600px below the grid for users with few or no workspaces.

Reproduces on prod (`thinkex.app/home`) and locally.

**Before:**
<img width="1407" height="840" alt="image" src="https://github.com/user-attachments/assets/6e737541-b111-4ac9-b3e3-a5bd8ead7558" />

## Root cause
`src/components/home/HomeContent.tsx:433` applies `min-h-screen` unconditionally to the workspaces section wrapper. This was needed for the unauthenticated landing page where the demo video sits in the same wrapper and should feel full-viewport — but it leaks into the signed-in case where there's no demo video and the grid should size to its content.

## Fix
Make `min-h-screen` conditional on `effectiveShowDemo`. The demo-video path keeps the full-viewport feel; the workspaces-grid path adapts to its content height.

```tsx
className={cn(
  "relative z-10 px-6 pb-8 pt-8 bg-gradient-to-b from-transparent via-background to-background",
  effectiveShowDemo && "min-h-screen",
)}
```

`cn` was already imported, `effectiveShowDemo` was already in scope. One file, one line meaningfully changed.

## Verification
- `pnpm lint` clean
- Verified on prod by toggling `min-height: 100vh` off the wrapper in DevTools — layout snaps as expected, footer rises to sit directly below the grid
- Unauth landing path preserved: `effectiveShowDemo = showDemoVideo && !hasWorkspaces`, so users without workspaces still see the full-viewport demo section
- Could not verify locally due to a separate database setup blocker (`function append_workspace_event does not exist` — unrelated, raised separately)

## Out of scope
- The fixed top bar overlapping the workspaces card heading on scroll — separate bug, separate fix.
- The bottom gradient overlay positioning — may need a tweak for short pages, but doesn't affect this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the layout height of the workspaces section to properly adjust when toggling demo mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->