### PR TITLE
Fix: chat abort propagation and empty message persistence

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -555,9 +555,16 @@ async function handlePOST(req: Request) {
       },
       onFinish: async ({ responseMessage, isAborted }) => {
         const meaningful = hasMeaningfulContent(responseMessage);
-        if (isAborted || !userId || !meaningful) {
+        if (isAborted) {
+          logger.debug(`${CHAT_DEBUG_TAG} onFinish skipped (aborted)`, {
+            hasUserId: !!userId,
+            hasMeaningfulContent: meaningful,
+            partCount: responseMessage.parts?.length ?? 0,
+          });
+          return;
+        }
+        if (!userId || !meaningful) {
           logger.warn(`${CHAT_DEBUG_TAG} onFinish skipped`, {
-            isAborted,
             hasUserId: !!userId,
             hasMeaningfulContent: meaningful,
             partCount: responseMessage.parts?.length ?? 0,

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,6 +1,7 @@
 import {
   streamText,
   smoothStream,
+  consumeStream,
   convertToModelMessages,
   pruneMessages,
   safeValidateUIMessages,
@@ -38,7 +39,11 @@ import {
 } from "@/lib/ai/gateway-provider-options";
 import { db } from "@/lib/db/client";
 import { chatThreads, chatMessages } from "@/lib/db/schema";
-import { CHAT_MESSAGE_FORMAT, type ChatMessage } from "@/lib/chat/types";
+import {
+  CHAT_MESSAGE_FORMAT,
+  hasMeaningfulContent,
+  type ChatMessage,
+} from "@/lib/chat/types";
 import {
   CHAT_DEBUG_TAG,
   summarizeMessage,
@@ -113,7 +118,8 @@ async function loadThreadHistory(threadId: string): Promise<ChatMessage[]> {
       ),
     )
     .orderBy(asc(chatMessages.createdAt));
-  return rows.map((r) => r.content) as ChatMessage[];
+  const messages = rows.map((r) => r.content) as ChatMessage[];
+  return messages.filter((m) => hasMeaningfulContent(m));
 }
 
 async function getThreadById(threadId: string) {
@@ -344,6 +350,7 @@ async function handlePOST(req: Request) {
     try {
       convertedMessages = await convertToModelMessages(validatedMessages, {
         tools,
+        ignoreIncompleteToolCalls: true,
       });
     } catch (convertError) {
       logger.error("❌ [CHAT-API] convertToModelMessages FAILED:", {
@@ -473,6 +480,7 @@ async function handlePOST(req: Request) {
           tools,
           providerOptions,
           headers: getGatewayAttributionHeaders(),
+          abortSignal: req.signal,
           experimental_telemetry: {
             isEnabled: true,
             metadata: {
@@ -546,10 +554,13 @@ async function handlePOST(req: Request) {
         }
       },
       onFinish: async ({ responseMessage, isAborted }) => {
-        if (isAborted || !userId) {
+        const meaningful = hasMeaningfulContent(responseMessage);
+        if (isAborted || !userId || !meaningful) {
           logger.warn(`${CHAT_DEBUG_TAG} onFinish skipped`, {
             isAborted,
             hasUserId: !!userId,
+            hasMeaningfulContent: meaningful,
+            partCount: responseMessage.parts?.length ?? 0,
           });
           return;
         }
@@ -599,7 +610,10 @@ async function handlePOST(req: Request) {
       },
     });
 
-    return createUIMessageStreamResponse({ stream });
+    return createUIMessageStreamResponse({
+      stream,
+      consumeSseStream: consumeStream,
+    });
   } catch (error) {
     if (error instanceof Response) {
       return error;

--- a/src/app/api/threads/[id]/messages/route.ts
+++ b/src/app/api/threads/[id]/messages/route.ts
@@ -14,7 +14,7 @@ import {
   summarizeMessage,
   summarizeRoster,
 } from "@/lib/chat/debug";
-import { CHAT_MESSAGE_FORMAT } from "@/lib/chat/types";
+import { CHAT_MESSAGE_FORMAT, hasMeaningfulContent } from "@/lib/chat/types";
 
 async function getThreadAndVerify(id: string, userId: string) {
   const [thread] = await db
@@ -70,7 +70,14 @@ export const GET = withServerObservability(
         .orderBy(asc(chatMessages.createdAt));
 
       // content is a stored UIMessage object; no reshaping required.
-      const messages = rows.map((r) => r.content);
+      // Drop any pre-existing rows whose stored content has no meaningful
+      // parts (empty or `step-start`-only) so corrupted history from before
+      // the persistence guard never poisons hydrated `useChat` state.
+      const messages = rows
+        .map((r) => r.content)
+        .filter((content) =>
+          hasMeaningfulContent(content as { parts?: unknown }),
+        );
 
       // [chat-debug] Snapshot what's actually in the DB for this thread so
       // we can correlate against what the client receives. If the assistant

--- a/src/app/api/threads/[id]/messages/route.ts
+++ b/src/app/api/threads/[id]/messages/route.ts
@@ -75,9 +75,7 @@ export const GET = withServerObservability(
       // the persistence guard never poisons hydrated `useChat` state.
       const messages = rows
         .map((r) => r.content)
-        .filter((content) =>
-          hasMeaningfulContent(content as { parts?: unknown }),
-        );
+        .filter((content) => hasMeaningfulContent(content));
 
       // [chat-debug] Snapshot what's actually in the DB for this thread so
       // we can correlate against what the client receives. If the assistant

--- a/src/components/chat/ChatProvider.tsx
+++ b/src/components/chat/ChatProvider.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/lib/chat/queries";
 import { createChatTransport } from "@/lib/chat/transport";
 import type { ChatMessage } from "@/lib/chat/types";
+import { hasMeaningfulContent } from "@/lib/chat/types";
 import { useUIStore } from "@/lib/stores/ui-store";
 import {
   selectCurrentThreadId,
@@ -302,7 +303,11 @@ export function ChatProvider({ workspaceId, children }: ChatProviderProps) {
   const chat = useChat<ChatMessage>({
     id: threadId,
     transport,
-    messages: shouldHydrateHistory ? persistedMessages : undefined,
+    messages: shouldHydrateHistory
+      ? (persistedMessages as ChatMessage[]).filter((m) =>
+          hasMeaningfulContent(m),
+        )
+      : undefined,
     onError: handleError,
     // Live title updates: the chat route writes a `data-chat-title` part to
     // the SSE stream once `generateThreadTitle` resolves. We patch the
@@ -366,20 +371,25 @@ export function ChatProvider({ workspaceId, children }: ChatProviderProps) {
   useEffect(() => {
     if (seededRef.current) return;
     if (persistedMessages.length === 0) return;
+    const cleanPersisted = (persistedMessages as ChatMessage[]).filter((m) =>
+      hasMeaningfulContent(m),
+    );
     if (messages.length > 0) {
       chatDebug("seed: skipped, useChat already has messages", {
         threadId,
         useChatCount: messages.length,
         persistedCount: persistedMessages.length,
+        cleanCount: cleanPersisted.length,
       });
       seededRef.current = true;
       return;
     }
     chatDebug("seed: pushing persisted messages into useChat", {
       threadId,
-      ...summarizeRoster(persistedMessages as unknown[]),
+      droppedEmpty: persistedMessages.length - cleanPersisted.length,
+      ...summarizeRoster(cleanPersisted as unknown[]),
     });
-    setMessages(persistedMessages);
+    setMessages(cleanPersisted);
     seededRef.current = true;
   }, [persistedMessages, messages.length, setMessages, threadId]);
 

--- a/src/lib/chat/types.ts
+++ b/src/lib/chat/types.ts
@@ -22,3 +22,26 @@ export type ChatMessage = UIMessage<ChatMessageMetadata>;
 /** Marker value written to `chat_messages.format` for every new row created after the migration. */
 export const CHAT_MESSAGE_FORMAT = "ai-sdk-ui/v1" as const;
 export type ChatMessageFormat = typeof CHAT_MESSAGE_FORMAT;
+
+/**
+ * Returns true if the UI message has at least one user-visible part. Pure structural
+ * parts (`step-start`) and empty/whitespace text parts don't count.
+ *
+ * Used as a guard for persistence and hydration so empty/aborted assistant rows
+ * (which would otherwise fail `safeValidateUIMessages.parts.nonempty(...)`) never
+ * make it into the validated message list.
+ */
+export function hasMeaningfulContent(message: { parts?: unknown }): boolean {
+  if (!Array.isArray(message.parts) || message.parts.length === 0) return false;
+  return message.parts.some((part) => {
+    if (!part || typeof part !== "object") return false;
+    const type = (part as { type?: unknown }).type;
+    if (typeof type !== "string") return false;
+    if (type === "step-start") return false;
+    if (type === "text" || type === "reasoning") {
+      const text = (part as { text?: unknown }).text;
+      return typeof text === "string" && text.trim().length > 0;
+    }
+    return true;
+  });
+}

--- a/src/lib/chat/types.ts
+++ b/src/lib/chat/types.ts
@@ -31,9 +31,11 @@ export type ChatMessageFormat = typeof CHAT_MESSAGE_FORMAT;
  * (which would otherwise fail `safeValidateUIMessages.parts.nonempty(...)`) never
  * make it into the validated message list.
  */
-export function hasMeaningfulContent(message: { parts?: unknown }): boolean {
-  if (!Array.isArray(message.parts) || message.parts.length === 0) return false;
-  return message.parts.some((part) => {
+export function hasMeaningfulContent(message: unknown): boolean {
+  if (!message || typeof message !== "object") return false;
+  const parts = (message as { parts?: unknown }).parts;
+  if (!Array.isArray(parts) || parts.length === 0) return false;
+  return parts.some((part) => {
     if (!part || typeof part !== "object") return false;
     const type = (part as { type?: unknown }).type;
     if (typeof type !== "string") return false;


### PR DESCRIPTION
This PR aligns chat abort and error handling with the AI SDK v6 canonical patterns and hardens against empty message DB rows that cause `TypeValidationError` in `safeValidateUIMessages`.

**Chat API (`src/app/api/chat/route.ts`)**
- Import `consumeStream` and pass to `createUIMessageStreamResponse` so `onFinish` reliably fires with `isAborted: true` on client disconnect
- Pass `abortSignal: req.signal` to `streamText` so the stop button cancels the model provider call
- Pass `ignoreIncompleteToolCalls: true` to `convertToModelMessages` so partial tool calls in history don't crash future turns with `AI_MissingToolResultsError`
- Guard persistence in `onFinish` by checking `hasMeaningfulContent` before writing to DB
- Filter out empty/structural-only rows when loading thread history (rescues pre-existing corrupted threads)

**Chat types (`src/lib/chat/types.ts`)**
- Add `hasMeaningfulContent` helper that returns `false` for messages with empty parts, only `step-start` parts, or whitespace-only text/reasoning parts

**Messages endpoint (`src/app/api/threads/[id]/messages/route.ts`)**
- Apply `hasMeaningfulContent` filter when hydrating persisted history so corrupted rows never reach the client

**ChatProvider (`src/components/chat/ChatProvider.tsx`)**
- Filter `persistedMessages` at both the `useChat` initializer and the post-mount seed effect
- Add debug logging for dropped empty messages

Existing `AssistantErrorRow` UX (`"AI failed to respond"` + Retry) is preserved; aborts leave partial client state and reset `status` to `"ready"` via `useChat`.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/14535f82-2a30-4ee9-8c64-c734d72d9c39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-066" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/14535f82-2a30-4ee9-8c64-c734d72d9c39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-066&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-066"><img alt="ENG-066" src="https://capy.ai/api/badge/thread.svg?label=ENG-066"></picture></a>
<!-- capy-pr-badge:end -->