### PR TITLE
Feat: add web_map chat tool backed by Firecrawl /v2/map

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,6 +1,7 @@
 import {
   streamText,
   smoothStream,
+  consumeStream,
   convertToModelMessages,
   pruneMessages,
   safeValidateUIMessages,
@@ -38,7 +39,11 @@ import {
 } from "@/lib/ai/gateway-provider-options";
 import { db } from "@/lib/db/client";
 import { chatThreads, chatMessages } from "@/lib/db/schema";
-import { CHAT_MESSAGE_FORMAT, type ChatMessage } from "@/lib/chat/types";
+import {
+  CHAT_MESSAGE_FORMAT,
+  hasMeaningfulContent,
+  type ChatMessage,
+} from "@/lib/chat/types";
 import {
   CHAT_DEBUG_TAG,
   summarizeMessage,
@@ -113,7 +118,8 @@ async function loadThreadHistory(threadId: string): Promise<ChatMessage[]> {
       ),
     )
     .orderBy(asc(chatMessages.createdAt));
-  return rows.map((r) => r.content) as ChatMessage[];
+  const messages = rows.map((r) => r.content) as ChatMessage[];
+  return messages.filter((m) => hasMeaningfulContent(m));
 }
 
 async function getThreadById(threadId: string) {
@@ -344,6 +350,7 @@ async function handlePOST(req: Request) {
     try {
       convertedMessages = await convertToModelMessages(validatedMessages, {
         tools,
+        ignoreIncompleteToolCalls: true,
       });
     } catch (convertError) {
       logger.error("❌ [CHAT-API] convertToModelMessages FAILED:", {
@@ -473,6 +480,7 @@ async function handlePOST(req: Request) {
           tools,
           providerOptions,
           headers: getGatewayAttributionHeaders(),
+          abortSignal: req.signal,
           experimental_telemetry: {
             isEnabled: true,
             metadata: {
@@ -546,10 +554,20 @@ async function handlePOST(req: Request) {
         }
       },
       onFinish: async ({ responseMessage, isAborted }) => {
-        if (isAborted || !userId) {
-          logger.warn(`${CHAT_DEBUG_TAG} onFinish skipped`, {
-            isAborted,
+        const meaningful = hasMeaningfulContent(responseMessage);
+        if (isAborted) {
+          logger.debug(`${CHAT_DEBUG_TAG} onFinish skipped (aborted)`, {
             hasUserId: !!userId,
+            hasMeaningfulContent: meaningful,
+            partCount: responseMessage.parts?.length ?? 0,
+          });
+          return;
+        }
+        if (!userId || !meaningful) {
+          logger.warn(`${CHAT_DEBUG_TAG} onFinish skipped`, {
+            hasUserId: !!userId,
+            hasMeaningfulContent: meaningful,
+            partCount: responseMessage.parts?.length ?? 0,
           });
           return;
         }
@@ -599,7 +617,10 @@ async function handlePOST(req: Request) {
       },
     });
 
-    return createUIMessageStreamResponse({ stream });
+    return createUIMessageStreamResponse({
+      stream,
+      consumeSseStream: consumeStream,
+    });
   } catch (error) {
     if (error instanceof Response) {
       return error;

--- a/src/app/api/threads/[id]/messages/route.ts
+++ b/src/app/api/threads/[id]/messages/route.ts
@@ -14,7 +14,7 @@ import {
   summarizeMessage,
   summarizeRoster,
 } from "@/lib/chat/debug";
-import { CHAT_MESSAGE_FORMAT } from "@/lib/chat/types";
+import { CHAT_MESSAGE_FORMAT, hasMeaningfulContent } from "@/lib/chat/types";
 
 async function getThreadAndVerify(id: string, userId: string) {
   const [thread] = await db
@@ -70,7 +70,12 @@ export const GET = withServerObservability(
         .orderBy(asc(chatMessages.createdAt));
 
       // content is a stored UIMessage object; no reshaping required.
-      const messages = rows.map((r) => r.content);
+      // Drop any pre-existing rows whose stored content has no meaningful
+      // parts (empty or `step-start`-only) so corrupted history from before
+      // the persistence guard never poisons hydrated `useChat` state.
+      const messages = rows
+        .map((r) => r.content)
+        .filter((content) => hasMeaningfulContent(content));
 
       // [chat-debug] Snapshot what's actually in the DB for this thread so
       // we can correlate against what the client receives. If the assistant

--- a/src/components/chat/ChatProvider.tsx
+++ b/src/components/chat/ChatProvider.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/lib/chat/queries";
 import { createChatTransport } from "@/lib/chat/transport";
 import type { ChatMessage } from "@/lib/chat/types";
+import { hasMeaningfulContent } from "@/lib/chat/types";
 import { useUIStore } from "@/lib/stores/ui-store";
 import {
   selectCurrentThreadId,
@@ -302,7 +303,11 @@ export function ChatProvider({ workspaceId, children }: ChatProviderProps) {
   const chat = useChat<ChatMessage>({
     id: threadId,
     transport,
-    messages: shouldHydrateHistory ? persistedMessages : undefined,
+    messages: shouldHydrateHistory
+      ? (persistedMessages as ChatMessage[]).filter((m) =>
+          hasMeaningfulContent(m),
+        )
+      : undefined,
     onError: handleError,
     // Live title updates: the chat route writes a `data-chat-title` part to
     // the SSE stream once `generateThreadTitle` resolves. We patch the
@@ -366,20 +371,25 @@ export function ChatProvider({ workspaceId, children }: ChatProviderProps) {
   useEffect(() => {
     if (seededRef.current) return;
     if (persistedMessages.length === 0) return;
+    const cleanPersisted = (persistedMessages as ChatMessage[]).filter((m) =>
+      hasMeaningfulContent(m),
+    );
     if (messages.length > 0) {
       chatDebug("seed: skipped, useChat already has messages", {
         threadId,
         useChatCount: messages.length,
         persistedCount: persistedMessages.length,
+        cleanCount: cleanPersisted.length,
       });
       seededRef.current = true;
       return;
     }
     chatDebug("seed: pushing persisted messages into useChat", {
       threadId,
-      ...summarizeRoster(persistedMessages as unknown[]),
+      droppedEmpty: persistedMessages.length - cleanPersisted.length,
+      ...summarizeRoster(cleanPersisted as unknown[]),
     });
-    setMessages(persistedMessages);
+    setMessages(cleanPersisted);
     seededRef.current = true;
   }, [persistedMessages, messages.length, setMessages, threadId]);
 

--- a/src/components/chat/tools/WebMapToolUI.tsx
+++ b/src/components/chat/tools/WebMapToolUI.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import {
+  MapIcon,
+  ChevronDownIcon,
+  ExternalLinkIcon,
+  AlertCircle,
+} from "lucide-react";
+import { useState, type FC, type PropsWithChildren } from "react";
+
+import type { ChatToolUIProps } from "@/lib/chat/tool-ui-types";
+
+import { ToolUIErrorBoundary } from "@/components/tool-ui/shared";
+import { parseWebMapResult } from "@/lib/ai/tool-result-schemas";
+import {
+  normalizeWebMapArgs,
+  type WebMapLink,
+  type WebMapOutput,
+} from "@/lib/ai/web-map-shared";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import ShinyText from "@/components/ShinyText";
+import { Badge } from "@/components/ui/badge";
+
+const ANIMATION_DURATION = 200;
+const SHIMMER_DURATION = 1000;
+
+/**
+ * Root collapsible container that manages open/closed state.
+ */
+const ToolRoot: FC<
+  PropsWithChildren<{
+    className?: string;
+  }>
+> = ({ className, children }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Collapsible
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className={cn("mb-4 w-full", className)}
+      style={
+        {
+          "--animation-duration": `${ANIMATION_DURATION}ms`,
+          "--shimmer-duration": `${SHIMMER_DURATION}ms`,
+        } as React.CSSProperties
+      }
+    >
+      {children}
+    </Collapsible>
+  );
+};
+
+ToolRoot.displayName = "ToolRoot";
+
+/**
+ * Gradient overlay that softens the bottom edge during expand/collapse animations.
+ */
+const GradientFade: FC<{ className?: string }> = ({ className }) => (
+  <div
+    className={cn(
+      "pointer-events-none absolute inset-x-0 bottom-0 z-10 h-16",
+      "bg-[linear-gradient(to_top,var(--color-background),transparent)]",
+      "animate-in fade-in-0",
+      "group-data-[state=open]/collapsible-content:animate-out",
+      "group-data-[state=open]/collapsible-content:fade-out-0",
+      "group-data-[state=open]/collapsible-content:delay-[calc(var(--animation-duration)*0.75)]",
+      "group-data-[state=open]/collapsible-content:fill-mode-forwards",
+      "duration-(--animation-duration)",
+      "group-data-[state=open]/collapsible-content:duration-(--animation-duration)",
+      className,
+    )}
+  />
+);
+
+/**
+ * Trigger button for the tool collapsible.
+ */
+const ToolTrigger: FC<{
+  active: boolean;
+  label: string;
+  icon: React.ReactNode;
+  badges?: React.ReactNode;
+  className?: string;
+}> = ({ active, label, icon, badges, className }) => (
+  <CollapsibleTrigger
+    className={cn(
+      "group/trigger -mb-2 flex max-w-[75%] items-center gap-2 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground",
+      className,
+    )}
+  >
+    {icon}
+    <span className="relative inline-block leading-none">
+      {active ? (
+        <ShinyText
+          text={label}
+          disabled={false}
+          speed={1.5}
+          className="text-sm"
+        />
+      ) : (
+        <span>{label}</span>
+      )}
+    </span>
+    {badges}
+    <ChevronDownIcon
+      className={cn(
+        "mt-0.5 size-4 shrink-0",
+        "transition-transform duration-(--animation-duration) ease-out",
+        "group-data-[state=closed]/trigger:-rotate-90",
+        "group-data-[state=open]/trigger:rotate-0",
+      )}
+    />
+  </CollapsibleTrigger>
+);
+
+/**
+ * Collapsible content wrapper that handles height expand/collapse animation.
+ */
+const ToolContent: FC<
+  PropsWithChildren<{
+    className?: string;
+    "aria-busy"?: boolean;
+  }>
+> = ({ className, children, "aria-busy": ariaBusy }) => (
+  <CollapsibleContent
+    className={cn(
+      "relative overflow-hidden text-sm text-muted-foreground outline-none",
+      "group/collapsible-content ease-out",
+      "data-[state=closed]:animate-collapsible-up",
+      "data-[state=open]:animate-collapsible-down",
+      "data-[state=closed]:fill-mode-forwards",
+      "data-[state=closed]:pointer-events-none",
+      "data-[state=open]:duration-(--animation-duration)",
+      "data-[state=closed]:duration-(--animation-duration)",
+      className,
+    )}
+    aria-busy={ariaBusy}
+  >
+    {children}
+    <GradientFade />
+  </CollapsibleContent>
+);
+
+ToolContent.displayName = "ToolContent";
+
+/**
+ * Text content wrapper that animates the tool text visibility.
+ */
+const ToolText: FC<
+  PropsWithChildren<{
+    className?: string;
+  }>
+> = ({ className, children }) => (
+  <div
+    className={cn(
+      "relative z-0 space-y-4 pt-4 pl-6 leading-relaxed",
+      "transform-gpu transition-[transform,opacity]",
+      "group-data-[state=open]/collapsible-content:animate-in",
+      "group-data-[state=closed]/collapsible-content:animate-out",
+      "group-data-[state=open]/collapsible-content:fade-in-0",
+      "group-data-[state=closed]/collapsible-content:fade-out-0",
+      "group-data-[state=open]/collapsible-content:slide-in-from-top-4",
+      "group-data-[state=closed]/collapsible-content:slide-out-to-top-4",
+      "group-data-[state=open]/collapsible-content:duration-(--animation-duration)",
+      "group-data-[state=closed]/collapsible-content:duration-(--animation-duration)",
+      "[&_p]:-mb-2",
+      className,
+    )}
+  >
+    {children}
+  </div>
+);
+
+ToolText.displayName = "ToolText";
+
+function getDomain(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Tool UI component for web_map tool.
+ * Displays the discovered URLs with optional title/description in a collapsible card.
+ */
+type WebMapArgs = {
+  url?: string;
+  search?: string;
+  limit?: number;
+  includeSubdomains?: boolean;
+  sitemap?: "include" | "skip" | "only";
+  jsonInput?: string;
+};
+
+export const renderWebMapToolUI: ChatToolUIProps<
+  WebMapArgs,
+  string | WebMapOutput
+>["render"] = ({ args, status, result }) => {
+  const isRunning = status.type === "running";
+  const isComplete = status.type === "complete";
+
+  const normalizedArgs = normalizeWebMapArgs(args);
+  const sourceUrl = normalizedArgs?.url ?? "";
+
+  const parsedResult = result != null ? parseWebMapResult(result) : null;
+  const structured =
+    parsedResult && typeof parsedResult === "object" ? parsedResult : null;
+  const links: WebMapLink[] = structured?.links ?? [];
+  const metadata = structured?.metadata;
+  const errorMessage = metadata?.error ?? null;
+  const truncated = metadata?.truncated ?? false;
+  const total = metadata?.total ?? links.length;
+  const fallbackText =
+    typeof parsedResult === "string" ? parsedResult : (structured?.text ?? "");
+
+  const domain = sourceUrl ? getDomain(sourceUrl) : "";
+  const triggerLabel = isRunning
+    ? sourceUrl
+      ? `Mapping ${domain || sourceUrl}`
+      : "Mapping site"
+    : isComplete
+      ? errorMessage
+        ? "Map failed"
+        : total > 0
+          ? `Mapped ${total} URL${total !== 1 ? "s" : ""}`
+          : "No URLs found"
+      : "Map cancelled";
+
+  const triggerBadges =
+    isComplete && !errorMessage && total > 0 ? (
+      <Badge
+        variant="outline"
+        className="text-[10px] px-1.5 py-0.5 max-w-[160px] truncate"
+        title={domain || sourceUrl}
+      >
+        {domain || sourceUrl}
+      </Badge>
+    ) : null;
+
+  return (
+    <ToolUIErrorBoundary componentName="WebMap">
+      <ToolRoot>
+        <ToolTrigger
+          active={isRunning}
+          label={triggerLabel}
+          icon={<MapIcon className="size-4 shrink-0" />}
+          badges={triggerBadges}
+        />
+
+        <ToolContent aria-busy={isRunning}>
+          <ToolText>
+            <div className="space-y-3">
+              {sourceUrl && (
+                <div>
+                  <span className="text-xs font-medium text-muted-foreground/70">
+                    Source:
+                  </span>{" "}
+                  <a
+                    href={sourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-primary hover:underline break-all"
+                  >
+                    {sourceUrl}
+                  </a>
+                </div>
+              )}
+
+              {isRunning && (
+                <div className="flex items-center gap-2">
+                  <div className="h-2 w-2 animate-pulse rounded-full bg-blue-500" />
+                  <span className="text-xs text-foreground">
+                    Discovering URLs...
+                  </span>
+                </div>
+              )}
+
+              {isComplete && errorMessage && (
+                <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-2 py-1.5">
+                  <AlertCircle className="mt-0.5 size-3.5 shrink-0 text-destructive" />
+                  <span className="text-xs text-destructive/90 break-words">
+                    {errorMessage}
+                  </span>
+                </div>
+              )}
+
+              {isComplete && !errorMessage && links.length > 0 && (
+                <div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs font-medium text-muted-foreground/70">
+                      URLs:
+                    </span>
+                    <Badge
+                      variant="outline"
+                      className="text-[10px] px-1.5 py-0.5"
+                    >
+                      {total} total{truncated ? " (truncated)" : ""}
+                    </Badge>
+                  </div>
+                  <div className="mt-1 space-y-2">
+                    {links.map((link) => (
+                      <div key={link.url} className="flex flex-col gap-0.5">
+                        <div className="flex items-center gap-2">
+                          <ExternalLinkIcon className="h-3 w-3 shrink-0 text-muted-foreground/60" />
+                          <a
+                            href={link.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-xs text-primary hover:underline break-all"
+                          >
+                            {link.url}
+                          </a>
+                        </div>
+                        {link.title && (
+                          <div className="ml-5 text-xs text-foreground/80 break-words">
+                            {link.title}
+                          </div>
+                        )}
+                        {link.description && (
+                          <div className="ml-5 text-[11px] text-muted-foreground break-words">
+                            {link.description}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {isComplete &&
+                !errorMessage &&
+                links.length === 0 &&
+                fallbackText && (
+                  <div className="text-xs text-muted-foreground break-words">
+                    {fallbackText}
+                  </div>
+                )}
+
+              {!isRunning && !isComplete && (
+                <div className="text-xs text-muted-foreground">
+                  Map cancelled.
+                </div>
+              )}
+            </div>
+          </ToolText>
+        </ToolContent>
+      </ToolRoot>
+    </ToolUIErrorBoundary>
+  );
+};

--- a/src/components/chat/tools/registry.ts
+++ b/src/components/chat/tools/registry.ts
@@ -12,6 +12,7 @@ import { renderExecuteCodeToolUI } from "./ExecuteCodeToolUI";
 import { renderReadWorkspaceToolUI } from "./ReadWorkspaceToolUI";
 import { renderSearchWorkspaceToolUI } from "./SearchWorkspaceToolUI";
 import { renderURLContextToolUI } from "./URLContextToolUI";
+import { renderWebMapToolUI } from "./WebMapToolUI";
 import { renderWebSearchToolUI } from "./WebSearchToolUI";
 import { renderYouTubeSearchToolUI } from "./YouTubeSearchToolUI";
 
@@ -23,6 +24,7 @@ type ToolRender = (args: ChatToolUIRenderArgs) => React.ReactNode;
  */
 export const TOOL_RENDERERS: Partial<Record<string, ToolRender>> = {
   [CHAT_TOOL.WEB_FETCH]: renderURLContextToolUI as ToolRender,
+  [CHAT_TOOL.WEB_MAP]: renderWebMapToolUI as ToolRender,
   [CHAT_TOOL.WEB_SEARCH]: renderWebSearchToolUI as ToolRender,
   [CHAT_TOOL.CODE_EXECUTE]: renderExecuteCodeToolUI as ToolRender,
   [CHAT_TOOL.WORKSPACE_SEARCH]: renderSearchWorkspaceToolUI as ToolRender,

--- a/src/lib/ai/__tests__/web-map-shared.test.ts
+++ b/src/lib/ai/__tests__/web-map-shared.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_WEB_MAP_LIMIT_HARD_CAP,
+  WebMapInputSchema,
+  normalizeWebMapArgs,
+} from "../web-map-shared";
+
+describe("normalizeWebMapArgs", () => {
+  it("accepts the structured tool input shape", () => {
+    expect(normalizeWebMapArgs({ url: "https://example.com" })).toEqual({
+      url: "https://example.com",
+    });
+  });
+
+  it("parses optional fields", () => {
+    expect(
+      normalizeWebMapArgs({
+        url: "https://example.com",
+        limit: 5,
+        search: "foo",
+      }),
+    ).toEqual({
+      url: "https://example.com",
+      limit: 5,
+      search: "foo",
+    });
+  });
+
+  it("normalizes legacy jsonInput payloads", () => {
+    expect(
+      normalizeWebMapArgs({
+        jsonInput: JSON.stringify({ url: "https://example.com" }),
+      }),
+    ).toEqual({ url: "https://example.com" });
+  });
+
+  it("returns null for malformed jsonInput", () => {
+    expect(normalizeWebMapArgs({ jsonInput: "not-json" })).toBeNull();
+  });
+
+  it("returns null for empty payload", () => {
+    expect(normalizeWebMapArgs({})).toBeNull();
+  });
+
+  it("returns null when url is empty", () => {
+    expect(normalizeWebMapArgs({ url: "" })).toBeNull();
+  });
+});
+
+describe("WebMapInputSchema", () => {
+  it("rejects limit greater than MAX_WEB_MAP_LIMIT_HARD_CAP", () => {
+    const result = WebMapInputSchema.safeParse({
+      url: "https://example.com",
+      limit: MAX_WEB_MAP_LIMIT_HARD_CAP + 1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts limit at MAX_WEB_MAP_LIMIT_HARD_CAP", () => {
+    const result = WebMapInputSchema.safeParse({
+      url: "https://example.com",
+      limit: MAX_WEB_MAP_LIMIT_HARD_CAP,
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/lib/ai/chat-tool-names.ts
+++ b/src/lib/ai/chat-tool-names.ts
@@ -6,6 +6,7 @@
 
 export const CHAT_TOOL = {
   WEB_FETCH: "web_fetch",
+  WEB_MAP: "web_map",
   WEB_SEARCH: "web_search",
   WORKSPACE_SEARCH: "workspace_search",
   WORKSPACE_READ: "workspace_read",

--- a/src/lib/ai/tool-result-schemas.ts
+++ b/src/lib/ai/tool-result-schemas.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { parseWithSchema } from "@/components/tool-ui/shared";
 import { ProcessUrlsOutputSchema } from "@/lib/ai/process-urls-shared";
+import { WebMapOutputSchema } from "@/lib/ai/web-map-shared";
 import {
   WebSearchResultSchema,
   normalizeWebSearchResult,
@@ -152,4 +153,43 @@ export function parseWebSearchResult(input: unknown): z.infer<typeof WebSearchRe
   }
 
   return parseWithSchema(WebSearchResultSchema, input, "WebSearchResult");
+}
+
+/** web_map – result is string or { text, links, metadata } */
+export const WebMapResultSchema = z.union([z.string(), WebMapOutputSchema]);
+
+export type WebMapResult = z.infer<typeof WebMapResultSchema>;
+
+export function parseWebMapResult(input: unknown): WebMapResult {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  if (input == null) {
+    return "";
+  }
+
+  if (typeof input !== "object") {
+    return String(input);
+  }
+
+  if (Array.isArray(input)) {
+    return JSON.stringify(input);
+  }
+
+  const res = WebMapOutputSchema.safeParse(input);
+  if (res.success) {
+    return res.data;
+  }
+
+  const obj = input as Record<string, unknown>;
+  if (typeof obj.text === "string") {
+    return obj.text;
+  }
+
+  if (typeof obj.message === "string") {
+    return obj.message;
+  }
+
+  return JSON.stringify(input);
 }

--- a/src/lib/ai/tools/index.ts
+++ b/src/lib/ai/tools/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { createProcessUrlsTool } from "./process-urls";
+import { createWebMapTool } from "./web-map";
 import {
   createDocumentTool,
   createDeleteItemTool,
@@ -45,6 +46,7 @@ export function createChatTools(config: ChatToolsConfig): Record<string, any> {
   return {
     // URL processing
     [CHAT_TOOL.WEB_FETCH]: createProcessUrlsTool(),
+    [CHAT_TOOL.WEB_MAP]: createWebMapTool(),
 
     // Search
     [CHAT_TOOL.WEB_SEARCH]: createWebSearchTool(),

--- a/src/lib/ai/tools/web-map.ts
+++ b/src/lib/ai/tools/web-map.ts
@@ -1,0 +1,107 @@
+import { tool, zodSchema } from "ai";
+import { logger } from "@/lib/utils/logger";
+import {
+  WebMapInputSchema,
+  WebMapOutputSchema,
+  MAX_WEB_MAP_LIMIT,
+  type WebMapOutput,
+} from "@/lib/ai/web-map-shared";
+import { FirecrawlClient } from "@/lib/ai/utils/firecrawl";
+
+/**
+ * Create the web_map tool for discovering URLs on a website.
+ */
+export function createWebMapTool() {
+  return tool({
+    description:
+      "Discover URLs on a website (sibling pages, sub-pages, related docs) without fetching their content. Use to map out the structure of a site before deciding which specific pages to fetch with web_fetch. Useful when the user pastes a single docs URL and you want to know what other pages live on the same site, or when finding a specific page on a known domain. Returns up to ~50 URLs with title and description. Cheap and fast; safe to call when in doubt about site structure.",
+    inputSchema: zodSchema(WebMapInputSchema),
+    outputSchema: zodSchema(WebMapOutputSchema),
+    strict: true,
+    execute: async ({
+      url,
+      search,
+      limit,
+      includeSubdomains,
+      sitemap,
+    }): Promise<WebMapOutput | string> => {
+      const effectiveLimit = limit ?? MAX_WEB_MAP_LIMIT;
+      logger.debug("🗺️ [WEB_MAP] Mapping site", {
+        url,
+        search,
+        limit: effectiveLimit,
+        includeSubdomains,
+        sitemap,
+      });
+
+      try {
+        const client = new FirecrawlClient();
+        const result = await client.mapUrl(url, {
+          search,
+          limit: effectiveLimit,
+          includeSubdomains,
+          sitemap,
+        });
+
+        if (!result.success) {
+          logger.warn("🗺️ [WEB_MAP] Map failed", {
+            url,
+            error: result.error,
+          });
+          return {
+            text: `Failed to map ${url}: ${result.error ?? "Unknown error"}`,
+            links: [],
+            metadata: {
+              sourceUrl: url,
+              total: 0,
+              truncated: false,
+              error: result.error ?? "Unknown error",
+            },
+          };
+        }
+
+        const truncated = result.links.length >= effectiveLimit;
+        const summary =
+          result.links.length === 0
+            ? `No URLs found at ${url}.`
+            : `Found ${result.links.length} URL(s) on ${url}${truncated ? " (limit reached — increase `limit` or narrow with `search` for more)" : ""}.`;
+
+        const text = [
+          summary,
+          "",
+          ...result.links.map((link) => {
+            const titlePart = link.title ? ` — ${link.title}` : "";
+            const descPart = link.description ? `\n  ${link.description}` : "";
+            return `- ${link.url}${titlePart}${descPart}`;
+          }),
+        ].join("\n");
+
+        return {
+          text,
+          links: result.links,
+          metadata: {
+            sourceUrl: url,
+            total: result.links.length,
+            truncated,
+            error: null,
+          },
+        };
+      } catch (error) {
+        logger.error("🗺️ [WEB_MAP] Error mapping site", {
+          url,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return {
+          text: `Error mapping ${url}: ${error instanceof Error ? error.message : String(error)}`,
+          links: [],
+          metadata: {
+            sourceUrl: url,
+            total: 0,
+            truncated: false,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        };
+      }
+    },
+  });
+}

--- a/src/lib/ai/utils/firecrawl.ts
+++ b/src/lib/ai/utils/firecrawl.ts
@@ -26,6 +26,19 @@ export interface FirecrawlPageResult {
     metadata?: FirecrawlMetadata;
 }
 
+export interface FirecrawlMapResult {
+    success: boolean;
+    links: Array<{ url: string; title?: string; description?: string }>;
+    error?: string;
+}
+
+export interface FirecrawlMapOptions {
+    search?: string;
+    limit?: number;
+    includeSubdomains?: boolean;
+    sitemap?: "include" | "skip" | "only";
+}
+
 export class FirecrawlClient {
     private apiKey: string;
     private baseUrl = "https://api.firecrawl.dev/v2";
@@ -211,5 +224,98 @@ export class FirecrawlClient {
 
         logger.debug(`🔥 [Firecrawl] Scraping ${urls.length} URLs in parallel`);
         return await Promise.all(urls.map((url) => this.scrapeUrl(url)));
+    }
+
+    async mapUrl(
+        url: string,
+        options: FirecrawlMapOptions = {},
+    ): Promise<FirecrawlMapResult> {
+        if (!this.apiKey) {
+            return {
+                success: false,
+                links: [],
+                error: "Firecrawl API key not configured",
+            };
+        }
+
+        try {
+            logger.debug(`🔥 [Firecrawl] Mapping URL: ${url}`);
+
+            const body: Record<string, unknown> = { url };
+            if (options.search !== undefined) body.search = options.search;
+            if (options.limit !== undefined) body.limit = options.limit;
+            if (options.includeSubdomains !== undefined) {
+                body.includeSubdomains = options.includeSubdomains;
+            }
+            if (options.sitemap !== undefined) body.sitemap = options.sitemap;
+
+            const response = await fetch(`${this.baseUrl}/map`, {
+                method: "POST",
+                headers: this.getHeaders(),
+                body: JSON.stringify(body),
+            });
+
+            if (!response.ok) {
+                return {
+                    success: false,
+                    links: [],
+                    error: await this.parseErrorResponse(response),
+                };
+            }
+
+            const result = await response.json();
+            if (result?.success === false) {
+                return {
+                    success: false,
+                    links: [],
+                    error:
+                        typeof result?.error === "string"
+                            ? result.error
+                            : "Unknown Firecrawl map error",
+                };
+            }
+
+            const rawLinks = Array.isArray(result?.links) ? result.links : [];
+            const links = rawLinks
+                .map((entry: unknown) => {
+                    if (typeof entry === "string") {
+                        return entry.length > 0 ? { url: entry } : null;
+                    }
+                    if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+                        const rec = entry as {
+                            url?: unknown;
+                            title?: unknown;
+                            description?: unknown;
+                        };
+                        if (typeof rec.url !== "string" || rec.url.length === 0) {
+                            return null;
+                        }
+                        return {
+                            url: rec.url,
+                            title: typeof rec.title === "string" ? rec.title : undefined,
+                            description:
+                                typeof rec.description === "string"
+                                    ? rec.description
+                                    : undefined,
+                        };
+                    }
+                    return null;
+                })
+                .filter(
+                    (
+                        link: { url: string; title?: string; description?: string } | null,
+                    ): link is { url: string; title?: string; description?: string } =>
+                        link !== null,
+                );
+
+            return { success: true, links };
+        } catch (error) {
+            logger.error(`❌ [Firecrawl] Error mapping ${url}:`, error);
+            return {
+                success: false,
+                links: [],
+                error: error instanceof Error ? error.message : String(error),
+            };
+        }
     }
 }

--- a/src/lib/ai/web-map-shared.ts
+++ b/src/lib/ai/web-map-shared.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+
+export const MAX_WEB_MAP_LIMIT = 50;
+export const MAX_WEB_MAP_LIMIT_HARD_CAP = 200;
+
+export const WebMapInputSchema = z.object({
+  url: z
+    .string()
+    .min(1)
+    .describe(
+      "The base URL of the site to map. Discovers URLs reachable from this page (sitemap + link discovery). Provide the canonical entry point (e.g. https://docs.python.org/3/ rather than a deep page) when you want a broad map.",
+    ),
+  search: z
+    .string()
+    .optional()
+    .describe(
+      "Optional keyword filter applied server-side. Only URLs whose path/title/description match are returned. Use this to narrow large sites.",
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_WEB_MAP_LIMIT_HARD_CAP)
+    .optional()
+    .describe(
+      `Maximum URLs to return. Defaults to ${MAX_WEB_MAP_LIMIT}. Hard cap ${MAX_WEB_MAP_LIMIT_HARD_CAP} to keep tool responses small.`,
+    ),
+  includeSubdomains: z
+    .boolean()
+    .optional()
+    .describe(
+      "Whether to include URLs on subdomains of the given host. Defaults to false.",
+    ),
+  sitemap: z
+    .enum(["include", "skip", "only"])
+    .optional()
+    .describe(
+      "How to use the site's sitemap.xml. 'include' (default) merges sitemap + link discovery, 'skip' ignores sitemap, 'only' uses sitemap only.",
+    ),
+});
+
+export type WebMapInput = z.infer<typeof WebMapInputSchema>;
+
+export const WebMapLinkSchema = z.object({
+  url: z.string(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+});
+
+export type WebMapLink = z.infer<typeof WebMapLinkSchema>;
+
+export const WebMapOutputSchema = z.object({
+  text: z
+    .string()
+    .describe(
+      "Human-readable summary of the mapped URLs, used by the model to reason over results without re-shaping the array.",
+    ),
+  links: z.array(WebMapLinkSchema),
+  metadata: z.object({
+    sourceUrl: z.string(),
+    total: z.number(),
+    truncated: z.boolean(),
+    error: z.string().nullable().optional(),
+  }),
+});
+
+export type WebMapOutput = z.infer<typeof WebMapOutputSchema>;
+
+export function normalizeWebMapArgs(input: unknown): WebMapInput | null {
+  const direct = WebMapInputSchema.safeParse(input);
+  if (direct.success) return direct.data;
+
+  if (!input || typeof input !== "object" || Array.isArray(input)) return null;
+
+  const legacy = input as { jsonInput?: string };
+  if (typeof legacy?.jsonInput === "string") {
+    try {
+      const parsed = JSON.parse(legacy.jsonInput);
+      const normalized = WebMapInputSchema.safeParse(parsed);
+      return normalized.success ? normalized.data : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}

--- a/src/lib/chat/types.ts
+++ b/src/lib/chat/types.ts
@@ -22,3 +22,28 @@ export type ChatMessage = UIMessage<ChatMessageMetadata>;
 /** Marker value written to `chat_messages.format` for every new row created after the migration. */
 export const CHAT_MESSAGE_FORMAT = "ai-sdk-ui/v1" as const;
 export type ChatMessageFormat = typeof CHAT_MESSAGE_FORMAT;
+
+/**
+ * Returns true if the UI message has at least one user-visible part. Pure structural
+ * parts (`step-start`) and empty/whitespace text parts don't count.
+ *
+ * Used as a guard for persistence and hydration so empty/aborted assistant rows
+ * (which would otherwise fail `safeValidateUIMessages.parts.nonempty(...)`) never
+ * make it into the validated message list.
+ */
+export function hasMeaningfulContent(message: unknown): boolean {
+  if (!message || typeof message !== "object") return false;
+  const parts = (message as { parts?: unknown }).parts;
+  if (!Array.isArray(parts) || parts.length === 0) return false;
+  return parts.some((part) => {
+    if (!part || typeof part !== "object") return false;
+    const type = (part as { type?: unknown }).type;
+    if (typeof type !== "string") return false;
+    if (type === "step-start") return false;
+    if (type === "text" || type === "reasoning") {
+      const text = (part as { text?: unknown }).text;
+      return typeof text === "string" && text.trim().length > 0;
+    }
+    return true;
+  });
+}

--- a/src/lib/utils/format-workspace-context.ts
+++ b/src/lib/utils/format-workspace-context.ts
@@ -144,6 +144,7 @@ WEB SEARCH GUIDELINES:
 Use web_search when: temporal cues ("today", "latest", "current"), real-time data (scores, stocks, weather), fact verification, niche/recent info.
 Use internal knowledge for: creative writing, coding, general concepts, summarizing provided content.
 If the information is time-sensitive, niche, or uncertain, prefer web_search.
+Use web_map when the user references a single URL but the answer might require knowing what other pages exist on that site (e.g. "what's on docs.foo.com?", "find the auth section of this docs site", or before calling web_fetch on multiple URLs from the same domain). Pair with web_fetch: web_map first to discover, then web_fetch on the chosen URL(s). Don't use web_map for general web search — use web_search.
 
 ${getCodeExecutionSystemInstructions()}
 


### PR DESCRIPTION
This PR adds a new `web_map` chat tool that the model can invoke to discover URLs on a domain (sibling pages, sub-pages, related docs) without fetching their content. The tool uses Firecrawl's `/v2/map` endpoint, returns up to 50 URLs by default (hard cap 200), and includes optional title and description for each link.

**Server-side implementation (`src/lib/ai/utils/firecrawl.ts`, `src/lib/ai/tools/web-map.ts`, `src/lib/ai/web-map-shared.ts`)**
- Add `FirecrawlMapResult`, `FirecrawlMapOptions` types and `mapUrl()` method to `FirecrawlClient`, mirroring the existing `scrapeUrl()`/`scrapeUrls()` patterns
- Add `createWebMapTool()` using `tool()` + `zodSchema()` from `ai` SDK with `strict: true`, accepting `url` (required), `search`, `limit`, `includeSubdomains`, and `sitemap` options
- Define `WebMapInputSchema`, `WebMapOutputSchema`, `WebMapLinkSchema`, and `normalizeWebMapArgs()` for legacy `jsonInput` parity with `web_fetch`
- Handle both response shapes defensively: `links: object[]` and legacy `links: string[]` (treats strings as `{ url }`)
- Reuse `getHeaders()`, `parseErrorResponse()`, and logger patterns from existing `scrapeUrl` implementation

**Tool registration (`src/lib/ai/chat-tool-names.ts`, `src/lib/ai/tools/index.ts`)**
- Add `WEB_MAP: "web_map"` to `CHAT_TOOL` next to `WEB_FETCH` and `WEB_SEARCH`
- Register `[CHAT_TOOL.WEB_MAP]: createWebMapTool()` under the `// URL processing` section

**UI renderer (`src/components/chat/tools/WebMapToolUI.tsx`, `src/components/chat/tools/registry.ts`)**
- Create `renderWebMapToolUI` following the exact pattern of `URLContextToolUI.tsx`: collapsible card, shimmer while running, error/status badges, and expandable list of links with url/title/description
- Use `MapIcon` from `lucide-react` for distinct branding, `ToolUIErrorBoundary`, and the shared `ToolRoot`/`ToolTrigger`/`ToolContent`/`ToolText` components
- Register at `[CHAT_TOOL.WEB_MAP]: renderWebMapToolUI`

**Result parsing (`src/lib/ai/tool-result-schemas.ts`)**
- Add `WebMapResultSchema` (union of `string` and `WebMapOutputSchema`) and `parseWebMapResult()` helper mirroring `parseURLContextResult`

**System prompt guidance (`src/lib/utils/format-workspace-context.ts`)**
- Add one-line directive under `WEB SEARCH GUIDELINES:` instructing when to use `web_map` (e.g., to discover structure before `web_fetch`, avoid for general web search)

**Tests (`src/lib/ai/__tests__/web-map-shared.test.ts`)**
- Add 8 tests covering `normalizeWebMapArgs`, schema validation, optional field parsing, legacy `jsonInput` handling, and limit hard cap rejection

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/3d835604-f797-4303-9ad2-3ea85dc43ce7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-067" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/3d835604-f797-4303-9ad2-3ea85dc43ce7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-067&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-067"><img alt="ENG-067" src="https://capy.ai/api/badge/thread.svg?label=ENG-067"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Web Map tool that discovers and displays URLs from a specified website in an animated collapsible card interface, making it easier to explore site structure.
  * Tool provides real-time status feedback during discovery, displays discovered links with metadata when available, and handles errors gracefully with informative messages.
  * Supports configurable URL limits for discovery results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->