### PR TITLE
fix: hide bottom gradient overlay below footer on signed-in home page

### DIFF
--- a/src/components/home/HomeContent.tsx
+++ b/src/components/home/HomeContent.tsx
@@ -376,13 +376,15 @@ export function HomeContent({ showDemoVideo, initialAuth }: HomeContentProps) {
               <FloatingWorkspaceCards bottomGradientHeight="40%" />
             </div>
 
-            <div
-              className="fixed bottom-0 left-0 right-0 h-[40vh] pointer-events-none z-[5]"
-              style={{
-                background:
-                  "linear-gradient(to bottom, transparent 0%, var(--background) 100%)",
-              }}
-            />
+            {effectiveShowDemo && (
+              <div
+                className="fixed bottom-0 left-0 right-0 h-[40vh] pointer-events-none z-[5]"
+                style={{
+                  background:
+                    "linear-gradient(to bottom, transparent 0%, var(--background) 100%)",
+                }}
+              />
+            )}
 
             <div
               className={cn(


### PR DESCRIPTION
## Problem
On `/home` after sign-in, cream-colored space extends below the site footer to the bottom of the viewport. The page actually ends at the footer — there's no extra layout height — but a fixed-position gradient paints over the bottom 40vh of the screen regardless of where content ends.

**Before:**
<img width="1456" height="830" alt="IMG_5935" src="https://github.com/user-attachments/assets/5245d8d7-7dfa-4b55-bb57-93f77ea60a65" />

## Root cause
`src/components/home/HomeContent.tsx:379-385` renders a `position: fixed` cream-to-background gradient pinned to the bottom 40vh of the viewport. This was designed for the unauth landing page where it blends into the marketing background, but it leaks into the signed-in case where the page ends at the footer — the fixed gradient keeps painting cream over the bottom of the screen with no content beneath it.

This was previously flagged as a side-effect concern in the recon for #[previous PR number] but left for follow-up.

## Fix
Wrap the gradient in `{effectiveShowDemo && (...)}` so it only renders when the demo video is active. Same gating pattern as the `min-h-screen` fix in #[previous PR number]:

```tsx
{effectiveShowDemo && (
  <div className="fixed bottom-0 left-0 right-0 h-[40vh] ..." />
)}
```

`effectiveShowDemo` was already in scope (used at lines 390 and 435 of the same component).

## Verification
- `pnpm lint` clean
- Demo-video path preserved: when `effectiveShowDemo` is true (unauth landing or signed-in with demo flag), gradient renders exactly as before
- Could not verify in-app locally due to the standing `append_workspace_event` DB blocker, but the change is a pure conditional render with no logic changes — element attributes byte-identical to before

## Out of scope
- The fixed top bar overlapping the workspaces card heading on scroll — separate bug, separate fix
- Any restructuring of the gradient's positioning strategy (`fixed` vs `absolute` to scroll container) — kept simple

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a visual element that was unnecessarily displayed in certain scenarios; it now appears conditionally based on application state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->