### PR TITLE
fix: local dev startup — wal_level, native SQLite bindings, and missing TCC_API_KEY

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-thinkex}
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
+    command: ["postgres", "-c", "wal_level=logical"]
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -13,10 +13,14 @@ export function register() {
     serviceName: "thinkex",
     spanProcessors: [
       "auto",
-      new TCCSpanProcessor({
-        debug: false,
-        otlpUrl: "https://ingest.thecontext.company",
-      }),
+      ...(process.env.TCC_API_KEY
+        ? [
+            new TCCSpanProcessor({
+              debug: false,
+              otlpUrl: "https://ingest.thecontext.company",
+            }),
+          ]
+        : []),
     ],
   });
 }


### PR DESCRIPTION
Summary
Fixes three issues that prevented pnpm dev from starting on a fresh clone or after switching Node versions.

Changes
1. docker-compose.yml — enable logical replication in Postgres
Zero (the sync engine) requires wal_level = logical in Postgres. The Docker container was starting with the default replica level, causing the [zero] process to crash immediately.
2. src/instrumentation.ts — make telemetry key optional
TCCSpanProcessor threw a hard error at startup when TCC_API_KEY was not set. This key is only available in staging/prod, so local dev always failed. The processor is now skipped when the key is absent.

**Steps to get unblocked (for anyone on an older version of this repo)**

**Step 1** — Rebuild the native SQLite binding (only needed once per machine / after a Node version change)
cd /path/to/thinkex
npx node-gyp rebuild --directory \
  node_modules/.pnpm/@rocicorp+zero-sqlite3@1.0.15/node_modules/@rocicorp/zero-sqlite3

This compiles the native better_sqlite3.node addon for your current Node version. You'll need Xcode Command Line Tools on Mac (xcode-select --install).

**Step 2** — Recreate the Postgres Docker container (needed once to pick up the new wal_level flag)
docker-compose up -d --force-recreate postgres

docker-compose restart is not enough — the container must be fully recreated to apply the new startup command. Your data volume is preserved.

**Step 3** — Run as normal
pnpm dev

Why --force-recreate and not just restart
docker-compose restart re-runs the existing container config. The command: directive in docker-compose.yml only takes effect when the container is created, not restarted. --force-recreate tears down and rebuilds the container while keeping the named postgres_data volume intact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Updated PostgreSQL database configuration for operational improvements
- Refined the observability system to only function when API credentials are explicitly configured

<!-- end of auto-generated comment: release notes by coderabbit.ai -->