### PR TITLE
Fix: Show concise fallback for failed Mermaid diagrams

### DIFF
--- a/src/components/chat/parts/MarkdownText.tsx
+++ b/src/components/chat/parts/MarkdownText.tsx
@@ -37,6 +37,18 @@ import {
 const math = createMathPlugin({ singleDollarTextMath: true });
 const code = createCodePlugin() as CodeHighlighterPlugin;
 
+type MermaidErrorFallbackProps = {
+  chart: string;
+  error: string;
+  retry: () => void;
+};
+
+const MermaidErrorFallback = (_props: MermaidErrorFallbackProps) => (
+  <div className="my-2 text-xs text-muted-foreground">
+    AI failed to create diagram.
+  </div>
+);
+
 function parseCitationPage(ref: string): {
   title: string;
   quote?: string;
@@ -278,7 +290,10 @@ const MarkdownTextImpl = ({
             </ul>
           ),
         }}
-        mermaid={{ config: { theme: "dark" } }}
+        mermaid={{
+          config: { theme: "dark" },
+          errorComponent: MermaidErrorFallback,
+        }}
       >
         {preprocessLatex(text)}
       </Streamdown>

--- a/src/components/ui/streamdown-markdown.tsx
+++ b/src/components/ui/streamdown-markdown.tsx
@@ -14,6 +14,18 @@ const math = createMathPlugin({ singleDollarTextMath: true });
 
 const code = createCodePlugin() as CodeHighlighterPlugin;
 
+type MermaidErrorFallbackProps = {
+  chart: string;
+  error: string;
+  retry: () => void;
+};
+
+const MermaidErrorFallback = (_props: MermaidErrorFallbackProps) => (
+  <div className="my-2 text-xs text-muted-foreground">
+    AI failed to create diagram.
+  </div>
+);
+
 interface StreamdownMarkdownProps {
   children: string;
   className?: string;
@@ -52,6 +64,7 @@ const StreamdownMarkdownImpl: React.FC<StreamdownMarkdownProps> = ({
           config: {
             theme: 'dark',
           },
+          errorComponent: MermaidErrorFallback,
         }}
       >
         {preprocessLatex(children)}


### PR DESCRIPTION
Adds a static fallback message when Mermaid diagrams fail to parse or render in Streamdown. The default Streamdown error output is replaced with 'AI failed to create diagram.' in both the chat and shared markdown renderers.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/2ab0e15a-2e44-42ce-9185-825c7e12f030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-060" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/2ab0e15a-2e44-42ce-9185-825c7e12f030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-060&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-060"><img alt="ENG-060" src="https://capy.ai/api/badge/thread.svg?label=ENG-060"></picture></a>
<!-- capy-pr-badge:end -->