### PR TITLE
Fix: TipTap toolbar cursor-state reactivity

### DIFF
--- a/src/components/tiptap-ui/blockquote-button/use-blockquote.ts
+++ b/src/components/tiptap-ui/blockquote-button/use-blockquote.ts
@@ -252,7 +252,7 @@ export function useBlockquote(config?: UseBlockquoteConfig) {
         canToggle: canToggleBlockquote(currentEditor),
       }
     },
-  })
+  })!
   const { isVisible, isActive, canToggle } = toolbarState
 
   const handleToggle = useCallback(() => {

--- a/src/components/tiptap-ui/blockquote-button/use-blockquote.ts
+++ b/src/components/tiptap-ui/blockquote-button/use-blockquote.ts
@@ -252,11 +252,7 @@ export function useBlockquote(config?: UseBlockquoteConfig) {
         canToggle: canToggleBlockquote(currentEditor),
       }
     },
-  }) ?? {
-    isVisible: true,
-    isActive: false,
-    canToggle: false,
-  }
+  })
   const { isVisible, isActive, canToggle } = toolbarState
 
   const handleToggle = useCallback(() => {

--- a/src/components/tiptap-ui/blockquote-button/use-blockquote.ts
+++ b/src/components/tiptap-ui/blockquote-button/use-blockquote.ts
@@ -1,7 +1,8 @@
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
+import { useCallback } from "react"
 import type { Editor } from "@tiptap/react"
+import { useEditorState } from "@tiptap/react"
 import { NodeSelection, TextSelection } from "@tiptap/pm/state"
 
 // --- Hooks ---
@@ -231,25 +232,32 @@ export function useBlockquote(config?: UseBlockquoteConfig) {
   } = config || {}
 
   const { editor } = useTiptapEditor(providedEditor)
-  const [isVisible, setIsVisible] = useState<boolean>(true)
-  const canToggle = canToggleBlockquote(editor)
-  const isActive = editor?.isActive("blockquote") || false
+  const toolbarState = useEditorState({
+    editor,
+    selector: ({ editor: currentEditor }) => {
+      if (!currentEditor) {
+        return {
+          isVisible: true,
+          isActive: false,
+          canToggle: false,
+        }
+      }
 
-  useEffect(() => {
-    if (!editor) return
-
-    const handleSelectionUpdate = () => {
-      setIsVisible(shouldShowButton({ editor, hideWhenUnavailable }))
-    }
-
-    handleSelectionUpdate()
-
-    editor.on("selectionUpdate", handleSelectionUpdate)
-
-    return () => {
-      editor.off("selectionUpdate", handleSelectionUpdate)
-    }
-  }, [editor, hideWhenUnavailable])
+      return {
+        isVisible: shouldShowButton({
+          editor: currentEditor,
+          hideWhenUnavailable,
+        }),
+        isActive: currentEditor.isActive("blockquote"),
+        canToggle: canToggleBlockquote(currentEditor),
+      }
+    },
+  }) ?? {
+    isVisible: true,
+    isActive: false,
+    canToggle: false,
+  }
+  const { isVisible, isActive, canToggle } = toolbarState
 
   const handleToggle = useCallback(() => {
     if (!editor) return false

--- a/src/components/tiptap-ui/code-block-button/use-code-block.ts
+++ b/src/components/tiptap-ui/code-block-button/use-code-block.ts
@@ -262,7 +262,7 @@ export function useCodeBlock(config?: UseCodeBlockConfig) {
         canToggle: canToggle(currentEditor),
       }
     },
-  })
+  })!
   const {
     isVisible,
     isActive,

--- a/src/components/tiptap-ui/code-block-button/use-code-block.ts
+++ b/src/components/tiptap-ui/code-block-button/use-code-block.ts
@@ -262,11 +262,7 @@ export function useCodeBlock(config?: UseCodeBlockConfig) {
         canToggle: canToggle(currentEditor),
       }
     },
-  }) ?? {
-    isVisible: true,
-    isActive: false,
-    canToggle: false,
-  }
+  })
   const {
     isVisible,
     isActive,

--- a/src/components/tiptap-ui/code-block-button/use-code-block.ts
+++ b/src/components/tiptap-ui/code-block-button/use-code-block.ts
@@ -1,7 +1,8 @@
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
+import { useCallback } from "react"
 import { type Editor } from "@tiptap/react"
+import { useEditorState } from "@tiptap/react"
 import { NodeSelection, TextSelection } from "@tiptap/pm/state"
 
 // --- Hooks ---
@@ -241,25 +242,36 @@ export function useCodeBlock(config?: UseCodeBlockConfig) {
   } = config || {}
 
   const { editor } = useTiptapEditor(providedEditor)
-  const [isVisible, setIsVisible] = useState<boolean>(true)
-  const canToggleState = canToggle(editor)
-  const isActive = editor?.isActive("codeBlock") || false
+  const toolbarState = useEditorState({
+    editor,
+    selector: ({ editor: currentEditor }) => {
+      if (!currentEditor) {
+        return {
+          isVisible: true,
+          isActive: false,
+          canToggle: false,
+        }
+      }
 
-  useEffect(() => {
-    if (!editor) return
-
-    const handleSelectionUpdate = () => {
-      setIsVisible(shouldShowButton({ editor, hideWhenUnavailable }))
-    }
-
-    handleSelectionUpdate()
-
-    editor.on("selectionUpdate", handleSelectionUpdate)
-
-    return () => {
-      editor.off("selectionUpdate", handleSelectionUpdate)
-    }
-  }, [editor, hideWhenUnavailable])
+      return {
+        isVisible: shouldShowButton({
+          editor: currentEditor,
+          hideWhenUnavailable,
+        }),
+        isActive: currentEditor.isActive("codeBlock"),
+        canToggle: canToggle(currentEditor),
+      }
+    },
+  }) ?? {
+    isVisible: true,
+    isActive: false,
+    canToggle: false,
+  }
+  const {
+    isVisible,
+    isActive,
+    canToggle: canToggleState,
+  } = toolbarState
 
   const handleToggle = useCallback(() => {
     if (!editor) return false

--- a/src/components/tiptap-ui/color-highlight-button/use-color-highlight.ts
+++ b/src/components/tiptap-ui/color-highlight-button/use-color-highlight.ts
@@ -1,7 +1,8 @@
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
+import { useCallback } from "react"
 import { type Editor } from "@tiptap/react"
+import { useEditorState } from "@tiptap/react"
 import { useHotkeys } from "react-hotkeys-hook"
 
 // --- Hooks ---
@@ -293,28 +294,40 @@ export function useColorHighlight(config: UseColorHighlightConfig) {
 
   const { editor } = useTiptapEditor(providedEditor)
   const isMobile = useIsBreakpoint()
-  const [isVisible, setIsVisible] = useState<boolean>(true)
-  const canColorHighlightState = canColorHighlight(editor, mode)
   const actualColor = highlightColor
     ? getHighlightColorValue(highlightColor, useColorValue)
     : highlightColor
-  const isActive = isColorHighlightActive(editor, actualColor, mode)
+  const toolbarState = useEditorState({
+    editor,
+    selector: ({ editor: currentEditor }) => {
+      if (!currentEditor) {
+        return {
+          isVisible: true,
+          isActive: false,
+          canColorHighlight: false,
+        }
+      }
 
-  useEffect(() => {
-    if (!editor) return
-
-    const handleSelectionUpdate = () => {
-      setIsVisible(shouldShowButton({ editor, hideWhenUnavailable, mode }))
-    }
-
-    handleSelectionUpdate()
-
-    editor.on("selectionUpdate", handleSelectionUpdate)
-
-    return () => {
-      editor.off("selectionUpdate", handleSelectionUpdate)
-    }
-  }, [editor, hideWhenUnavailable, mode])
+      return {
+        isVisible: shouldShowButton({
+          editor: currentEditor,
+          hideWhenUnavailable,
+          mode,
+        }),
+        isActive: isColorHighlightActive(currentEditor, actualColor, mode),
+        canColorHighlight: canColorHighlight(currentEditor, mode),
+      }
+    },
+  }) ?? {
+    isVisible: true,
+    isActive: false,
+    canColorHighlight: false,
+  }
+  const {
+    isVisible,
+    isActive,
+    canColorHighlight: canColorHighlightState,
+  } = toolbarState
 
   const handleColorHighlight = useCallback(() => {
     if (!editor || !canColorHighlightState || !actualColor || !label)

--- a/src/components/tiptap-ui/color-highlight-button/use-color-highlight.ts
+++ b/src/components/tiptap-ui/color-highlight-button/use-color-highlight.ts
@@ -318,11 +318,7 @@ export function useColorHighlight(config: UseColorHighlightConfig) {
         canColorHighlight: canColorHighlight(currentEditor, mode),
       }
     },
-  }) ?? {
-    isVisible: true,
-    isActive: false,
-    canColorHighlight: false,
-  }
+  })
   const {
     isVisible,
     isActive,

--- a/src/components/tiptap-ui/color-highlight-button/use-color-highlight.ts
+++ b/src/components/tiptap-ui/color-highlight-button/use-color-highlight.ts
@@ -318,7 +318,7 @@ export function useColorHighlight(config: UseColorHighlightConfig) {
         canColorHighlight: canColorHighlight(currentEditor, mode),
       }
     },
-  })
+  })!
   const {
     isVisible,
     isActive,

--- a/src/components/tiptap-ui/heading-button/use-heading.ts
+++ b/src/components/tiptap-ui/heading-button/use-heading.ts
@@ -1,7 +1,8 @@
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
+import { useCallback } from "react"
 import { type Editor } from "@tiptap/react"
+import { useEditorState } from "@tiptap/react"
 import { NodeSelection, TextSelection } from "@tiptap/pm/state"
 
 // --- Hooks ---
@@ -301,25 +302,37 @@ export function useHeading(config: UseHeadingConfig) {
   } = config
 
   const { editor } = useTiptapEditor(providedEditor)
-  const [isVisible, setIsVisible] = useState<boolean>(true)
-  const canToggleState = canToggle(editor, level)
-  const isActive = isHeadingActive(editor, level)
+  const toolbarState = useEditorState({
+    editor,
+    selector: ({ editor: currentEditor }) => {
+      if (!currentEditor) {
+        return {
+          isVisible: true,
+          isActive: false,
+          canToggle: false,
+        }
+      }
 
-  useEffect(() => {
-    if (!editor) return
-
-    const handleSelectionUpdate = () => {
-      setIsVisible(shouldShowButton({ editor, level, hideWhenUnavailable }))
-    }
-
-    handleSelectionUpdate()
-
-    editor.on("selectionUpdate", handleSelectionUpdate)
-
-    return () => {
-      editor.off("selectionUpdate", handleSelectionUpdate)
-    }
-  }, [editor, level, hideWhenUnavailable])
+      return {
+        isVisible: shouldShowButton({
+          editor: currentEditor,
+          level,
+          hideWhenUnavailable,
+        }),
+        isActive: isHeadingActive(currentEditor, level),
+        canToggle: canToggle(currentEditor, level),
+      }
+    },
+  }) ?? {
+    isVisible: true,
+    isActive: false,
+    canToggle: false,
+  }
+  const {
+    isVisible,
+    isActive,
+    canToggle: canToggleState,
+  } = toolbarState
 
   const handleToggle = useCallback(() => {
     if (!editor) return false

--- a/src/components/tiptap-ui/heading-button/use-heading.ts
+++ b/src/components/tiptap-ui/heading-button/use-heading.ts
@@ -323,11 +323,7 @@ export function useHeading(config: UseHeadingConfig) {
         canToggle: canToggle(currentEditor, level),
       }
     },
-  }) ?? {
-    isVisible: true,
-    isActive: false,
-    canToggle: false,
-  }
+  })
   const {
     isVisible,
     isActive,

--- a/src/components/tiptap-ui/heading-button/use-heading.ts
+++ b/src/components/tiptap-ui/heading-button/use-heading.ts
@@ -323,7 +323,7 @@ export function useHeading(config: UseHeadingConfig) {
         canToggle: canToggle(currentEditor, level),
       }
     },
-  })
+  })!
   const {
     isVisible,
     isActive,

--- a/src/components/tiptap-ui/heading-dropdown-menu/use-heading-dropdown-menu.ts
+++ b/src/components/tiptap-ui/heading-dropdown-menu/use-heading-dropdown-menu.ts
@@ -119,7 +119,7 @@ export function useHeadingDropdownMenu(config?: UseHeadingDropdownMenuConfig) {
         canToggle: canToggle(currentEditor),
       }
     },
-  })
+  })!
   const {
     isVisible,
     activeLevel,

--- a/src/components/tiptap-ui/heading-dropdown-menu/use-heading-dropdown-menu.ts
+++ b/src/components/tiptap-ui/heading-dropdown-menu/use-heading-dropdown-menu.ts
@@ -1,7 +1,7 @@
 "use client"
 
-import { useEffect, useState } from "react"
 import type { Editor } from "@tiptap/react"
+import { useEditorState } from "@tiptap/react"
 
 // --- Hooks ---
 import { useTiptapEditor } from "@/hooks/use-tiptap-editor"
@@ -96,29 +96,41 @@ export function useHeadingDropdownMenu(config?: UseHeadingDropdownMenuConfig) {
   } = config || {}
 
   const { editor } = useTiptapEditor(providedEditor)
-  const [isVisible, setIsVisible] = useState(true)
+  const toolbarState = useEditorState({
+    editor,
+    selector: ({ editor: currentEditor }) => {
+      if (!currentEditor) {
+        return {
+          isVisible: true,
+          activeLevel: undefined,
+          isActive: false,
+          canToggle: false,
+        }
+      }
 
-  const activeLevel = getActiveHeadingLevel(editor, levels)
-  const isActive = isHeadingActive(editor)
-  const canToggleState = canToggle(editor)
-
-  useEffect(() => {
-    if (!editor) return
-
-    const handleSelectionUpdate = () => {
-      setIsVisible(
-        shouldShowButton({ editor, hideWhenUnavailable, level: levels })
-      )
-    }
-
-    handleSelectionUpdate()
-
-    editor.on("selectionUpdate", handleSelectionUpdate)
-
-    return () => {
-      editor.off("selectionUpdate", handleSelectionUpdate)
-    }
-  }, [editor, hideWhenUnavailable, levels])
+      return {
+        isVisible: shouldShowButton({
+          editor: currentEditor,
+          hideWhenUnavailable,
+          level: levels,
+        }),
+        activeLevel: getActiveHeadingLevel(currentEditor, levels),
+        isActive: isHeadingActive(currentEditor, levels),
+        canToggle: canToggle(currentEditor),
+      }
+    },
+  }) ?? {
+    isVisible: true,
+    activeLevel: undefined,
+    isActive: false,
+    canToggle: false,
+  }
+  const {
+    isVisible,
+    activeLevel,
+    isActive,
+    canToggle: canToggleState,
+  } = toolbarState
 
   return {
     isVisible,

--- a/src/components/tiptap-ui/heading-dropdown-menu/use-heading-dropdown-menu.ts
+++ b/src/components/tiptap-ui/heading-dropdown-menu/use-heading-dropdown-menu.ts
@@ -119,12 +119,7 @@ export function useHeadingDropdownMenu(config?: UseHeadingDropdownMenuConfig) {
         canToggle: canToggle(currentEditor),
       }
     },
-  }) ?? {
-    isVisible: true,
-    activeLevel: undefined,
-    isActive: false,
-    canToggle: false,
-  }
+  })
   const {
     isVisible,
     activeLevel,

--- a/src/components/tiptap-ui/list-button/use-list.ts
+++ b/src/components/tiptap-ui/list-button/use-list.ts
@@ -331,11 +331,7 @@ export function useList(config: UseListConfig) {
         canToggle: canToggleList(currentEditor, type),
       }
     },
-  }) ?? {
-    isVisible: true,
-    isActive: false,
-    canToggle: false,
-  }
+  })
   const { isVisible, isActive, canToggle } = toolbarState
 
   const handleToggle = useCallback(() => {

--- a/src/components/tiptap-ui/list-button/use-list.ts
+++ b/src/components/tiptap-ui/list-button/use-list.ts
@@ -1,7 +1,8 @@
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
+import { useCallback } from "react"
 import { type Editor } from "@tiptap/react"
+import { useEditorState } from "@tiptap/react"
 import { NodeSelection, TextSelection } from "@tiptap/pm/state"
 
 // --- Hooks ---
@@ -309,25 +310,33 @@ export function useList(config: UseListConfig) {
   } = config
 
   const { editor } = useTiptapEditor(providedEditor)
-  const [isVisible, setIsVisible] = useState<boolean>(true)
-  const canToggle = canToggleList(editor, type)
-  const isActive = isListActive(editor, type)
+  const toolbarState = useEditorState({
+    editor,
+    selector: ({ editor: currentEditor }) => {
+      if (!currentEditor) {
+        return {
+          isVisible: true,
+          isActive: false,
+          canToggle: false,
+        }
+      }
 
-  useEffect(() => {
-    if (!editor) return
-
-    const handleSelectionUpdate = () => {
-      setIsVisible(shouldShowButton({ editor, type, hideWhenUnavailable }))
-    }
-
-    handleSelectionUpdate()
-
-    editor.on("selectionUpdate", handleSelectionUpdate)
-
-    return () => {
-      editor.off("selectionUpdate", handleSelectionUpdate)
-    }
-  }, [editor, type, hideWhenUnavailable])
+      return {
+        isVisible: shouldShowButton({
+          editor: currentEditor,
+          type,
+          hideWhenUnavailable,
+        }),
+        isActive: isListActive(currentEditor, type),
+        canToggle: canToggleList(currentEditor, type),
+      }
+    },
+  }) ?? {
+    isVisible: true,
+    isActive: false,
+    canToggle: false,
+  }
+  const { isVisible, isActive, canToggle } = toolbarState
 
   const handleToggle = useCallback(() => {
     if (!editor) return false

--- a/src/components/tiptap-ui/list-button/use-list.ts
+++ b/src/components/tiptap-ui/list-button/use-list.ts
@@ -331,7 +331,7 @@ export function useList(config: UseListConfig) {
         canToggle: canToggleList(currentEditor, type),
       }
     },
-  })
+  })!
   const { isVisible, isActive, canToggle } = toolbarState
 
   const handleToggle = useCallback(() => {

--- a/src/components/tiptap-ui/list-dropdown-menu/use-list-dropdown-menu.ts
+++ b/src/components/tiptap-ui/list-dropdown-menu/use-list-dropdown-menu.ts
@@ -1,7 +1,8 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useMemo } from "react"
 import type { Editor } from "@tiptap/react"
+import { useEditorState } from "@tiptap/react"
 
 // --- Hooks ---
 import { useTiptapEditor } from "@/hooks/use-tiptap-editor"
@@ -170,40 +171,50 @@ export function useListDropdownMenu(config?: UseListDropdownMenuConfig) {
   } = config || {}
 
   const { editor } = useTiptapEditor(providedEditor)
-  const [isVisible, setIsVisible] = useState(true)
-
-  const listInSchema = types.some((type) => isNodeInSchema(type, editor))
-
   const filteredLists = useMemo(() => getFilteredListOptions(types), [types])
+  const toolbarState = useEditorState({
+    editor,
+    selector: ({ editor: currentEditor }) => {
+      if (!currentEditor) {
+        return {
+          isVisible: true,
+          canToggleAny: false,
+          isAnyActive: false,
+          activeType: undefined,
+        }
+      }
 
-  const canToggleAny = canToggleAnyList(editor, types)
-  const isAnyActive = isAnyListActive(editor, types)
-  const activeType = getActiveListType(editor, types)
-  const activeList = filteredLists.find((option) => option.type === activeType)
+      const listInSchema = types.some((type) =>
+        isNodeInSchema(type, currentEditor)
+      )
+      const canToggleAny = canToggleAnyList(currentEditor, types)
 
-  useEffect(() => {
-    if (!editor) return
-
-    const handleSelectionUpdate = () => {
-      setIsVisible(
-        shouldShowListDropdown({
-          editor,
+      return {
+        isVisible: shouldShowListDropdown({
+          editor: currentEditor,
           listTypes: types,
           hideWhenUnavailable,
           listInSchema,
           canToggleAny,
-        })
-      )
-    }
-
-    handleSelectionUpdate()
-
-    editor.on("selectionUpdate", handleSelectionUpdate)
-
-    return () => {
-      editor.off("selectionUpdate", handleSelectionUpdate)
-    }
-  }, [canToggleAny, editor, hideWhenUnavailable, listInSchema, types])
+        }),
+        canToggleAny,
+        isAnyActive: isAnyListActive(currentEditor, types),
+        activeType: getActiveListType(currentEditor, types),
+      }
+    },
+  }) ?? {
+    isVisible: true,
+    canToggleAny: false,
+    isAnyActive: false,
+    activeType: undefined,
+  }
+  const {
+    isVisible,
+    canToggleAny,
+    isAnyActive,
+    activeType,
+  } = toolbarState
+  const activeList = filteredLists.find((option) => option.type === activeType)
 
   return {
     isVisible,

--- a/src/components/tiptap-ui/list-dropdown-menu/use-list-dropdown-menu.ts
+++ b/src/components/tiptap-ui/list-dropdown-menu/use-list-dropdown-menu.ts
@@ -202,7 +202,7 @@ export function useListDropdownMenu(config?: UseListDropdownMenuConfig) {
         activeType: getActiveListType(currentEditor, types),
       }
     },
-  })
+  })!
   const {
     isVisible,
     canToggleAny,

--- a/src/components/tiptap-ui/list-dropdown-menu/use-list-dropdown-menu.ts
+++ b/src/components/tiptap-ui/list-dropdown-menu/use-list-dropdown-menu.ts
@@ -202,12 +202,7 @@ export function useListDropdownMenu(config?: UseListDropdownMenuConfig) {
         activeType: getActiveListType(currentEditor, types),
       }
     },
-  }) ?? {
-    isVisible: true,
-    canToggleAny: false,
-    isAnyActive: false,
-    activeType: undefined,
-  }
+  })
   const {
     isVisible,
     canToggleAny,

--- a/src/components/tiptap-ui/mark-button/use-mark.ts
+++ b/src/components/tiptap-ui/mark-button/use-mark.ts
@@ -195,7 +195,7 @@ export function useMark(config: UseMarkConfig) {
         canToggle: canToggleMark(currentEditor, type),
       }
     },
-  })
+  })!
   const { isVisible, isActive, canToggle } = toolbarState
 
   const handleMark = useCallback(() => {

--- a/src/components/tiptap-ui/mark-button/use-mark.ts
+++ b/src/components/tiptap-ui/mark-button/use-mark.ts
@@ -195,11 +195,7 @@ export function useMark(config: UseMarkConfig) {
         canToggle: canToggleMark(currentEditor, type),
       }
     },
-  }) ?? {
-    isVisible: true,
-    isActive: false,
-    canToggle: false,
-  }
+  })
   const { isVisible, isActive, canToggle } = toolbarState
 
   const handleMark = useCallback(() => {

--- a/src/components/tiptap-ui/mark-button/use-mark.ts
+++ b/src/components/tiptap-ui/mark-button/use-mark.ts
@@ -1,7 +1,8 @@
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
+import { useCallback } from "react"
 import type { Editor } from "@tiptap/react"
+import { useEditorState } from "@tiptap/react"
 
 // --- Hooks ---
 import { useTiptapEditor } from "@/hooks/use-tiptap-editor"
@@ -173,25 +174,33 @@ export function useMark(config: UseMarkConfig) {
   } = config
 
   const { editor } = useTiptapEditor(providedEditor)
-  const [isVisible, setIsVisible] = useState<boolean>(true)
-  const canToggle = canToggleMark(editor, type)
-  const isActive = isMarkActive(editor, type)
+  const toolbarState = useEditorState({
+    editor,
+    selector: ({ editor: currentEditor }) => {
+      if (!currentEditor) {
+        return {
+          isVisible: true,
+          isActive: false,
+          canToggle: false,
+        }
+      }
 
-  useEffect(() => {
-    if (!editor) return
-
-    const handleSelectionUpdate = () => {
-      setIsVisible(shouldShowButton({ editor, type, hideWhenUnavailable }))
-    }
-
-    handleSelectionUpdate()
-
-    editor.on("selectionUpdate", handleSelectionUpdate)
-
-    return () => {
-      editor.off("selectionUpdate", handleSelectionUpdate)
-    }
-  }, [editor, type, hideWhenUnavailable])
+      return {
+        isVisible: shouldShowButton({
+          editor: currentEditor,
+          type,
+          hideWhenUnavailable,
+        }),
+        isActive: isMarkActive(currentEditor, type),
+        canToggle: canToggleMark(currentEditor, type),
+      }
+    },
+  }) ?? {
+    isVisible: true,
+    isActive: false,
+    canToggle: false,
+  }
+  const { isVisible, isActive, canToggle } = toolbarState
 
   const handleMark = useCallback(() => {
     if (!editor) return false

--- a/src/components/tiptap-ui/text-align-button/use-text-align.ts
+++ b/src/components/tiptap-ui/text-align-button/use-text-align.ts
@@ -208,11 +208,7 @@ export function useTextAlign(config: UseTextAlignConfig) {
         canAlign: canSetTextAlign(currentEditor, align),
       }
     },
-  }) ?? {
-    isVisible: true,
-    isActive: false,
-    canAlign: false,
-  }
+  })
   const { isVisible, isActive, canAlign } = toolbarState
 
   const handleTextAlign = useCallback(() => {

--- a/src/components/tiptap-ui/text-align-button/use-text-align.ts
+++ b/src/components/tiptap-ui/text-align-button/use-text-align.ts
@@ -1,8 +1,9 @@
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
+import { useCallback } from "react"
 import type { ChainedCommands } from "@tiptap/react"
 import { type Editor } from "@tiptap/react"
+import { useEditorState } from "@tiptap/react"
 
 // --- Hooks ---
 import { useTiptapEditor } from "@/hooks/use-tiptap-editor"
@@ -186,25 +187,33 @@ export function useTextAlign(config: UseTextAlignConfig) {
   } = config
 
   const { editor } = useTiptapEditor(providedEditor)
-  const [isVisible, setIsVisible] = useState<boolean>(true)
-  const canAlign = canSetTextAlign(editor, align)
-  const isActive = isTextAlignActive(editor, align)
+  const toolbarState = useEditorState({
+    editor,
+    selector: ({ editor: currentEditor }) => {
+      if (!currentEditor) {
+        return {
+          isVisible: true,
+          isActive: false,
+          canAlign: false,
+        }
+      }
 
-  useEffect(() => {
-    if (!editor) return
-
-    const handleSelectionUpdate = () => {
-      setIsVisible(shouldShowButton({ editor, align, hideWhenUnavailable }))
-    }
-
-    handleSelectionUpdate()
-
-    editor.on("selectionUpdate", handleSelectionUpdate)
-
-    return () => {
-      editor.off("selectionUpdate", handleSelectionUpdate)
-    }
-  }, [editor, hideWhenUnavailable, align])
+      return {
+        isVisible: shouldShowButton({
+          editor: currentEditor,
+          align,
+          hideWhenUnavailable,
+        }),
+        isActive: isTextAlignActive(currentEditor, align),
+        canAlign: canSetTextAlign(currentEditor, align),
+      }
+    },
+  }) ?? {
+    isVisible: true,
+    isActive: false,
+    canAlign: false,
+  }
+  const { isVisible, isActive, canAlign } = toolbarState
 
   const handleTextAlign = useCallback(() => {
     if (!editor) return false

--- a/src/components/tiptap-ui/text-align-button/use-text-align.ts
+++ b/src/components/tiptap-ui/text-align-button/use-text-align.ts
@@ -208,7 +208,7 @@ export function useTextAlign(config: UseTextAlignConfig) {
         canAlign: canSetTextAlign(currentEditor, align),
       }
     },
-  })
+  })!
   const { isVisible, isActive, canAlign } = toolbarState
 
   const handleTextAlign = useCallback(() => {

--- a/src/hooks/use-tiptap-editor.ts
+++ b/src/hooks/use-tiptap-editor.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import type { Editor } from "@tiptap/react"
-import { useCurrentEditor, useEditorState } from "@tiptap/react"
+import { useCurrentEditor } from "@tiptap/react"
 import { useMemo } from "react"
 
 /**
@@ -17,33 +17,12 @@ import { useMemo } from "react"
  */
 export function useTiptapEditor(providedEditor?: Editor | null): {
   editor: Editor | null
-  editorState?: Editor["state"]
-  canCommand?: Editor["can"]
 } {
   const { editor: coreEditor } = useCurrentEditor()
-  const mainEditor = useMemo(
+  const editor = useMemo(
     () => providedEditor || coreEditor,
     [providedEditor, coreEditor]
   )
 
-  const editorState = useEditorState({
-    editor: mainEditor,
-    selector(context) {
-      if (!context.editor) {
-        return {
-          editor: null,
-          editorState: undefined,
-          canCommand: undefined,
-        }
-      }
-
-      return {
-        editor: context.editor,
-        editorState: context.editor.state,
-        canCommand: context.editor.can,
-      }
-    },
-  })
-
-  return editorState || { editor: null }
+  return { editor: editor || null }
 }


### PR DESCRIPTION
Fixes TipTap toolbar active/disabled/visible state not updating when the cursor/selection moves, specifically when the editor autofocuses into an initial code block and later moves elsewhere.

Previously, toolbar hooks used ad-hoc `selectionUpdate` listeners with local `useState` for `isVisible`; if visibility didn't change, React bailed out and `isActive`/`canToggle` values stayed stale. This re-implements all toolbar state using TipTap's recommended `useEditorState` selector pattern.

- Simplified `useTiptapEditor` to only resolve the editor instance; removed non-reactive `editorState`/`canCommand` returns
- Replaced `selectionUpdate` listeners with `useEditorState({ editor, selector })` in all button/dropdown hooks:
  - `useMark`, `useHeading`, `useList`, `useBlockquote`, `useCodeBlock`, `useTextAlign`, `useColorHighlight`
  - `useHeadingDropdownMenu`, `useListDropdownMenu`
- Selectors return primitive booleans (`isVisible`, `isActive`, capability) with null-editor fallbacks
- Moving the cursor/selection now triggers immediate re-renders and updates toolbar state

Verified `tsc --noEmit` passes and no remaining `selectionUpdate`/`useState` patterns in affected hooks.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/63290ed2-47fd-4102-843f-a192695e1b28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-062" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/63290ed2-47fd-4102-843f-a192695e1b28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-062&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-062"><img alt="ENG-062" src="https://capy.ai/api/badge/thread.svg?label=ENG-062"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal state management architecture for editor toolbar buttons. Enhanced how the editor handles visibility and availability state computation, resulting in more efficient state synchronization without affecting user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->