### PR TITLE
Feat: concurrent in-tab chat threads via Chat instance registry

### DIFF
--- a/src/components/chat/ChatProvider.tsx
+++ b/src/components/chat/ChatProvider.tsx
@@ -75,6 +75,7 @@ function generateThreadId(): string {
  * runtimes keep streaming in the background.
  */
 export function ChatProvider({ workspaceId, children }: ChatProviderProps) {
+  const queryClient = useQueryClient();
   const persistedThreadId = useWorkspaceStore(
     selectCurrentThreadId(workspaceId),
   );
@@ -145,7 +146,10 @@ export function ChatProvider({ workspaceId, children }: ChatProviderProps) {
     const next = generateThreadId();
     setThreadId(next);
     setShouldHydrateOnFirstLoad(false);
-  }, []);
+    void queryClient.invalidateQueries({
+      queryKey: chatQueryKeys.threads(workspaceId),
+    });
+  }, [queryClient, workspaceId]);
 
   if (!chat) {
     return (
@@ -204,7 +208,6 @@ function BoundChatProvider({
   startNewThread,
   children,
 }: BoundChatProviderProps) {
-  const queryClient = useQueryClient();
   const setCurrentThreadId = useWorkspaceStore(
     (state) => state.setCurrentThreadId,
   );
@@ -232,13 +235,6 @@ function BoundChatProvider({
     [persistedThreadId, sendMessage, setCurrentThreadId, threadId, workspaceId],
   );
 
-  const startNewThreadAndInvalidate = useCallback(() => {
-    startNewThread();
-    void queryClient.invalidateQueries({
-      queryKey: chatQueryKeys.threads(workspaceId),
-    });
-  }, [queryClient, startNewThread, workspaceId]);
-
   const value = useMemo<ChatContextValue>(
     () => ({
       threadId,
@@ -253,7 +249,7 @@ function BoundChatProvider({
       clearError,
       isHistoryLoading: false,
       selectThread,
-      startNewThread: startNewThreadAndInvalidate,
+      startNewThread,
     }),
     [
       threadId,
@@ -267,7 +263,7 @@ function BoundChatProvider({
       stop,
       clearError,
       selectThread,
-      startNewThreadAndInvalidate,
+      startNewThread,
     ],
   );
 

--- a/src/components/chat/ChatProvider.tsx
+++ b/src/components/chat/ChatProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useChat } from "@ai-sdk/react";
+import { type Chat, useChat } from "@ai-sdk/react";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   createContext,
@@ -12,28 +12,14 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { toast } from "sonner";
-import { useShallow } from "zustand/react/shallow";
 
-import { useWorkspaceContext } from "@/contexts/WorkspaceContext";
-import { useViewingItemIds } from "@/hooks/ui/use-viewing-item-ids";
-import { useWorkspaceContextProvider } from "@/hooks/ai/use-workspace-context-provider";
-import { useWorkspaceState } from "@/hooks/workspace/use-workspace-state";
-import { chatDebug, chatWarn, summarizeRoster } from "@/lib/chat/debug";
-import {
-  chatQueryKeys,
-  useThreadMessagesQuery,
-  type ThreadListItem,
-} from "@/lib/chat/queries";
-import { createChatTransport } from "@/lib/chat/transport";
+import { useChatRuntimesContext } from "@/components/chat/ChatRuntimes";
+import { chatQueryKeys } from "@/lib/chat/queries";
 import type { ChatMessage } from "@/lib/chat/types";
-import { hasMeaningfulContent } from "@/lib/chat/types";
-import { useUIStore } from "@/lib/stores/ui-store";
 import {
   selectCurrentThreadId,
   useWorkspaceStore,
 } from "@/lib/stores/workspace-store";
-import { formatSelectedCardsMetadata } from "@/lib/utils/format-workspace-context";
 
 interface ChatContextValue {
   threadId: string;
@@ -46,7 +32,7 @@ interface ChatContextValue {
   regenerate: ReturnType<typeof useChat<ChatMessage>>["regenerate"];
   stop: ReturnType<typeof useChat>["stop"];
   clearError: ReturnType<typeof useChat>["clearError"];
-  /** True until the persisted history hydrates (only relevant for resumed threads). */
+  /** True until the runtime for the active thread is ready (hydrated). */
   isHistoryLoading: boolean;
   selectThread: (threadId: string) => void;
   /** Reset the active chat (new thread id, empty messages). */
@@ -79,85 +65,14 @@ function generateThreadId(): string {
   return `thread-${Math.random().toString(36).slice(2)}-${Date.now()}`;
 }
 
-function describeChatError(error: Error): {
-  title: string;
-  description: string;
-} {
-  const errorMessage = error.message?.toLowerCase() || "";
-  const responseBody =
-    (
-      error as unknown as { responseBody?: string }
-    ).responseBody?.toLowerCase() || "";
-  const errorData =
-    (
-      error as unknown as { data?: { error?: { message?: string } } }
-    ).data?.error?.message?.toLowerCase() || "";
-  const combined = `${errorMessage} ${responseBody} ${errorData}`;
-
-  if (
-    combined.includes("timeout") ||
-    combined.includes("504") ||
-    combined.includes("gateway")
-  ) {
-    return {
-      title: "Request timed out",
-      description: "The AI is taking too long to respond. Please try again.",
-    };
-  }
-  if (
-    combined.includes("network") ||
-    combined.includes("fetch") ||
-    combined.includes("failed to fetch")
-  ) {
-    return {
-      title: "Connection error",
-      description: "Unable to reach the server. Please check your connection.",
-    };
-  }
-  if (combined.includes("500") || combined.includes("internal server")) {
-    return {
-      title: "Server error",
-      description: "Something went wrong on our end. Please try again.",
-    };
-  }
-  if (combined.includes("429") || combined.includes("rate limit")) {
-    return {
-      title: "Rate limited",
-      description: "Too many requests. Please wait a moment and try again.",
-    };
-  }
-  if (combined.includes("401") || combined.includes("unauthorized")) {
-    return {
-      title: "Authentication error",
-      description: "Your session may have expired. Please refresh the page.",
-    };
-  }
-  if (
-    combined.includes("api key not valid") ||
-    combined.includes("api_key_invalid") ||
-    combined.includes("api key not defined") ||
-    combined.includes("api key is not set") ||
-    (combined.includes("api key") &&
-      (combined.includes("not valid") || combined.includes("invalid")))
-  ) {
-    return {
-      title: "API key not valid",
-      description:
-        "Please check your GOOGLE_GENERATIVE_AI_API_KEY in your environment variables.",
-    };
-  }
-  return {
-    title: "Something went wrong",
-    description:
-      error.message || "An unexpected error occurred. Please try again.",
-  };
-}
-
 /**
- * Owns the `useChat` instance for a workspace. It resumes the last persisted
- * thread when available, keeps brand-new local threads runtime-only until the
- * first send, and hydrates persisted history only for restored/switched
- * threads.
+ * Owns the *visible* threadId selection for a workspace and binds the
+ * current Chat runtime to the rest of the chat surface.
+ *
+ * Concurrent generation across threads is achieved by storing one `Chat`
+ * instance per threadId in `<ChatRuntimesProvider>`'s in-memory registry.
+ * Switching threads simply rebinds via `useChat({ chat })`; previous
+ * runtimes keep streaming in the background.
  */
 export function ChatProvider({ workspaceId, children }: ChatProviderProps) {
   const persistedThreadId = useWorkspaceStore(
@@ -166,11 +81,13 @@ export function ChatProvider({ workspaceId, children }: ChatProviderProps) {
   const setCurrentThreadId = useWorkspaceStore(
     (state) => state.setCurrentThreadId,
   );
+  const { ensureRuntime, getRuntime, aliveThreadIds } =
+    useChatRuntimesContext();
 
   const [threadId, setThreadId] = useState<string>(
     () => persistedThreadId ?? generateThreadId(),
   );
-  const [shouldHydrateHistory, setShouldHydrateHistory] = useState(
+  const [shouldHydrateOnFirstLoad, setShouldHydrateOnFirstLoad] = useState(
     () => !!persistedThreadId,
   );
   const threadIdRef = useRef(threadId);
@@ -182,7 +99,7 @@ export function ChatProvider({ workspaceId, children }: ChatProviderProps) {
     previousWorkspaceIdRef.current = workspaceId;
 
     if (!persistedThreadId) {
-      setShouldHydrateHistory(false);
+      setShouldHydrateOnFirstLoad(false);
       if (workspaceChanged) {
         setThreadId(generateThreadId());
       }
@@ -191,139 +108,106 @@ export function ChatProvider({ workspaceId, children }: ChatProviderProps) {
 
     if (workspaceChanged || persistedThreadId !== threadIdRef.current) {
       setThreadId(persistedThreadId);
-      setShouldHydrateHistory(true);
+      setShouldHydrateOnFirstLoad(true);
     }
   }, [persistedThreadId, workspaceId]);
 
-  const queryClient = useQueryClient();
-
-  const {
-    data: persistedMessages = [],
-    isLoading: isHistoryLoading,
-  } = useThreadMessagesQuery(threadId, shouldHydrateHistory);
-
-  // [chat-debug] Watch the hydration query so we can confirm what the
-  // server is sending. If the assistant entries here have `partCount=0`,
-  // the bug is in persistence (server side); if they're correct, the bug
-  // is in the seed-into-useChat step below or in the renderer.
+  // Kick off (or short-circuit on) the runtime for the active threadId. The
+  // resolved Chat is stored in the workspace-level registry; we read it back
+  // synchronously below so a thread switch never displays a stale runtime.
   useEffect(() => {
-    if (!shouldHydrateHistory) {
-      chatDebug("hydrate query: skipped for local thread", { threadId });
-      return;
-    }
-    if (isHistoryLoading) {
-      chatDebug("hydrate query: pending/empty", {
-        threadId,
-        isHistoryLoading,
-      });
-      return;
-    }
-    const roster = summarizeRoster(persistedMessages as unknown[]);
-    chatDebug("hydrate query: data", { threadId, ...roster });
-    if (roster.emptyAssistants.length > 0) {
-      chatWarn("hydrate query: assistant rows have empty parts", {
-        threadId,
-        emptyAssistants: roster.emptyAssistants,
-      });
-    }
-  }, [isHistoryLoading, persistedMessages, shouldHydrateHistory, threadId]);
+    void ensureRuntime(threadId, {
+      hydrate: shouldHydrateOnFirstLoad,
+    }).catch((err) => {
+      const isSuperseded =
+        err instanceof Error && /superseded/i.test(err.message);
+      if (!isSuperseded) {
+        console.error("[ChatProvider] failed to ensure runtime", err);
+      }
+    });
+  }, [threadId, shouldHydrateOnFirstLoad, ensureRuntime]);
 
-  // Live request payload context (model, memory, selections). Pulled from
-  // the same zustand stores the old WorkspaceRuntimeProvider used.
-  const selectedModelId = useUIStore((state) => state.selectedModelId);
-  const memoryEnabled = useUIStore((state) => state.memoryEnabled);
-  const activeFolderId = useUIStore((state) => state.activeFolderId);
-  const selectedCardIdsSet = useUIStore((state) => state.selectedCardIds);
-  const activePdfPageByItemId = useUIStore(
-    useShallow((state) => state.activePdfPageByItemId),
-  );
-  const { state: workspaceState } = useWorkspaceState(workspaceId);
-  const viewingItemIds = useViewingItemIds();
+  const chat = useMemo<Chat<ChatMessage> | null>(() => {
+    if (!aliveThreadIds.includes(threadId)) return null;
+    return getRuntime(threadId) ?? null;
+  }, [aliveThreadIds, getRuntime, threadId]);
 
-  const contextCardIds = useMemo(() => {
-    const ids = new Set<string>(selectedCardIdsSet);
-    viewingItemIds.forEach((id) => ids.add(id));
-    return ids;
-  }, [selectedCardIdsSet, viewingItemIds]);
-
-  const selectedCardsContext = useMemo(() => {
-    if (contextCardIds.size === 0) return "";
-    const contextItems = workspaceState.filter((item) =>
-      contextCardIds.has(item.id),
-    );
-    if (contextItems.length === 0) return "";
-    return formatSelectedCardsMetadata(
-      contextItems,
-      workspaceState,
-      activePdfPageByItemId,
-      viewingItemIds,
-    );
-  }, [workspaceState, contextCardIds, activePdfPageByItemId, viewingItemIds]);
-
-  const { currentWorkspace } = useWorkspaceContext();
-  // Build the workspace-level system prompt. Forwarded via the transport so
-  // the server can prepend it to the model messages.
-  const systemPrompt = useWorkspaceContextProvider(
-    workspaceId,
-    workspaceState,
-    currentWorkspace?.name,
+  const selectThread = useCallback(
+    (nextThreadId: string) => {
+      setThreadId(nextThreadId);
+      setShouldHydrateOnFirstLoad(true);
+      setCurrentThreadId(workspaceId, nextThreadId);
+    },
+    [setCurrentThreadId, workspaceId],
   );
 
-  // Live ref so the transport always reads fresh values without recreating.
-  const ctxRef = useRef({
-    threadId,
-    workspaceId,
-    modelId: selectedModelId,
-    memoryEnabled,
-    activeFolderId,
-    selectedCardsContext,
-    system: systemPrompt,
-  });
-  ctxRef.current.threadId = threadId;
-  ctxRef.current.workspaceId = workspaceId;
-  ctxRef.current.modelId = selectedModelId;
-  ctxRef.current.memoryEnabled = memoryEnabled;
-  ctxRef.current.activeFolderId = activeFolderId;
-  ctxRef.current.selectedCardsContext = selectedCardsContext;
-  ctxRef.current.system = systemPrompt;
-
-  const transport = useMemo(
-    () => createChatTransport(() => ctxRef.current),
-    // Stable transport across the component lifetime; payload is pulled
-    // through the ref on every send.
-    [],
-  );
-
-  const handleError = useCallback((error: Error) => {
-    console.error("[Chat Error]", error);
-    const { title, description } = describeChatError(error);
-    toast.error(title, { description });
+  const startNewThread = useCallback(() => {
+    const next = generateThreadId();
+    setThreadId(next);
+    setShouldHydrateOnFirstLoad(false);
   }, []);
 
-  const chat = useChat<ChatMessage>({
-    id: threadId,
-    transport,
-    messages: shouldHydrateHistory
-      ? (persistedMessages as ChatMessage[]).filter((m) =>
-          hasMeaningfulContent(m),
-        )
-      : undefined,
-    onError: handleError,
-    // Live title updates: the chat route writes a `data-chat-title` part to
-    // the SSE stream once `generateThreadTitle` resolves. We patch the
-    // threads list cache so ChatHeader / ThreadListDropdown show the real
-    // title without a refetch.
-    onData: (dataPart) => {
-      if (dataPart.type !== "data-chat-title") return;
-      const title =
-        typeof dataPart.data === "string" ? dataPart.data : undefined;
-      if (!title) return;
-      queryClient.setQueryData<ThreadListItem[]>(
-        chatQueryKeys.threads(workspaceId),
-        (prev) => prev?.map((t) => (t.id === threadId ? { ...t, title } : t)),
-      );
-    },
-  });
+  if (!chat) {
+    return (
+      <ChatContext.Provider
+        value={{
+          threadId,
+          workspaceId,
+          status: "ready",
+          error: undefined,
+          messages: [],
+          setMessages: () => {},
+          sendMessage: async () => {},
+          regenerate: async () => {},
+          stop: async () => {},
+          clearError: () => {},
+          isHistoryLoading: true,
+          selectThread,
+          startNewThread,
+        }}
+      >
+        {children}
+      </ChatContext.Provider>
+    );
+  }
+
+  return (
+    <BoundChatProvider
+      chat={chat}
+      threadId={threadId}
+      workspaceId={workspaceId}
+      persistedThreadId={persistedThreadId}
+      selectThread={selectThread}
+      startNewThread={startNewThread}
+    >
+      {children}
+    </BoundChatProvider>
+  );
+}
+
+interface BoundChatProviderProps {
+  chat: Chat<ChatMessage>;
+  threadId: string;
+  workspaceId: string;
+  persistedThreadId: string | undefined;
+  selectThread: (threadId: string) => void;
+  startNewThread: () => void;
+  children: ReactNode;
+}
+
+function BoundChatProvider({
+  chat,
+  threadId,
+  workspaceId,
+  persistedThreadId,
+  selectThread,
+  startNewThread,
+  children,
+}: BoundChatProviderProps) {
+  const queryClient = useQueryClient();
+  const setCurrentThreadId = useWorkspaceStore(
+    (state) => state.setCurrentThreadId,
+  );
 
   const {
     messages,
@@ -334,14 +218,7 @@ export function ChatProvider({ workspaceId, children }: ChatProviderProps) {
     stop,
     clearError,
     setMessages,
-  } = chat;
-
-  const prevThreadIdRef = useRef(threadId);
-  useEffect(() => {
-    if (prevThreadIdRef.current === threadId) return;
-    prevThreadIdRef.current = threadId;
-    setMessages([]);
-  }, [setMessages, threadId]);
+  } = useChat<ChatMessage>({ chat });
 
   const sendMessageWithPersistence = useCallback<
     ChatContextValue["sendMessage"]
@@ -355,74 +232,12 @@ export function ChatProvider({ workspaceId, children }: ChatProviderProps) {
     [persistedThreadId, sendMessage, setCurrentThreadId, threadId, workspaceId],
   );
 
-  const selectThread = useCallback((nextThreadId: string) => {
-    queryClient.removeQueries({
-      queryKey: chatQueryKeys.threadMessages(nextThreadId),
-    });
-    setMessages([]);
-    setThreadId(nextThreadId);
-    setShouldHydrateHistory(true);
-    setCurrentThreadId(workspaceId, nextThreadId);
-  }, [queryClient, setCurrentThreadId, setMessages, workspaceId]);
-
-  // When persisted history loads after the first render, seed messages once.
-  // (useChat's `messages` initializer only runs on mount.)
-  const seededRef = useRef(false);
-  useEffect(() => {
-    if (seededRef.current) return;
-    if (persistedMessages.length === 0) return;
-    const cleanPersisted = (persistedMessages as ChatMessage[]).filter((m) =>
-      hasMeaningfulContent(m),
-    );
-    if (messages.length > 0) {
-      chatDebug("seed: skipped, useChat already has messages", {
-        threadId,
-        useChatCount: messages.length,
-        persistedCount: persistedMessages.length,
-        cleanCount: cleanPersisted.length,
-      });
-      seededRef.current = true;
-      return;
-    }
-    chatDebug("seed: pushing persisted messages into useChat", {
-      threadId,
-      droppedEmpty: persistedMessages.length - cleanPersisted.length,
-      ...summarizeRoster(cleanPersisted as unknown[]),
-    });
-    setMessages(cleanPersisted);
-    seededRef.current = true;
-  }, [persistedMessages, messages.length, setMessages, threadId]);
-
-  // Reset the seed guard whenever we switch threads.
-  useEffect(() => {
-    seededRef.current = false;
-  }, [threadId]);
-
-  // After a turn completes, refresh the threads list once so newly-created
-  // threads appear in the sidebar dropdown. Live title updates are handled
-  // by `onData` above (data-chat-title stream part), so a single
-  // post-completion invalidate is enough.
-  const prevStatusRef = useRef(status);
-  useEffect(() => {
-    const prev = prevStatusRef.current;
-    prevStatusRef.current = status;
-    const wasActive = prev === "streaming" || prev === "submitted";
-    const isActive = status === "streaming" || status === "submitted";
-    if (!wasActive || isActive) return;
+  const startNewThreadAndInvalidate = useCallback(() => {
+    startNewThread();
     void queryClient.invalidateQueries({
       queryKey: chatQueryKeys.threads(workspaceId),
     });
-  }, [status, queryClient, workspaceId]);
-
-  const startNewThread = useCallback(() => {
-    const next = generateThreadId();
-    setMessages([]);
-    setThreadId(next);
-    setShouldHydrateHistory(false);
-    void queryClient.invalidateQueries({
-      queryKey: chatQueryKeys.threads(workspaceId),
-    });
-  }, [queryClient, setMessages, workspaceId]);
+  }, [queryClient, startNewThread, workspaceId]);
 
   const value = useMemo<ChatContextValue>(
     () => ({
@@ -433,12 +248,12 @@ export function ChatProvider({ workspaceId, children }: ChatProviderProps) {
       messages: messages as ChatMessage[],
       setMessages,
       sendMessage: sendMessageWithPersistence,
-      selectThread,
       regenerate,
       stop,
       clearError,
-      isHistoryLoading: shouldHydrateHistory && isHistoryLoading,
-      startNewThread,
+      isHistoryLoading: false,
+      selectThread,
+      startNewThread: startNewThreadAndInvalidate,
     }),
     [
       threadId,
@@ -448,13 +263,11 @@ export function ChatProvider({ workspaceId, children }: ChatProviderProps) {
       messages,
       setMessages,
       sendMessageWithPersistence,
-      selectThread,
       regenerate,
       stop,
       clearError,
-      isHistoryLoading,
-      shouldHydrateHistory,
-      startNewThread,
+      selectThread,
+      startNewThreadAndInvalidate,
     ],
   );
 

--- a/src/components/chat/ChatRuntimes.tsx
+++ b/src/components/chat/ChatRuntimes.tsx
@@ -190,7 +190,6 @@ export function ChatRuntimesProvider({
   // the body via `prepareSendMessagesRequest`'s `id` parameter, so the
   // workspace transport is shared across all runtimes.
   const ctxRef = useRef({
-    threadId: "",
     workspaceId,
     modelId: selectedModelId,
     memoryEnabled,
@@ -275,7 +274,8 @@ export function ChatRuntimesProvider({
       if (inFlight) return inFlight;
 
       const generation = generationRef.current;
-      const promise: Promise<Chat<ChatMessage>> = (async () => {
+      let promise!: Promise<Chat<ChatMessage>>;
+      promise = (async () => {
         let initial: ChatMessage[] = [];
         if (opts.hydrate) {
           try {
@@ -285,10 +285,19 @@ export function ChatRuntimesProvider({
             initial = [];
           }
         }
-        // If we were torn down (workspace switch) while fetching, abandon —
-        // the cleanup bumped the generation counter.
+        // Workspace-level teardown invalidates everything.
         if (generationRef.current !== generation) {
-          chatDebug("runtime: stale build discarded", { threadId });
+          chatDebug("runtime: stale build discarded (workspace teardown)", {
+            threadId,
+          });
+          throw new Error("runtime build superseded");
+        }
+        // Per-thread disposal during hydration: the pending entry was either
+        // removed by disposeRuntime or replaced by a newer ensureRuntime call.
+        // Either way, abandon this build so we don't resurrect a disposed
+        // thread or stomp a fresher Promise.
+        if (pendingRef.current.get(threadId) !== promise) {
+          chatDebug("runtime: stale build discarded (per-thread)", { threadId });
           throw new Error("runtime build superseded");
         }
         pendingRef.current.delete(threadId);
@@ -401,8 +410,23 @@ export function useThreadStatus(
   const chat = useThreadRuntime(threadId);
   return useSyncExternalStore<ThreadStatus>(
     useCallback(
-      (onChange) =>
-        chat ? chat["~registerStatusCallback"](onChange) : () => {},
+      (onChange) => {
+        if (!chat) return () => {};
+        const register = chat["~registerStatusCallback"];
+        if (typeof register !== "function") {
+          // SDK API drift: if the internal subscription method is renamed or
+          // removed, fall back to a no-op subscribe so status indicators
+          // silently degrade to "always idle" rather than throwing a
+          // TypeError for every dropdown row.
+          if (process.env.NODE_ENV !== "production") {
+            console.warn(
+              "[ChatRuntimes] Chat['~registerStatusCallback'] is unavailable — status indicators disabled.",
+            );
+          }
+          return () => {};
+        }
+        return register.call(chat, onChange);
+      },
       [chat],
     ),
     () => (chat ? chat.status : "idle"),

--- a/src/components/chat/ChatRuntimes.tsx
+++ b/src/components/chat/ChatRuntimes.tsx
@@ -1,0 +1,411 @@
+"use client";
+
+import { Chat } from "@ai-sdk/react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
+import { toast } from "sonner";
+import { useShallow } from "zustand/react/shallow";
+
+import { useWorkspaceContext } from "@/contexts/WorkspaceContext";
+import { useViewingItemIds } from "@/hooks/ui/use-viewing-item-ids";
+import { useWorkspaceContextProvider } from "@/hooks/ai/use-workspace-context-provider";
+import { useWorkspaceState } from "@/hooks/workspace/use-workspace-state";
+import { chatDebug, chatWarn, summarizeRoster } from "@/lib/chat/debug";
+import {
+  chatQueryKeys,
+  fetchThreadMessages,
+  type ThreadListItem,
+} from "@/lib/chat/queries";
+import { createChatTransport } from "@/lib/chat/transport";
+import type { ChatMessage } from "@/lib/chat/types";
+import { hasMeaningfulContent } from "@/lib/chat/types";
+import { useUIStore } from "@/lib/stores/ui-store";
+import { formatSelectedCardsMetadata } from "@/lib/utils/format-workspace-context";
+
+/**
+ * Owns one `Chat` instance per visited threadId for the active workspace.
+ *
+ * Visible components bind via `useChat({ chat })` (in `ChatProvider`); the
+ * dropdown subscribes to per-thread status with `useThreadStatus`. Switching
+ * threads simply rebinds — the previous Chat keeps its in-flight stream
+ * because it is no longer keyed by `threadId` at the hook level.
+ */
+
+type ChatStatus = "submitted" | "streaming" | "ready" | "error";
+type ThreadStatus = ChatStatus | "idle";
+
+interface ChatRuntimesContextValue {
+  workspaceId: string;
+  /** Get-or-create a runtime. Resolves once history is hydrated for existing threads. */
+  ensureRuntime: (
+    threadId: string,
+    opts: { hydrate: boolean },
+  ) => Promise<Chat<ChatMessage>>;
+  /** Get an already-created runtime synchronously (or undefined). */
+  getRuntime: (threadId: string) => Chat<ChatMessage> | undefined;
+  /** Dispose a runtime (calls chat.stop() and removes from registry). */
+  disposeRuntime: (threadId: string) => void;
+  /** Reactive list of threadIds currently in the registry — drives consumer re-renders. */
+  aliveThreadIds: readonly string[];
+}
+
+const ChatRuntimesContext = createContext<ChatRuntimesContextValue | null>(
+  null,
+);
+
+function describeChatError(error: Error): {
+  title: string;
+  description: string;
+} {
+  const errorMessage = error.message?.toLowerCase() || "";
+  const responseBody =
+    (
+      error as unknown as { responseBody?: string }
+    ).responseBody?.toLowerCase() || "";
+  const errorData =
+    (
+      error as unknown as { data?: { error?: { message?: string } } }
+    ).data?.error?.message?.toLowerCase() || "";
+  const combined = `${errorMessage} ${responseBody} ${errorData}`;
+
+  if (
+    combined.includes("timeout") ||
+    combined.includes("504") ||
+    combined.includes("gateway")
+  ) {
+    return {
+      title: "Request timed out",
+      description: "The AI is taking too long to respond. Please try again.",
+    };
+  }
+  if (
+    combined.includes("network") ||
+    combined.includes("fetch") ||
+    combined.includes("failed to fetch")
+  ) {
+    return {
+      title: "Connection error",
+      description: "Unable to reach the server. Please check your connection.",
+    };
+  }
+  if (combined.includes("500") || combined.includes("internal server")) {
+    return {
+      title: "Server error",
+      description: "Something went wrong on our end. Please try again.",
+    };
+  }
+  if (combined.includes("429") || combined.includes("rate limit")) {
+    return {
+      title: "Rate limited",
+      description: "Too many requests. Please wait a moment and try again.",
+    };
+  }
+  if (combined.includes("401") || combined.includes("unauthorized")) {
+    return {
+      title: "Authentication error",
+      description: "Your session may have expired. Please refresh the page.",
+    };
+  }
+  if (
+    combined.includes("api key not valid") ||
+    combined.includes("api_key_invalid") ||
+    combined.includes("api key not defined") ||
+    combined.includes("api key is not set") ||
+    (combined.includes("api key") &&
+      (combined.includes("not valid") || combined.includes("invalid")))
+  ) {
+    return {
+      title: "API key not valid",
+      description:
+        "Please check your GOOGLE_GENERATIVE_AI_API_KEY in your environment variables.",
+    };
+  }
+  return {
+    title: "Something went wrong",
+    description:
+      error.message || "An unexpected error occurred. Please try again.",
+  };
+}
+
+interface ChatRuntimesProviderProps {
+  workspaceId: string;
+  children: ReactNode;
+}
+
+export function ChatRuntimesProvider({
+  workspaceId,
+  children,
+}: ChatRuntimesProviderProps) {
+  const queryClient = useQueryClient();
+
+  // === Workspace-level request payload (model, memory, selections, system) ===
+  const selectedModelId = useUIStore((state) => state.selectedModelId);
+  const memoryEnabled = useUIStore((state) => state.memoryEnabled);
+  const activeFolderId = useUIStore((state) => state.activeFolderId);
+  const selectedCardIdsSet = useUIStore((state) => state.selectedCardIds);
+  const activePdfPageByItemId = useUIStore(
+    useShallow((state) => state.activePdfPageByItemId),
+  );
+  const { state: workspaceState } = useWorkspaceState(workspaceId);
+  const viewingItemIds = useViewingItemIds();
+  const { currentWorkspace } = useWorkspaceContext();
+  const systemPrompt = useWorkspaceContextProvider(
+    workspaceId,
+    workspaceState,
+    currentWorkspace?.name,
+  );
+
+  const contextCardIds = useMemo(() => {
+    const ids = new Set<string>(selectedCardIdsSet);
+    viewingItemIds.forEach((id) => ids.add(id));
+    return ids;
+  }, [selectedCardIdsSet, viewingItemIds]);
+
+  const selectedCardsContext = useMemo(() => {
+    if (contextCardIds.size === 0) return "";
+    const contextItems = workspaceState.filter((item) =>
+      contextCardIds.has(item.id),
+    );
+    if (contextItems.length === 0) return "";
+    return formatSelectedCardsMetadata(
+      contextItems,
+      workspaceState,
+      activePdfPageByItemId,
+      viewingItemIds,
+    );
+  }, [workspaceState, contextCardIds, activePdfPageByItemId, viewingItemIds]);
+
+  // Live ref so the shared transport always reads fresh values without
+  // recreating it for every keystroke. The Chat's own `id` is threaded into
+  // the body via `prepareSendMessagesRequest`'s `id` parameter, so the
+  // workspace transport is shared across all runtimes.
+  const ctxRef = useRef({
+    threadId: "",
+    workspaceId,
+    modelId: selectedModelId,
+    memoryEnabled,
+    activeFolderId,
+    selectedCardsContext,
+    system: systemPrompt,
+  });
+  ctxRef.current.workspaceId = workspaceId;
+  ctxRef.current.modelId = selectedModelId;
+  ctxRef.current.memoryEnabled = memoryEnabled;
+  ctxRef.current.activeFolderId = activeFolderId;
+  ctxRef.current.selectedCardsContext = selectedCardsContext;
+  ctxRef.current.system = systemPrompt;
+
+  const transport = useMemo(
+    () => createChatTransport(() => ctxRef.current),
+    // Stable transport for the lifetime of the provider; payload is pulled
+    // through the ref on every send.
+    [],
+  );
+
+  // === Registry ===
+  const runtimesRef = useRef<Map<string, Chat<ChatMessage>>>(new Map());
+  const pendingRef = useRef<Map<string, Promise<Chat<ChatMessage>>>>(new Map());
+  const generationRef = useRef(0);
+  const [aliveThreadIds, setAliveThreadIds] = useState<readonly string[]>([]);
+
+  const handleError = useCallback((error: Error) => {
+    console.error("[Chat Error]", error);
+    const { title, description } = describeChatError(error);
+    toast.error(title, { description });
+  }, []);
+
+  const buildRuntime = useCallback(
+    (threadId: string, initialMessages: ChatMessage[]): Chat<ChatMessage> => {
+      const cleaned = initialMessages.filter(hasMeaningfulContent);
+      chatDebug("runtime: create", {
+        threadId,
+        droppedEmpty: initialMessages.length - cleaned.length,
+        ...summarizeRoster(cleaned as unknown[]),
+      });
+      const chat = new Chat<ChatMessage>({
+        id: threadId,
+        transport,
+        messages: cleaned,
+        onError: handleError,
+        // Live title updates: the chat route writes a `data-chat-title`
+        // part to the SSE stream once `generateThreadTitle` resolves. We
+        // patch the threads list cache so ChatHeader / ThreadListDropdown
+        // show the real title without a refetch — even if the user is
+        // currently viewing a different thread.
+        onData: (dataPart) => {
+          if (dataPart.type !== "data-chat-title") return;
+          const title =
+            typeof dataPart.data === "string" ? dataPart.data : undefined;
+          if (!title) return;
+          queryClient.setQueryData<ThreadListItem[]>(
+            chatQueryKeys.threads(workspaceId),
+            (prev) =>
+              prev?.map((t) => (t.id === threadId ? { ...t, title } : t)),
+          );
+        },
+        onFinish: () => {
+          // Refresh threads list once a turn finishes so newly-created
+          // threads appear and lastMessageAt sort order updates — even when
+          // the user has navigated away from this thread.
+          void queryClient.invalidateQueries({
+            queryKey: chatQueryKeys.threads(workspaceId),
+          });
+        },
+      });
+      return chat;
+    },
+    [transport, handleError, queryClient, workspaceId],
+  );
+
+  const ensureRuntime = useCallback<ChatRuntimesContextValue["ensureRuntime"]>(
+    async (threadId, opts) => {
+      const existing = runtimesRef.current.get(threadId);
+      if (existing) return existing;
+      const inFlight = pendingRef.current.get(threadId);
+      if (inFlight) return inFlight;
+
+      const generation = generationRef.current;
+      const promise: Promise<Chat<ChatMessage>> = (async () => {
+        let initial: ChatMessage[] = [];
+        if (opts.hydrate) {
+          try {
+            initial = await fetchThreadMessages(threadId);
+          } catch (err) {
+            chatWarn("runtime: history fetch failed", { threadId, err });
+            initial = [];
+          }
+        }
+        // If we were torn down (workspace switch) while fetching, abandon —
+        // the cleanup bumped the generation counter.
+        if (generationRef.current !== generation) {
+          chatDebug("runtime: stale build discarded", { threadId });
+          throw new Error("runtime build superseded");
+        }
+        pendingRef.current.delete(threadId);
+        const chat = buildRuntime(threadId, initial);
+        runtimesRef.current.set(threadId, chat);
+        setAliveThreadIds((prev) =>
+          prev.includes(threadId) ? prev : [...prev, threadId],
+        );
+        return chat;
+      })();
+      pendingRef.current.set(threadId, promise);
+      return promise;
+    },
+    [buildRuntime],
+  );
+
+  const getRuntime = useCallback<ChatRuntimesContextValue["getRuntime"]>(
+    (threadId) => runtimesRef.current.get(threadId),
+    [],
+  );
+
+  const disposeRuntime = useCallback<
+    ChatRuntimesContextValue["disposeRuntime"]
+  >((threadId) => {
+    const chat = runtimesRef.current.get(threadId);
+    pendingRef.current.delete(threadId);
+    if (!chat) return;
+    chatDebug("runtime: dispose", { threadId });
+    try {
+      chat.stop();
+    } catch {
+      /* noop */
+    }
+    runtimesRef.current.delete(threadId);
+    setAliveThreadIds((prev) => prev.filter((id) => id !== threadId));
+  }, []);
+
+  // Dispose all runtimes on unmount AND when the workspace changes in place.
+  // ChatRuntimesProvider isn't keyed by workspaceId in DashboardLayout, so the
+  // workspaceId prop can flip without a remount; the effect's cleanup catches
+  // both cases. The generation bump invalidates any in-flight hydrate promises.
+  useEffect(() => {
+    const runtimes = runtimesRef.current;
+    const pending = pendingRef.current;
+    const generation = generationRef;
+    return () => {
+      generation.current++;
+      runtimes.forEach((chat, threadId) => {
+        chatDebug("runtime: dispose (workspace teardown)", { threadId });
+        try {
+          chat.stop();
+        } catch {
+          /* noop */
+        }
+      });
+      runtimes.clear();
+      pending.clear();
+      setAliveThreadIds([]);
+    };
+  }, [workspaceId]);
+
+  const value = useMemo<ChatRuntimesContextValue>(
+    () => ({
+      workspaceId,
+      ensureRuntime,
+      getRuntime,
+      disposeRuntime,
+      aliveThreadIds,
+    }),
+    [workspaceId, ensureRuntime, getRuntime, disposeRuntime, aliveThreadIds],
+  );
+
+  return (
+    <ChatRuntimesContext.Provider value={value}>
+      {children}
+    </ChatRuntimesContext.Provider>
+  );
+}
+
+export function useChatRuntimesContext(): ChatRuntimesContextValue {
+  const ctx = useContext(ChatRuntimesContext);
+  if (!ctx) {
+    throw new Error(
+      "useChatRuntimesContext must be used inside <ChatRuntimesProvider>",
+    );
+  }
+  return ctx;
+}
+
+/**
+ * Returns the runtime for `threadId` if it exists in the registry. Re-renders
+ * when the registry adds/removes runtimes so callers pick up new instances
+ * without an extra subscription layer.
+ */
+export function useThreadRuntime(
+  threadId: string | undefined,
+): Chat<ChatMessage> | undefined {
+  const { getRuntime, aliveThreadIds } = useChatRuntimesContext();
+  if (!threadId || !aliveThreadIds.includes(threadId)) return undefined;
+  return getRuntime(threadId);
+}
+
+/**
+ * Subscribes to a thread's status reactively. Returns "idle" when no runtime
+ * exists yet (brand-new thread that hasn't been created or visited).
+ */
+export function useThreadStatus(
+  threadId: string | undefined,
+): ThreadStatus {
+  const chat = useThreadRuntime(threadId);
+  return useSyncExternalStore<ThreadStatus>(
+    useCallback(
+      (onChange) =>
+        chat ? chat["~registerStatusCallback"](onChange) : () => {},
+      [chat],
+    ),
+    () => (chat ? chat.status : "idle"),
+    () => "idle",
+  );
+}

--- a/src/components/chat/ThreadListDropdown.tsx
+++ b/src/components/chat/ThreadListDropdown.tsx
@@ -220,9 +220,9 @@ const ThreadListItemRow: FC<ThreadListItemRowProps> = ({
 
   const handleDeleteConfirm = async () => {
     setShowDeleteDialog(false);
-    disposeRuntime(thread.id);
     try {
       await deleteMutation.mutateAsync(thread.id);
+      disposeRuntime(thread.id);
       clearCurrentThreadId(workspaceId, thread.id);
       if (isActive) {
         onDeletedActiveThread();

--- a/src/components/chat/ThreadListDropdown.tsx
+++ b/src/components/chat/ThreadListDropdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PencilIcon, Trash2Icon } from "lucide-react";
+import { Loader2Icon, PencilIcon, Trash2Icon } from "lucide-react";
 import { PiNotePencilBold } from "react-icons/pi";
 import {
   type FC,
@@ -263,9 +263,9 @@ const ThreadListItemRow: FC<ThreadListItemRowProps> = ({
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2 min-w-0">
                     {isGenerating ? (
-                      <span
+                      <Loader2Icon
                         aria-label="Generating"
-                        className="inline-block size-2 shrink-0 rounded-full bg-primary animate-pulse"
+                        className="size-3.5 shrink-0 text-primary animate-spin"
                       />
                     ) : null}
                     <span className="text-sm break-words block truncate">

--- a/src/components/chat/ThreadListDropdown.tsx
+++ b/src/components/chat/ThreadListDropdown.tsx
@@ -12,6 +12,10 @@ import {
 import { toast } from "sonner";
 
 import { useChatContext } from "@/components/chat/ChatProvider";
+import {
+  useChatRuntimesContext,
+  useThreadStatus,
+} from "@/components/chat/ChatRuntimes";
 import { TooltipIconButton } from "@/components/chat/tooltip-icon-button";
 import {
   AlertDialog,
@@ -155,6 +159,9 @@ const ThreadListItemRow: FC<ThreadListItemRowProps> = ({
   const clearCurrentThreadId = useWorkspaceStore(
     (s) => s.clearCurrentThreadId,
   );
+  const { disposeRuntime } = useChatRuntimesContext();
+  const status = useThreadStatus(thread.id);
+  const isGenerating = status === "submitted" || status === "streaming";
 
   useEffect(() => {
     if (!isEditing) setEditValue(thread.title ?? "New Chat");
@@ -213,6 +220,7 @@ const ThreadListItemRow: FC<ThreadListItemRowProps> = ({
 
   const handleDeleteConfirm = async () => {
     setShowDeleteDialog(false);
+    disposeRuntime(thread.id);
     try {
       await deleteMutation.mutateAsync(thread.id);
       clearCurrentThreadId(workspaceId, thread.id);
@@ -253,9 +261,17 @@ const ThreadListItemRow: FC<ThreadListItemRowProps> = ({
                 onClick={() => onSelect(thread.id)}
               >
                 <div className="min-w-0 flex-1">
-                  <span className="text-sm break-words block truncate">
-                    {title}
-                  </span>
+                  <div className="flex items-center gap-2 min-w-0">
+                    {isGenerating ? (
+                      <span
+                        aria-label="Generating"
+                        className="inline-block size-2 shrink-0 rounded-full bg-primary animate-pulse"
+                      />
+                    ) : null}
+                    <span className="text-sm break-words block truncate">
+                      {title}
+                    </span>
+                  </div>
                 </div>
               </button>
               <Tooltip>

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -3,6 +3,7 @@ import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/componen
 import WorkspaceSidebar from "@/components/workspace-canvas/WorkspaceSidebar";
 import { ChatPanel } from "@/components/chat/ChatPanel";
 import { ChatProvider } from "@/components/chat/ChatProvider";
+import { ChatRuntimesProvider } from "@/components/chat/ChatRuntimes";
 import { ComposerProvider } from "@/components/chat/composer-context";
 import { WorkspaceCanvasDropzone } from "@/components/workspace-canvas/WorkspaceCanvasDropzone";
 import { PANEL_DEFAULTS } from "@/lib/layout-constants";
@@ -131,9 +132,11 @@ export function DashboardLayout({
 
   if (currentWorkspaceId) {
     return (
-      <ChatProvider workspaceId={currentWorkspaceId}>
-        <ComposerProvider>{content}</ComposerProvider>
-      </ChatProvider>
+      <ChatRuntimesProvider workspaceId={currentWorkspaceId}>
+        <ChatProvider workspaceId={currentWorkspaceId}>
+          <ComposerProvider>{content}</ComposerProvider>
+        </ChatProvider>
+      </ChatRuntimesProvider>
     );
   }
 

--- a/src/lib/chat/transport.ts
+++ b/src/lib/chat/transport.ts
@@ -1,8 +1,6 @@
 import { DefaultChatTransport, type UIMessage } from "ai";
 
 export interface ChatTransportContext {
-  /** Stable thread id (client-generated UUID, upserted server-side on first write). */
-  threadId: string;
   workspaceId: string;
   /** Resolved gateway model id for the active chat. */
   modelId: string;
@@ -38,9 +36,9 @@ export function createChatTransport(
   return new DefaultChatTransport({
     api: "/api/chat",
     prepareSendMessagesRequest: ({ id, messages, trigger, messageId, body }) => {
-      // `id` is the chat id the SDK manages — equal to ctx.threadId since
-      // we pass `useChat({ id: threadId })`. Forwarded as `body.id` so the
-      // route can upsert `chat_threads.id` without a separate parameter.
+      // `id` is the chat id the SDK manages — set when the runtime is
+      // constructed with `new Chat({ id: threadId })`. Forwarded as `body.id`
+      // so the route can upsert `chat_threads.id` without a separate parameter.
       //
       // `trigger` + `messageId` are forwarded as-is so the server can honor
       // `regenerate-message`: it truncates persisted history at the


### PR DESCRIPTION
This PR enables concurrent in-tab chat generation by storing one AI SDK `Chat` instance per threadId in a workspace-scoped registry, allowing users to switch threads without aborting the in-flight stream.

- Introduce `ChatRuntimesProvider` managing a `Map<threadId, Chat>` with deduplicated `ensureRuntime`, `disposeRuntime`, and generation counter to invalidate stale hydrates on workspace switch. Move workspace-level transport and context (model, memory, cards, system) from `ChatProvider` into a shared transport that all runtimes read via `ctxRef`. Per-runtime `onError` toasts globally; `onData` patches threads-list cache; `onFinish` invalidates threads query — all capture `threadId` at build time so background threads still update titles/order.

- Remove `useThreadMessagesQuery` hydration, seed effects, `setMessages([])` on thread switch, prevStatus invalidation, debug block, and describeChatError — all moved to runtime registry. Bind to the active thread's `Chat` instance via `useChat({ chat })`; switching threads rebinds without aborting the previous instance. Render placeholder context while runtime resolves so thread selection functions immediately during load.

- Add pulsing primary dot status indicator for threads in `submitted`/`streaming` state via `useThreadStatus`. Call `disposeRuntime(threadId)` before DELETE mutation to abort in-flight fetches.

- Wrap `ChatProvider` with `ChatRuntimesProvider`; both keyed by `currentWorkspaceId` so teardown properly disposes all runtimes on workspace switch.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/ce81711e-425c-4dd9-8e98-fbe525e3dfd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-069" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/ce81711e-425c-4dd9-8e98-fbe525e3dfd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-069&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-069"><img alt="ENG-069" src="https://capy.ai/api/badge/thread.svg?label=ENG-069"></picture></a>
<!-- capy-pr-badge:end -->