### PR TITLE
Fix: scroll to bottom on thread load

### DIFF
--- a/src/components/chat/Messages.tsx
+++ b/src/components/chat/Messages.tsx
@@ -133,25 +133,30 @@ const MessagesImpl = () => {
 
   // When a thread is loaded/switched, drop the user at the bottom of the
   // scroll container so they land on the latest exchange (typically the
-  // most recent assistant response). `<Messages>` unmounts whenever the
-  // active thread changes — `ChatProvider.selectThread` clears messages
-  // and `<ThreadBody>` swaps in the loading skeleton — so this ref is
-  // fresh on every mount and naturally fires once per thread load.
-  const initialScrollToBottomRef = useRef(false);
+  // most recent assistant response). `<Messages>` remounts on every
+  // thread load — `ChatProvider.selectThread` clears messages and
+  // `<ThreadBody>` swaps in the loading skeleton until hydration
+  // completes — so a single mount-time effect is enough; no ref guard
+  // or dep tracking needed.
+  //
+  // We bail when `isStreaming` is true on mount so we don't fight the
+  // pin-to-top effect below in the brand-new-thread case (where
+  // `<Messages>` mounts mid-turn). Empty deps mean the effect won't
+  // re-fire when streaming ends, avoiding a post-turn scroll jolt.
   useLayoutEffect(() => {
-    if (initialScrollToBottomRef.current) return;
-    if (messages.length === 0) return;
-    // Active turns are handled by the pin-to-top effect below; don't
-    // fight it.
     if (isStreaming) return;
+    if (messages.length === 0) return;
     const handle = vlistRef.current;
     if (!handle) return;
-    initialScrollToBottomRef.current = true;
     const lastIndex = messages.length - 1;
     requestAnimationFrame(() => {
       handle.scrollToIndex(lastIndex, { align: "end" });
     });
-  }, [messages.length, isStreaming]);
+    // Intentional: fire once per <Messages> mount. `messages` and
+    // `isStreaming` are read from the first-render closure, which is
+    // the correct moment.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Pin the newest message just below the top of the viewport on every new
   // turn. Most turns arrive as a `ready → submitted` transition, but the

--- a/src/components/chat/Messages.tsx
+++ b/src/components/chat/Messages.tsx
@@ -131,6 +131,28 @@ const MessagesImpl = () => {
   const vlistRef = useRef<VListHandle>(null);
   const initialTurnPinnedRef = useRef(false);
 
+  // When a thread is loaded/switched, drop the user at the bottom of the
+  // scroll container so they land on the latest exchange (typically the
+  // most recent assistant response). `<Messages>` unmounts whenever the
+  // active thread changes — `ChatProvider.selectThread` clears messages
+  // and `<ThreadBody>` swaps in the loading skeleton — so this ref is
+  // fresh on every mount and naturally fires once per thread load.
+  const initialScrollToBottomRef = useRef(false);
+  useLayoutEffect(() => {
+    if (initialScrollToBottomRef.current) return;
+    if (messages.length === 0) return;
+    // Active turns are handled by the pin-to-top effect below; don't
+    // fight it.
+    if (isStreaming) return;
+    const handle = vlistRef.current;
+    if (!handle) return;
+    initialScrollToBottomRef.current = true;
+    const lastIndex = messages.length - 1;
+    requestAnimationFrame(() => {
+      handle.scrollToIndex(lastIndex, { align: "end" });
+    });
+  }, [messages.length, isStreaming]);
+
   // Pin the newest message just below the top of the viewport on every new
   // turn. Most turns arrive as a `ready → submitted` transition, but the
   // very first turn mounts `<Messages>` after we already left the welcome

--- a/src/components/chat/Messages.tsx
+++ b/src/components/chat/Messages.tsx
@@ -133,11 +133,12 @@ const MessagesImpl = () => {
 
   // When a thread is loaded/switched, drop the user at the bottom of the
   // scroll container so they land on the latest exchange (typically the
-  // most recent assistant response). `<Messages>` remounts on every
-  // thread load — `ChatProvider.selectThread` clears messages and
-  // `<ThreadBody>` swaps in the loading skeleton until hydration
-  // completes — so a single mount-time effect is enough; no ref guard
-  // or dep tracking needed.
+  // most recent assistant response). This relies on `<Messages>` being
+  // keyed by `threadId` in `<ThreadBody>` so React remounts it on every
+  // thread switch — a fresh mount is the one-shot signal, no ref guard
+  // or dep tracking needed. (Without the key the future
+  // `ChatRuntimesProvider` runtime cache would let React reconcile this
+  // tree in place across threads and the effect would stop firing.)
   //
   // We bail when `isStreaming` is true on mount so we don't fight the
   // pin-to-top effect below in the brand-new-thread case (where

--- a/src/components/chat/ThreadBody.tsx
+++ b/src/components/chat/ThreadBody.tsx
@@ -19,7 +19,7 @@ interface ThreadBodyProps {
  * `<Messages>` can rely on their DOM being present on first mount.
  */
 export function ThreadBody({ empty }: ThreadBodyProps) {
-  const { messages, isHistoryLoading } = useChatContext();
+  const { threadId, messages, isHistoryLoading } = useChatContext();
 
   if (messages.length === 0 && isHistoryLoading) {
     return (
@@ -45,5 +45,14 @@ export function ThreadBody({ empty }: ThreadBodyProps) {
     );
   }
 
-  return <Messages />;
+  // Key by threadId so `<Messages>` remounts on every thread switch.
+  // Today, ChatProvider clears messages on switch and we route through
+  // the skeleton above, so a remount happens naturally. Once the
+  // ChatRuntimesProvider lands and BoundChatProvider rebinds
+  // useChat({ chat }) to a cached runtime, that gap disappears — React
+  // would otherwise reconcile in place and stale per-thread state
+  // (initial scroll position, lastMeasuredUser, prevStatusRef, the
+  // initialTurnPinnedRef guard, virtua's internal cache) would carry
+  // across threads. The key forces a fresh mount instead.
+  return <Messages key={threadId} />;
 }


### PR DESCRIPTION
Fixes thread loading dropping users at the top of history instead of the latest exchange. `<Messages>` now calls `scrollToIndex(lastIndex, { align: "end" })` on mount when messages exist and we're not streaming, landing the user at the bottom of the thread (typically the most recent assistant response). The existing pin-to-top behavior for new turns remains unchanged.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/6c0136f2-7c9c-46a1-9392-fcd54ed50ab4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-068" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/6c0136f2-7c9c-46a1-9392-fcd54ed50ab4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-068&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-068"><img alt="ENG-068" src="https://capy.ai/api/badge/thread.svg?label=ENG-068"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message viewport auto-scrolling behavior when loading or switching between conversation threads for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->