### PR TITLE
Fix: skip folder delete dialog for empty folders

### DIFF
--- a/src/components/workspace-canvas/FlashcardWorkspaceCard.tsx
+++ b/src/components/workspace-canvas/FlashcardWorkspaceCard.tsx
@@ -22,12 +22,10 @@ import type {
 } from "@/lib/workspace-state/types";
 import { FlipCard } from "./FlipCard";
 import {
-  SWATCHES_COLOR_GROUPS,
   getCardColorCSS,
   getCardAccentColor,
   type CardColor,
 } from "@/lib/workspace-state/colors";
-import { SwatchesPicker, ColorResult } from "react-color";
 import { useUIStore, selectItemScrollLocked } from "@/lib/stores/ui-store";
 import { StreamdownMarkdown } from "@/components/ui/streamdown-markdown";
 import {
@@ -44,24 +42,8 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import MoveToDialog from "@/components/modals/MoveToDialog";
-import RenameDialog from "@/components/modals/RenameDialog";
+import { WorkspaceCardDialogs } from "./WorkspaceCardDialogs";
+import { useItemActionDialogs } from "@/hooks/workspace/use-item-action-dialogs";
 import { cn } from "@/lib/utils";
 interface FlashcardWorkspaceCardProps {
   item: Item;
@@ -165,10 +147,13 @@ export function FlashcardWorkspaceCard({
   const onToggleSelection = useUIStore((state) => state.toggleCardSelection);
   const { resolvedTheme } = useTheme();
 
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-  const [showMoveDialog, setShowMoveDialog] = useState(false);
-  const [showRenameDialog, setShowRenameDialog] = useState(false);
-  const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
+  const actions = useItemActionDialogs({
+    item,
+    onDeleteItem,
+    onUpdateItem,
+    onMoveItem: onMoveItem ? (id, folderId) => { onMoveItem(id, folderId); toast.success("Item moved"); } : undefined,
+  });
+
   const [isFlipped, setIsFlipped] = useState(false);
   const [isFlipping, setIsFlipping] = useState(false);
   // Get scroll lock state from Zustand store (persists across interactions)
@@ -250,31 +235,6 @@ export function FlashcardWorkspaceCard({
       }
     };
   }, []);
-
-  const handleDelete = useCallback(() => {
-    setShowDeleteDialog(true);
-  }, []);
-
-  const confirmDelete = useCallback(() => {
-    onDeleteItem(item.id);
-    setShowDeleteDialog(false);
-  }, [item.id, onDeleteItem]);
-
-  const handleColorChange = useCallback(
-    (color: ColorResult) => {
-      onUpdateItem(item.id, { color: color.hex as CardColor });
-      setIsColorPickerOpen(false);
-    },
-    [item.id, onUpdateItem],
-  );
-
-  const handleRename = useCallback(
-    (newName: string) => {
-      onUpdateItem(item.id, { name: newName });
-      toast.success("Flashcard renamed");
-    },
-    [item.id, onUpdateItem],
-  );
 
   // Helper function to hide tabs during flip animation
   const startFlipAnimation = useCallback(() => {
@@ -596,13 +556,13 @@ export function FlashcardWorkspaceCard({
                 className="w-48"
                 onClick={(e) => e.stopPropagation()}
               >
-                <DropdownMenuItem onSelect={() => setShowRenameDialog(true)}>
+                <DropdownMenuItem onSelect={() => actions.requestRename()}>
                   <Pencil className="mr-2 h-4 w-4" />
                   <span>Rename</span>
                 </DropdownMenuItem>
                 {onMoveItem && (
                   <>
-                    <DropdownMenuItem onSelect={() => setShowMoveDialog(true)}>
+                    <DropdownMenuItem onSelect={() => actions.requestMove()}>
                       <FolderInput className="mr-2 h-4 w-4" />
                       <span>Move to</span>
                     </DropdownMenuItem>
@@ -613,13 +573,13 @@ export function FlashcardWorkspaceCard({
                   <Pencil className="mr-2 h-4 w-4" />
                   <span>Edit</span>
                 </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => setIsColorPickerOpen(true)}>
+                <DropdownMenuItem onSelect={() => actions.requestColorPicker()}>
                   <Palette className="mr-2 h-4 w-4" />
                   <span>Change Color</span>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
-                  onClick={handleDelete}
+                  onClick={() => actions.requestDelete()}
                   className="text-destructive focus:text-destructive"
                 >
                   <Trash2 className="mr-2 h-4 w-4" />
@@ -628,29 +588,6 @@ export function FlashcardWorkspaceCard({
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
-
-          <Dialog open={isColorPickerOpen} onOpenChange={setIsColorPickerOpen}>
-            <DialogContent
-              className="w-auto max-w-fit p-6"
-              onClick={(e) => e.stopPropagation()}
-              onMouseDown={(e) => e.stopPropagation()}
-            >
-              <DialogHeader>
-                <DialogTitle>Choose a Color</DialogTitle>
-              </DialogHeader>
-              <div
-                className="flex justify-center color-picker-wrapper"
-                onClick={(e) => e.stopPropagation()}
-                onMouseDown={(e) => e.stopPropagation()}
-              >
-                <SwatchesPicker
-                  color={item.color || "#3B82F6"}
-                  colors={SWATCHES_COLOR_GROUPS}
-                  onChangeComplete={handleColorChange}
-                />
-              </div>
-            </DialogContent>
-          </Dialog>
 
           {/* Navigation Controls - Only show if Multiple Cards */}
           {cards.length > 1 && (
@@ -762,65 +699,37 @@ export function FlashcardWorkspaceCard({
             </div>
           </div>
 
-          <AlertDialog
-            open={showDeleteDialog}
-            onOpenChange={setShowDeleteDialog}
-          >
-            <AlertDialogContent onClick={(e) => e.stopPropagation()}>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Delete Flashcard</AlertDialogTitle>
-                <AlertDialogDescription>
-                  Are you sure you want to delete "
-                  {item.name || "this flashcard"}"? You can restore from version
-                  history if needed.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction onClick={confirmDelete}>
-                  Delete
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-
-          {/* Rename Dialog */}
-          <RenameDialog
-            open={showRenameDialog}
-            onOpenChange={setShowRenameDialog}
-            currentName={item.name || "Untitled"}
-            itemType={item.type}
-            onRename={handleRename}
+          <WorkspaceCardDialogs
+            item={item}
+            allItems={allItems || []}
+            workspaceName={workspaceName || ""}
+            workspaceIcon={workspaceIcon}
+            workspaceColor={workspaceColor}
+            isColorPickerOpen={actions.showColorPicker}
+            onColorPickerOpenChange={actions.setShowColorPicker}
+            showDeleteDialog={actions.showDeleteDialog}
+            onDeleteDialogChange={actions.setShowDeleteDialog}
+            showMoveDialog={actions.showMoveDialog}
+            onMoveDialogChange={actions.setShowMoveDialog}
+            showRenameDialog={actions.showRenameDialog}
+            onRenameDialogChange={actions.setShowRenameDialog}
+            onColorChange={actions.handleColorChange}
+            onDeleteConfirm={() => { actions.confirmDelete(); toast.success("Card deleted successfully"); }}
+            onRename={(newName) => { actions.handleRename(newName); toast.success("Flashcard renamed"); }}
+            onMove={onMoveItem ? actions.handleMove : undefined}
           />
-
-          {/* Move to Dialog */}
-          {onMoveItem && allItems && workspaceName && (
-            <MoveToDialog
-              open={showMoveDialog}
-              onOpenChange={setShowMoveDialog}
-              item={item}
-              allItems={allItems}
-              workspaceName={workspaceName}
-              workspaceIcon={workspaceIcon}
-              workspaceColor={workspaceColor}
-              onMove={(folderId) => {
-                onMoveItem(item.id, folderId);
-                toast.success("Item moved");
-              }}
-            />
-          )}
         </div>
       </ContextMenuTrigger>
 
       {/* Right-Click Context Menu */}
       <ContextMenuContent className="w-48">
-        <ContextMenuItem onSelect={() => setShowRenameDialog(true)}>
+        <ContextMenuItem onSelect={() => actions.requestRename()}>
           <Pencil className="mr-2 h-4 w-4" />
           <span>Rename</span>
         </ContextMenuItem>
         {onMoveItem && (
           <>
-            <ContextMenuItem onSelect={() => setShowMoveDialog(true)}>
+            <ContextMenuItem onSelect={() => actions.requestMove()}>
               <FolderInput className="mr-2 h-4 w-4" />
               <span>Move to</span>
             </ContextMenuItem>
@@ -831,13 +740,13 @@ export function FlashcardWorkspaceCard({
           <Pencil className="mr-2 h-4 w-4" />
           <span>Edit</span>
         </ContextMenuItem>
-        <ContextMenuItem onSelect={() => setIsColorPickerOpen(true)}>
+        <ContextMenuItem onSelect={() => actions.requestColorPicker()}>
           <Palette className="mr-2 h-4 w-4" />
           <span>Change Color</span>
         </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem
-          onSelect={handleDelete}
+          onSelect={() => actions.requestDelete()}
           className="text-destructive focus:text-destructive"
         >
           <Trash2 className="mr-2 h-4 w-4" />

--- a/src/components/workspace-canvas/FolderCard.tsx
+++ b/src/components/workspace-canvas/FolderCard.tsx
@@ -388,7 +388,11 @@ function FolderCardComponent({
                 <DropdownMenuItem
                   onClick={(e) => {
                     e.stopPropagation();
-                    setShowDeleteConfirm(true);
+                    if (itemCount === 0) {
+                      onDeleteItem(item.id);
+                    } else {
+                      setShowDeleteConfirm(true);
+                    }
                   }}
                   className="text-destructive focus:text-destructive"
                 >
@@ -595,7 +599,13 @@ function FolderCardComponent({
         </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem
-          onSelect={() => setShowDeleteConfirm(true)}
+          onSelect={() => {
+            if (itemCount === 0) {
+              onDeleteItem(item.id);
+            } else {
+              setShowDeleteConfirm(true);
+            }
+          }}
           className="text-destructive focus:text-destructive"
         >
           <Trash2 className="mr-2 h-4 w-4" />

--- a/src/components/workspace-canvas/FolderCard.tsx
+++ b/src/components/workspace-canvas/FolderCard.tsx
@@ -3,11 +3,11 @@
 import { memo, useState, useCallback, useEffect, useRef } from "react";
 import { MoreVertical, Trash2, Palette, CheckCircle2, FolderInput, X, Pencil } from "lucide-react";
 import ItemHeader from "@/components/workspace-canvas/ItemHeader";
-import { SwatchesPicker, ColorResult } from "react-color";
 import { cn } from "@/lib/utils";
 import type { Item } from "@/lib/workspace-state/types";
-import { getCardColorCSS, getCardAccentColor, SWATCHES_COLOR_GROUPS, type CardColor } from "@/lib/workspace-state/colors";
+import { getCardColorCSS, getCardAccentColor } from "@/lib/workspace-state/colors";
 import { useTheme } from "next-themes";
+import { toast } from "sonner";
 
 import { useUIStore } from "@/lib/stores/ui-store";
 import {
@@ -24,25 +24,8 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import MoveToDialog from "@/components/modals/MoveToDialog";
-import RenameDialog from "@/components/modals/RenameDialog";
-import { toast } from "sonner";
+import { WorkspaceCardDialogs } from "./WorkspaceCardDialogs";
+import { useItemActionDialogs } from "@/hooks/workspace/use-item-action-dialogs";
 
 interface FolderCardProps {
   item: Item; // Folder-type item
@@ -75,11 +58,15 @@ function FolderCardComponent({
   onDeleteFolderWithContents,
   onMoveItem,
 }: FolderCardProps) {
-  const [showColorPicker, setShowColorPicker] = useState(false);
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [deleteOption, setDeleteOption] = useState<'keep' | 'delete' | null>(null);
-  const [showMoveDialog, setShowMoveDialog] = useState(false);
-  const [showRenameDialog, setShowRenameDialog] = useState(false);
+  const actions = useItemActionDialogs({
+    item,
+    itemCount,
+    onDeleteItem,
+    onDeleteFolderWithContents,
+    onUpdateItem,
+    onMoveItem: onMoveItem ? (id, folderId) => { onMoveItem(id, folderId); toast.success('Folder moved'); } : undefined,
+  });
+
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isDragHover, setIsDragHover] = useState(false);
   const [selectedCount, setSelectedCount] = useState<number | null>(null);
@@ -194,14 +181,6 @@ function FolderCardComponent({
     onOpenFolder(item.id);
   }, [item.id, onOpenFolder, onToggleSelection, isEditingTitle]);
 
-  const handleColorChange = useCallback(
-    (color: ColorResult) => {
-      onUpdateItem(item.id, { color: color.hex as CardColor });
-      setShowColorPicker(false);
-    },
-    [item.id, onUpdateItem]
-  );
-
   // Handlers for inline title editing (like WorkspaceCard)
   const handleNameChange = useCallback((v: string) => {
     onUpdateItem(item.id, { name: v });
@@ -210,28 +189,6 @@ function FolderCardComponent({
   const handleNameCommit = useCallback((v: string) => {
     onUpdateItem(item.id, { name: v });
   }, [item.id, onUpdateItem]);
-
-  const handleDelete = useCallback(() => {
-    if (deleteOption === 'delete' && onDeleteFolderWithContents) {
-      onDeleteFolderWithContents(item.id);
-    } else {
-      onDeleteItem(item.id);
-    }
-    setShowDeleteConfirm(false);
-    setDeleteOption(null);
-  }, [item.id, onDeleteItem, onDeleteFolderWithContents, deleteOption]);
-
-  const handleRename = useCallback((newName: string) => {
-    onUpdateItem(item.id, { name: newName });
-    toast.success("Folder renamed");
-  }, [item.id, onUpdateItem]);
-
-  // Reset delete option when dialog closes
-  useEffect(() => {
-    if (!showDeleteConfirm) {
-      setDeleteOption(null);
-    }
-  }, [showDeleteConfirm]);
 
   const { resolvedTheme } = useTheme();
 
@@ -355,7 +312,7 @@ function FolderCardComponent({
                 <DropdownMenuItem
                   onClick={(e) => {
                     e.stopPropagation();
-                    setShowRenameDialog(true);
+                    actions.requestRename();
                   }}
                 >
                   <Pencil className="mr-2 h-4 w-4" />
@@ -366,7 +323,7 @@ function FolderCardComponent({
                     <DropdownMenuItem
                       onClick={(e) => {
                         e.stopPropagation();
-                        setShowMoveDialog(true);
+                        actions.requestMove();
                       }}
                     >
                       <FolderInput className="mr-2 h-4 w-4" />
@@ -378,7 +335,7 @@ function FolderCardComponent({
                 <DropdownMenuItem
                   onClick={(e) => {
                     e.stopPropagation();
-                    setShowColorPicker(true);
+                    actions.requestColorPicker();
                   }}
                 >
                   <Palette className="mr-2 h-4 w-4" />
@@ -388,11 +345,7 @@ function FolderCardComponent({
                 <DropdownMenuItem
                   onClick={(e) => {
                     e.stopPropagation();
-                    if (itemCount === 0) {
-                      onDeleteItem(item.id);
-                    } else {
-                      setShowDeleteConfirm(true);
-                    }
+                    actions.requestDelete();
                   }}
                   className="text-destructive focus:text-destructive"
                 >
@@ -447,165 +400,54 @@ function FolderCardComponent({
             )}
           </div>
 
-
-          {/* Color Picker Dialog - same styling as WorkspaceCard */}
-          <Dialog open={showColorPicker} onOpenChange={setShowColorPicker}>
-            <DialogContent
-              className="w-auto max-w-fit p-6"
-              onClick={(e) => e.stopPropagation()}
-              onMouseDown={(e) => e.stopPropagation()}
-            >
-              <DialogHeader>
-                <DialogTitle>Choose Folder Color</DialogTitle>
-              </DialogHeader>
-              <div
-                className="flex justify-center color-picker-wrapper"
-                onClick={(e) => e.stopPropagation()}
-                onMouseDown={(e) => e.stopPropagation()}
-              >
-                <SwatchesPicker
-                  color={folderColor}
-                  onChange={handleColorChange}
-                  colors={SWATCHES_COLOR_GROUPS}
-                />
-              </div>
-            </DialogContent>
-          </Dialog>
-
-          {/* Delete Confirmation Dialog */}
-          <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
-            <AlertDialogContent
-              onClick={(e) => e.stopPropagation()}
-              onMouseDown={(e) => e.stopPropagation()}
-            >
-              <AlertDialogHeader>
-                <AlertDialogTitle>Delete Folder</AlertDialogTitle>
-                <AlertDialogDescription asChild>
-                  <div className="space-y-4">
-                    <div>
-                      Choose what happens to the {itemCount} {itemCount === 1 ? 'item' : 'items'} in &quot;{item.name}&quot;:
-                    </div>
-                    <div className="space-y-3 pt-2">
-                      <label className="flex items-start space-x-3 cursor-pointer group">
-                        <input
-                          type="radio"
-                          name="deleteOption"
-                          value="keep"
-                          checked={deleteOption === 'keep'}
-                          onChange={() => setDeleteOption('keep')}
-                          className="mt-1 h-4 w-4 text-primary focus:ring-primary border-gray-300"
-                          onClick={(e) => e.stopPropagation()}
-                        />
-                        <div className="flex-1">
-                          <div className="font-medium text-sm">Keep items</div>
-                          <div className="text-xs text-muted-foreground">
-                            Move items out of folder before deleting
-                          </div>
-                        </div>
-                      </label>
-                      <label className={`flex items-start space-x-3 group ${onDeleteFolderWithContents ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}`}>
-                        <input
-                          type="radio"
-                          name="deleteOption"
-                          value="delete"
-                          checked={deleteOption === 'delete'}
-                          onChange={() => setDeleteOption('delete')}
-                          disabled={!onDeleteFolderWithContents}
-                          className="mt-1 h-4 w-4 text-destructive focus:ring-destructive border-gray-300 disabled:opacity-50"
-                          onClick={(e) => e.stopPropagation()}
-                        />
-                        <div className="flex-1">
-                          <div className="font-medium text-sm text-destructive">Delete items</div>
-                          <div className="text-xs text-muted-foreground">
-                            Delete folder and all {itemCount} {itemCount === 1 ? 'item' : 'items'} inside
-                          </div>
-                        </div>
-                      </label>
-                    </div>
-                  </div>
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setDeleteOption(null);
-                  }}
-                  onMouseDown={(e) => e.stopPropagation()}
-                >
-                  Cancel
-                </AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleDelete();
-                  }}
-                  onMouseDown={(e) => e.stopPropagation()}
-                  disabled={deleteOption === null}
-                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  Delete
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-
-          {/* Rename Dialog */}
-          <RenameDialog
-            open={showRenameDialog}
-            onOpenChange={setShowRenameDialog}
-            currentName={item.name}
-            itemType="folder"
-            onRename={handleRename}
+          <WorkspaceCardDialogs
+            item={item}
+            allItems={allItems}
+            workspaceName={workspaceName}
+            workspaceIcon={workspaceIcon}
+            workspaceColor={workspaceColor}
+            isColorPickerOpen={actions.showColorPicker}
+            onColorPickerOpenChange={actions.setShowColorPicker}
+            showDeleteDialog={actions.showDeleteDialog}
+            onDeleteDialogChange={actions.setShowDeleteDialog}
+            showMoveDialog={actions.showMoveDialog}
+            onMoveDialogChange={actions.setShowMoveDialog}
+            showRenameDialog={actions.showRenameDialog}
+            onRenameDialogChange={actions.setShowRenameDialog}
+            onColorChange={actions.handleColorChange}
+            onDeleteConfirm={actions.confirmDelete}
+            onRename={(newName) => { actions.handleRename(newName); toast.success("Folder renamed"); }}
+            onMove={onMoveItem ? actions.handleMove : undefined}
+            itemCount={itemCount}
+            deleteOption={actions.deleteOption}
+            onDeleteOptionChange={actions.setDeleteOption}
+            canDeleteWithContents={Boolean(onDeleteFolderWithContents)}
           />
-
-          {/* Move to Dialog */}
-          {onMoveItem && (
-            <MoveToDialog
-              open={showMoveDialog}
-              onOpenChange={setShowMoveDialog}
-              item={item}
-              allItems={allItems}
-              workspaceName={workspaceName}
-              workspaceIcon={workspaceIcon}
-              workspaceColor={workspaceColor}
-              onMove={(folderId) => {
-                onMoveItem(item.id, folderId);
-                toast.success('Folder moved');
-              }}
-            />
-          )}
         </div>
       </ContextMenuTrigger>
 
       {/* Right-Click Context Menu */}
       <ContextMenuContent className="w-48">
-        <ContextMenuItem onSelect={() => setShowRenameDialog(true)}>
+        <ContextMenuItem onSelect={() => actions.requestRename()}>
           <Pencil className="mr-2 h-4 w-4" />
           <span>Rename</span>
         </ContextMenuItem>
         {onMoveItem && (
           <>
-            <ContextMenuItem onSelect={() => setShowMoveDialog(true)}>
+            <ContextMenuItem onSelect={() => actions.requestMove()}>
               <FolderInput className="mr-2 h-4 w-4" />
               <span>Move to</span>
             </ContextMenuItem>
             <ContextMenuSeparator />
           </>
         )}
-        <ContextMenuItem onSelect={() => setShowColorPicker(true)}>
+        <ContextMenuItem onSelect={() => actions.requestColorPicker()}>
           <Palette className="mr-2 h-4 w-4" />
           <span>Change Color</span>
         </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem
-          onSelect={() => {
-            if (itemCount === 0) {
-              onDeleteItem(item.id);
-            } else {
-              setShowDeleteConfirm(true);
-            }
-          }}
+          onSelect={() => actions.requestDelete()}
           className="text-destructive focus:text-destructive"
         >
           <Trash2 className="mr-2 h-4 w-4" />
@@ -617,4 +459,3 @@ function FolderCardComponent({
 }
 
 export const FolderCard = memo(FolderCardComponent);
-

--- a/src/components/workspace-canvas/WorkspaceCard.tsx
+++ b/src/components/workspace-canvas/WorkspaceCard.tsx
@@ -4,10 +4,8 @@ import { toast } from "sonner";
 import {
   getCardColorCSS,
   getCardAccentColor,
-  type CardColor,
 } from "@/lib/workspace-state/colors";
 import type { Item, DocumentData } from "@/lib/workspace-state/types";
-import type { ColorResult } from "react-color";
 import { useUIStore, selectItemScrollLocked } from "@/lib/stores/ui-store";
 import { getLayoutForBreakpoint } from "@/lib/workspace-state/grid-layout-helpers";
 import {
@@ -22,6 +20,7 @@ import {
 import { WorkspaceCardContent } from "./WorkspaceCardContent";
 import { WorkspaceCardDialogs } from "./WorkspaceCardDialogs";
 import { WorkspaceCardTypeBadge } from "./WorkspaceCardTypeBadge";
+import { useItemActionDialogs } from "@/hooks/workspace/use-item-action-dialogs";
 
 interface WorkspaceCardProps {
   item: Item;
@@ -72,10 +71,13 @@ function WorkspaceCard({
   const onToggleSelection = useUIStore((state) => state.toggleCardSelection);
 
   // No dynamic calculations needed - just overflow hidden
-  const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-  const [showMoveDialog, setShowMoveDialog] = useState(false);
-  const [showRenameDialog, setShowRenameDialog] = useState(false);
+  const actions = useItemActionDialogs({
+    item,
+    onDeleteItem,
+    onUpdateItem,
+    onMoveItem: onMoveItem ? (id, folderId) => { onMoveItem(id, folderId); toast.success("Item moved"); } : undefined,
+  });
+
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   // Get scroll lock state from Zustand store (persists across interactions)
   const isScrollLocked = useUIStore(selectItemScrollLocked(item.id));
@@ -151,33 +153,6 @@ function WorkspaceCard({
   const handleTitleBlur = useCallback(() => {
     setIsEditingTitle(false);
   }, []);
-
-  // Handle color change from color picker
-  const handleColorChange = useCallback(
-    (color: ColorResult) => {
-      onUpdateItem(item.id, { color: color.hex as CardColor });
-      setIsColorPickerOpen(false);
-    },
-    [item.id, onUpdateItem],
-  );
-
-  const handleDelete = useCallback(() => {
-    setShowDeleteDialog(true);
-  }, []);
-
-  const handleDeleteConfirm = useCallback(() => {
-    onDeleteItem(item.id);
-    setShowDeleteDialog(false);
-    toast.success("Card deleted successfully");
-  }, [item.id, onDeleteItem]);
-
-  const handleRename = useCallback(
-    (newName: string) => {
-      onUpdateItem(item.id, { name: newName });
-      toast.success("Card renamed");
-    },
-    [item.id, onUpdateItem],
-  );
 
   const handleCopyMarkdown = useCallback(() => {
     if (item.type !== "document") return;
@@ -384,15 +359,6 @@ function WorkspaceCard({
     ],
   );
 
-  const handleMove = useCallback(
-    (folderId: string | null) => {
-      if (!onMoveItem) return;
-      onMoveItem(item.id, folderId);
-      toast.success("Item moved");
-    },
-    [item.id, onMoveItem],
-  );
-
   const shouldUseFramelessLayout =
     item.type === "youtube" ||
     item.type === "image" ||
@@ -469,11 +435,11 @@ function WorkspaceCard({
               canMove={Boolean(onMoveItem)}
               onToggleScrollLock={() => toggleItemScrollLocked(item.id)}
               onToggleSelection={() => onToggleSelection(item.id)}
-              onOpenRename={() => setShowRenameDialog(true)}
-              onOpenMove={() => setShowMoveDialog(true)}
+              onOpenRename={() => actions.requestRename()}
+              onOpenMove={() => actions.requestMove()}
               onCopyMarkdown={handleCopyMarkdown}
-              onOpenColorPicker={() => setIsColorPickerOpen(true)}
-              onDelete={handleDelete}
+              onOpenColorPicker={() => actions.requestColorPicker()}
+              onDelete={() => actions.requestDelete()}
             />
 
             <WorkspaceCardTypeBadge
@@ -508,18 +474,18 @@ function WorkspaceCard({
             workspaceName={workspaceName}
             workspaceIcon={workspaceIcon}
             workspaceColor={workspaceColor}
-            isColorPickerOpen={isColorPickerOpen}
-            onColorPickerOpenChange={setIsColorPickerOpen}
-            showDeleteDialog={showDeleteDialog}
-            onDeleteDialogChange={setShowDeleteDialog}
-            showMoveDialog={showMoveDialog}
-            onMoveDialogChange={setShowMoveDialog}
-            showRenameDialog={showRenameDialog}
-            onRenameDialogChange={setShowRenameDialog}
-            onColorChange={handleColorChange}
-            onDeleteConfirm={handleDeleteConfirm}
-            onRename={handleRename}
-            onMove={onMoveItem ? handleMove : undefined}
+            isColorPickerOpen={actions.showColorPicker}
+            onColorPickerOpenChange={actions.setShowColorPicker}
+            showDeleteDialog={actions.showDeleteDialog}
+            onDeleteDialogChange={actions.setShowDeleteDialog}
+            showMoveDialog={actions.showMoveDialog}
+            onMoveDialogChange={actions.setShowMoveDialog}
+            showRenameDialog={actions.showRenameDialog}
+            onRenameDialogChange={actions.setShowRenameDialog}
+            onColorChange={actions.handleColorChange}
+            onDeleteConfirm={() => { actions.confirmDelete(); toast.success("Card deleted successfully"); }}
+            onRename={(newName) => { actions.handleRename(newName); toast.success("Card renamed"); }}
+            onMove={onMoveItem ? actions.handleMove : undefined}
           />
         </div>
       </ContextMenuTrigger>
@@ -528,11 +494,11 @@ function WorkspaceCard({
         <WorkspaceCardContextMenuItems
           itemType={item.type}
           canMove={Boolean(onMoveItem)}
-          onOpenRename={() => setShowRenameDialog(true)}
-          onOpenMove={() => setShowMoveDialog(true)}
+          onOpenRename={() => actions.requestRename()}
+          onOpenMove={() => actions.requestMove()}
           onCopyMarkdown={handleCopyMarkdown}
-          onOpenColorPicker={() => setIsColorPickerOpen(true)}
-          onDelete={handleDelete}
+          onOpenColorPicker={() => actions.requestColorPicker()}
+          onDelete={() => actions.requestDelete()}
         />
       </ContextMenuContent>
     </ContextMenu>

--- a/src/components/workspace-canvas/WorkspaceCardDialogs.tsx
+++ b/src/components/workspace-canvas/WorkspaceCardDialogs.tsx
@@ -41,6 +41,106 @@ interface WorkspaceCardDialogsProps {
   onDeleteConfirm: () => void;
   onRename: (newName: string) => void;
   onMove?: (folderId: string | null) => void;
+  itemCount?: number;
+  deleteOption?: "keep" | "delete" | null;
+  onDeleteOptionChange?: (option: "keep" | "delete" | null) => void;
+  canDeleteWithContents?: boolean;
+}
+
+function DeleteDialogBody({
+  item,
+  itemCount,
+  deleteOption,
+  onDeleteOptionChange,
+  canDeleteWithContents,
+}: {
+  item: Item;
+  itemCount?: number;
+  deleteOption?: "keep" | "delete" | null;
+  onDeleteOptionChange?: (option: "keep" | "delete" | null) => void;
+  canDeleteWithContents?: boolean;
+}) {
+  if (item.type === "folder" && canDeleteWithContents && (itemCount ?? 0) > 0) {
+    return (
+      <AlertDialogDescription asChild>
+        <div className="space-y-4">
+          <div>
+            Choose what happens to the {itemCount}{" "}
+            {itemCount === 1 ? "item" : "items"} in &quot;{item.name}&quot;:
+          </div>
+          <div className="space-y-3 pt-2">
+            <label className="flex items-start space-x-3 cursor-pointer group">
+              <input
+                type="radio"
+                name="deleteOption"
+                value="keep"
+                checked={deleteOption === "keep"}
+                onChange={() => onDeleteOptionChange?.("keep")}
+                className="mt-1 h-4 w-4 text-primary focus:ring-primary border-gray-300"
+                onClick={(e) => e.stopPropagation()}
+              />
+              <div className="flex-1">
+                <div className="font-medium text-sm">Keep items</div>
+                <div className="text-xs text-muted-foreground">
+                  Move items out of folder before deleting
+                </div>
+              </div>
+            </label>
+            <label className="flex items-start space-x-3 group cursor-pointer">
+              <input
+                type="radio"
+                name="deleteOption"
+                value="delete"
+                checked={deleteOption === "delete"}
+                onChange={() => onDeleteOptionChange?.("delete")}
+                className="mt-1 h-4 w-4 text-destructive focus:ring-destructive border-gray-300"
+                onClick={(e) => e.stopPropagation()}
+              />
+              <div className="flex-1">
+                <div className="font-medium text-sm text-destructive">
+                  Delete items
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  Delete folder and all {itemCount}{" "}
+                  {itemCount === 1 ? "item" : "items"} inside
+                </div>
+              </div>
+            </label>
+          </div>
+        </div>
+      </AlertDialogDescription>
+    );
+  }
+
+  if (
+    item.type === "folder" &&
+    !canDeleteWithContents &&
+    (itemCount ?? 0) > 0
+  ) {
+    return (
+      <AlertDialogDescription>
+        Are you sure you want to delete &quot;{item.name}&quot;? Items in this
+        folder will be moved out, but not deleted.
+      </AlertDialogDescription>
+    );
+  }
+
+  const label =
+    item.type === "folder"
+      ? "Folder"
+      : item.type === "flashcard"
+        ? "Flashcard"
+        : "Card";
+
+  return (
+    <AlertDialogDescription>
+      Are you sure you want to delete &quot;{item.name || `this ${label.toLowerCase()}`}
+      &quot;?{" "}
+      {item.type === "folder"
+        ? "This action cannot be undone right now."
+        : "You can restore from version history if needed."}
+    </AlertDialogDescription>
+  );
 }
 
 export function WorkspaceCardDialogs({
@@ -61,7 +161,16 @@ export function WorkspaceCardDialogs({
   onDeleteConfirm,
   onRename,
   onMove,
+  itemCount,
+  deleteOption,
+  onDeleteOptionChange,
+  canDeleteWithContents,
 }: WorkspaceCardDialogsProps) {
+  const isFolder = item.type === "folder";
+  const deleteTitle = isFolder ? "Delete Folder" : item.type === "flashcard" ? "Delete Flashcard" : "Delete Card";
+  const needsRadioSelection =
+    isFolder && canDeleteWithContents && (itemCount ?? 0) > 0;
+
   return (
     <>
       <Dialog open={isColorPickerOpen} onOpenChange={onColorPickerOpenChange}>
@@ -88,20 +197,38 @@ export function WorkspaceCardDialogs({
       </Dialog>
 
       <AlertDialog open={showDeleteDialog} onOpenChange={onDeleteDialogChange}>
-        <AlertDialogContent>
+        <AlertDialogContent
+          onClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete Card</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to delete &quot;
-              {item.name || "this card"}&quot;? You can restore from version
-              history if needed.
-            </AlertDialogDescription>
+            <AlertDialogTitle>{deleteTitle}</AlertDialogTitle>
+            <DeleteDialogBody
+              item={item}
+              itemCount={itemCount}
+              deleteOption={deleteOption}
+              onDeleteOptionChange={onDeleteOptionChange}
+              canDeleteWithContents={canDeleteWithContents}
+            />
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel
+              onClick={(e) => {
+                e.stopPropagation();
+                onDeleteOptionChange?.(null);
+              }}
+              onMouseDown={(e) => e.stopPropagation()}
+            >
+              Cancel
+            </AlertDialogCancel>
             <AlertDialogAction
-              onClick={onDeleteConfirm}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDeleteConfirm();
+              }}
+              onMouseDown={(e) => e.stopPropagation()}
+              disabled={needsRadioSelection && deleteOption === null}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Delete
             </AlertDialogAction>

--- a/src/components/workspace/SidebarCardList.tsx
+++ b/src/components/workspace/SidebarCardList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useMemo, useCallback, useState, useEffect, useRef } from "react";
+import { memo, useMemo, useCallback, useState } from "react";
 import { ChevronRight, FolderOpen, Folder as FolderIcon, MoreVertical, Trash2, Pencil, FolderInput } from "lucide-react";
 import {
     SidebarMenu,
@@ -19,16 +19,6 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import {
-    AlertDialog,
-    AlertDialogAction,
-    AlertDialogCancel,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { useCurrentWorkspaceId } from "@/contexts/WorkspaceContext";
 import {
   useWorkspaceItems,
@@ -40,22 +30,16 @@ import type { Item, CardType } from "@/lib/workspace-state/types";
 import { getChildFolders, getFolderPath } from "@/lib/workspace-state/search";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
-import MoveToDialog from "@/components/modals/MoveToDialog";
-import RenameDialog from "@/components/modals/RenameDialog";
 import { useWorkspaceContext } from "@/contexts/WorkspaceContext";
 import { WorkspaceItemTypeIcon } from "@/components/workspace/WorkspaceItemTypeIcon";
+import { WorkspaceCardDialogs } from "@/components/workspace-canvas/WorkspaceCardDialogs";
+import { useItemActionDialogs } from "@/hooks/workspace/use-item-action-dialogs";
 
-/**
- * Get icon for card type
- */
 function getCardTypeIcon(type: CardType) {
     return <WorkspaceItemTypeIcon type={type} className="size-3.5" />;
 }
 
-/**
- * Sidebar item button component with hover menu (for nested items)
- */
-interface SidebarItemButtonProps {
+interface SidebarItemProps {
     item: Item;
     allItems: Item[];
     workspaceName: string;
@@ -65,47 +49,33 @@ interface SidebarItemButtonProps {
     onDeleteItem?: (itemId: string) => void;
     onRenameItem?: (itemId: string, newName: string) => void;
     onMoveItem?: (itemId: string, folderId: string | null) => void;
+    isNested?: boolean;
 }
 
-function SidebarItemButton({ item, allItems, workspaceName, workspaceIcon, workspaceColor, onItemClick, onDeleteItem, onRenameItem, onMoveItem }: SidebarItemButtonProps) {
+function SidebarItem({ item, allItems, workspaceName, workspaceIcon, workspaceColor, onItemClick, onDeleteItem, onRenameItem, onMoveItem, isNested = false }: SidebarItemProps) {
     const [isHovered, setIsHovered] = useState(false);
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-    const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-    const [showRenameDialog, setShowRenameDialog] = useState(false);
-    const [showMoveDialog, setShowMoveDialog] = useState(false);
 
-    const handleDelete = useCallback(() => {
-        if (onDeleteItem) {
-            onDeleteItem(item.id);
-        }
-        setShowDeleteDialog(false);
-    }, [item.id, onDeleteItem]);
+    const actions = useItemActionDialogs({
+        item,
+        onDeleteItem: onDeleteItem ? (id) => { onDeleteItem(id); toast.success('Item deleted'); } : () => {},
+        onUpdateItem: onRenameItem ? (id, updates) => { if (updates.name !== undefined) onRenameItem(id, updates.name as string); } : () => {},
+        onMoveItem: onMoveItem ? (id, folderId) => { onMoveItem(id, folderId); toast.success('Item moved'); } : undefined,
+    });
 
-    const handleRename = useCallback((newName: string) => {
-        if (onRenameItem) {
-            onRenameItem(item.id, newName);
-        }
-    }, [item.id, onRenameItem]);
+    const Wrapper = isNested ? SidebarMenuSubItem : SidebarMenuItem;
 
-    const handleMove = useCallback((folderId: string | null) => {
-        if (onMoveItem) {
-            onMoveItem(item.id, folderId);
-            toast.success('Item moved');
-        }
-    }, [item.id, onMoveItem]);
-
-    return (
-        <SidebarMenuSubItem>
+    const content = (
+        <Wrapper>
             <div
                 className="relative w-full"
                 onMouseEnter={() => setIsHovered(true)}
                 onMouseLeave={() => setIsHovered(false)}
             >
                 <SidebarMenuButton
-                    size="sm"
+                    size={isNested ? "sm" : undefined}
                     className="w-full cursor-pointer p-0"
                     onClick={(e: React.MouseEvent) => {
-                        // Don't trigger item click if clicking the menu button
                         if ((e.target as HTMLElement).closest('[data-menu-button]')) {
                             e.stopPropagation();
                             return;
@@ -113,208 +83,37 @@ function SidebarItemButton({ item, allItems, workspaceName, workspaceIcon, works
                         onItemClick(item);
                     }}
                 >
-                    <div className="flex items-center gap-2 px-1 py-1 w-full">
-                        {getCardTypeIcon(item.type)}
-                        <span className={cn("flex-1 text-xs", (isHovered || isDropdownOpen) ? "truncate pr-6" : "truncate")}>
-                            {item.name || "Untitled"}
-                        </span>
-                    </div>
-                </SidebarMenuButton>
-                {/* Three dots menu button - appears on hover or when dropdown is open */}
-                {(isHovered || isDropdownOpen) && (onDeleteItem || onRenameItem) && (
-                    <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
-                        <DropdownMenuTrigger asChild>
-                            <button
-                                data-menu-button
-                                className="absolute right-1 top-1/2 -translate-y-1/2 h-5 w-5 flex items-center justify-center rounded hover:bg-sidebar-accent flex-shrink-0 z-50 pointer-events-auto cursor-pointer"
-                                onClick={(e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                }}
-                                onMouseDown={(e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                }}
-                                onMouseUp={(e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                }}
-                                type="button"
-                            >
-                                <MoreVertical className="size-3 text-muted-foreground pointer-events-none" />
-                            </button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent
-                            align="end"
-                            onClick={(e) => e.stopPropagation()}
-                        >
-                            {onRenameItem && (
-                                <DropdownMenuItem
-                                    onClick={(e) => {
-                                        e.stopPropagation();
-                                        setIsDropdownOpen(false);
-                                        setShowRenameDialog(true);
-                                    }}
-                                >
-                                    <Pencil className="mr-2 h-4 w-4" />
-                                    Rename
-                                </DropdownMenuItem>
-                            )}
-                            {onMoveItem && (
-                                <DropdownMenuItem
-                                    onClick={(e) => {
-                                        e.stopPropagation();
-                                        setIsDropdownOpen(false);
-                                        setShowMoveDialog(true);
-                                    }}
-                                >
-                                    <FolderInput className="mr-2 h-4 w-4" />
-                                    Move to
-                                </DropdownMenuItem>
-                            )}
-                            <DropdownMenuItem
-                                className="text-destructive focus:text-destructive"
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                    setIsDropdownOpen(false);
-                                    setShowDeleteDialog(true);
-                                }}
-                            >
-                                <Trash2 className="mr-2 h-4 w-4" />
-                                Delete
-                            </DropdownMenuItem>
-                        </DropdownMenuContent>
-                    </DropdownMenu>
-                )}
-            </div>
-            {/* Delete confirmation dialog */}
-            <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
-                <AlertDialogContent>
-                    <AlertDialogHeader>
-                        <AlertDialogTitle>Delete {item.type === 'pdf' ? 'PDF' : item.type === 'flashcard' ? 'Flashcard' : 'Note'}</AlertDialogTitle>
-                        <AlertDialogDescription>
-                            Are you sure you want to delete &quot;{item.name || 'Untitled'}&quot;? This action cannot be undone right now.
-                        </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                        <AlertDialogCancel>Cancel</AlertDialogCancel>
-                        <AlertDialogAction
-                            onClick={handleDelete}
-                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                        >
-                            Delete
-                        </AlertDialogAction>
-                    </AlertDialogFooter>
-                </AlertDialogContent>
-            </AlertDialog>
-            {/* Rename Dialog */}
-            <RenameDialog
-                open={showRenameDialog}
-                onOpenChange={setShowRenameDialog}
-                currentName={item.name || "Untitled"}
-                itemType={item.type}
-                onRename={handleRename}
-            />
-            {/* Move to Dialog */}
-            {onMoveItem && (
-                <MoveToDialog
-                    open={showMoveDialog}
-                    onOpenChange={setShowMoveDialog}
-                    item={item}
-                    allItems={allItems}
-                    workspaceName={workspaceName}
-                    workspaceIcon={workspaceIcon}
-                    workspaceColor={workspaceColor}
-                    onMove={handleMove}
-                />
-            )}
-        </SidebarMenuSubItem>
-    );
-}
-
-/**
- * Root-level sidebar item component with hover menu (for items not in folders)
- */
-interface SidebarRootItemProps {
-    item: Item;
-    allItems: Item[];
-    workspaceName: string;
-    workspaceIcon?: string | null;
-    workspaceColor?: string | null;
-    onItemClick: (item: Item) => void;
-    onDeleteItem?: (itemId: string) => void;
-    onRenameItem?: (itemId: string, newName: string) => void;
-    onMoveItem?: (itemId: string, folderId: string | null) => void;
-}
-
-function SidebarRootItem({ item, allItems, workspaceName, workspaceIcon, workspaceColor, onItemClick, onDeleteItem, onRenameItem, onMoveItem }: SidebarRootItemProps) {
-    const [isHovered, setIsHovered] = useState(false);
-    const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-    const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-    const [showRenameDialog, setShowRenameDialog] = useState(false);
-    const [showMoveDialog, setShowMoveDialog] = useState(false);
-
-    const handleDelete = useCallback(() => {
-        if (onDeleteItem) {
-            onDeleteItem(item.id);
-        }
-        setShowDeleteDialog(false);
-    }, [item.id, onDeleteItem]);
-
-    const handleRename = useCallback((newName: string) => {
-        if (onRenameItem) {
-            onRenameItem(item.id, newName);
-        }
-    }, [item.id, onRenameItem]);
-
-    const handleMove = useCallback((folderId: string | null) => {
-        if (onMoveItem) {
-            onMoveItem(item.id, folderId);
-            toast.success('Item moved');
-        }
-    }, [item.id, onMoveItem]);
-
-
-    return (
-        <SidebarMenuItem>
-            <div
-                className="relative w-full"
-                onMouseEnter={() => setIsHovered(true)}
-                onMouseLeave={() => setIsHovered(false)}
-            >
-                <SidebarMenuButton
-                    className="w-full cursor-pointer p-0"
-                    onClick={(e: React.MouseEvent) => {
-                        // Don't trigger item click if clicking the menu button
-                        if ((e.target as HTMLElement).closest('[data-menu-button]')) {
-                            e.stopPropagation();
-                            return;
-                        }
-                        onItemClick(item);
-                    }}
-                >
-                    <div className="flex items-center w-full">
-                        {/* Icon area - matches folder chevron area structure */}
-                        <div className="px-1 py-2 flex items-center justify-center flex-shrink-0 w-6">
+                    {isNested ? (
+                        <div className="flex items-center gap-2 px-1 py-1 w-full">
                             {getCardTypeIcon(item.type)}
-                        </div>
-                        {/* Item name area - matches folder name area structure */}
-                        <div className={cn(
-                            "flex-1 flex items-center px-1 py-1 rounded cursor-pointer min-w-0"
-                        )}>
                             <span className={cn("flex-1 text-xs", (isHovered || isDropdownOpen) ? "truncate pr-6" : "truncate")}>
                                 {item.name || "Untitled"}
                             </span>
                         </div>
-                    </div>
+                    ) : (
+                        <div className="flex items-center w-full">
+                            <div className="px-1 py-2 flex items-center justify-center flex-shrink-0 w-6">
+                                {getCardTypeIcon(item.type)}
+                            </div>
+                            <div className={cn(
+                                "flex-1 flex items-center px-1 py-1 rounded cursor-pointer min-w-0"
+                            )}>
+                                <span className={cn("flex-1 text-xs", (isHovered || isDropdownOpen) ? "truncate pr-6" : "truncate")}>
+                                    {item.name || "Untitled"}
+                                </span>
+                            </div>
+                        </div>
+                    )}
                 </SidebarMenuButton>
-                {/* Three dots menu button - appears on hover or when dropdown is open */}
                 {(isHovered || isDropdownOpen) && (onDeleteItem || onRenameItem) && (
                     <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
                         <DropdownMenuTrigger asChild>
                             <button
                                 data-menu-button
-                                className="absolute right-1 top-1/2 -translate-y-1/2 h-6 w-6 flex items-center justify-center rounded hover:bg-sidebar-accent flex-shrink-0 z-50 pointer-events-auto cursor-pointer"
+                                className={cn(
+                                    "absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center rounded hover:bg-sidebar-accent flex-shrink-0 z-50 pointer-events-auto cursor-pointer",
+                                    isNested ? "h-5 w-5" : "h-6 w-6"
+                                )}
                                 onClick={(e) => {
                                     e.preventDefault();
                                     e.stopPropagation();
@@ -329,7 +128,10 @@ function SidebarRootItem({ item, allItems, workspaceName, workspaceIcon, workspa
                                 }}
                                 type="button"
                             >
-                                <MoreVertical className="size-3.5 text-muted-foreground pointer-events-none" />
+                                <MoreVertical className={cn(
+                                    "text-muted-foreground pointer-events-none",
+                                    isNested ? "size-3" : "size-3.5"
+                                )} />
                             </button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent
@@ -341,7 +143,7 @@ function SidebarRootItem({ item, allItems, workspaceName, workspaceIcon, workspa
                                     onClick={(e) => {
                                         e.stopPropagation();
                                         setIsDropdownOpen(false);
-                                        setShowRenameDialog(true);
+                                        actions.requestRename();
                                     }}
                                 >
                                     <Pencil className="mr-2 h-4 w-4" />
@@ -353,7 +155,7 @@ function SidebarRootItem({ item, allItems, workspaceName, workspaceIcon, workspa
                                     onClick={(e) => {
                                         e.stopPropagation();
                                         setIsDropdownOpen(false);
-                                        setShowMoveDialog(true);
+                                        actions.requestMove();
                                     }}
                                 >
                                     <FolderInput className="mr-2 h-4 w-4" />
@@ -365,7 +167,7 @@ function SidebarRootItem({ item, allItems, workspaceName, workspaceIcon, workspa
                                 onClick={(e) => {
                                     e.stopPropagation();
                                     setIsDropdownOpen(false);
-                                    setShowDeleteDialog(true);
+                                    actions.requestDelete();
                                 }}
                             >
                                 <Trash2 className="mr-2 h-4 w-4" />
@@ -375,56 +177,36 @@ function SidebarRootItem({ item, allItems, workspaceName, workspaceIcon, workspa
                     </DropdownMenu>
                 )}
             </div>
-            {/* Delete confirmation dialog */}
-            <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
-                <AlertDialogContent>
-                    <AlertDialogHeader>
-                        <AlertDialogTitle>Delete {item.type === 'pdf' ? 'PDF' : item.type === 'flashcard' ? 'Flashcard' : 'Note'}</AlertDialogTitle>
-                        <AlertDialogDescription>
-                            Are you sure you want to delete &quot;{item.name || 'Untitled'}&quot;? This action cannot be undone right now.
-                        </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                        <AlertDialogCancel>Cancel</AlertDialogCancel>
-                        <AlertDialogAction
-                            onClick={handleDelete}
-                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                        >
-                            Delete
-                        </AlertDialogAction>
-                    </AlertDialogFooter>
-                </AlertDialogContent>
-            </AlertDialog>
-            {/* Rename Dialog */}
-            <RenameDialog
-                open={showRenameDialog}
-                onOpenChange={setShowRenameDialog}
-                currentName={item.name || "Untitled"}
-                itemType={item.type}
-                onRename={handleRename}
+            <WorkspaceCardDialogs
+                item={item}
+                allItems={allItems}
+                workspaceName={workspaceName}
+                workspaceIcon={workspaceIcon}
+                workspaceColor={workspaceColor}
+                isColorPickerOpen={false}
+                onColorPickerOpenChange={() => {}}
+                showDeleteDialog={actions.showDeleteDialog}
+                onDeleteDialogChange={actions.setShowDeleteDialog}
+                showMoveDialog={actions.showMoveDialog}
+                onMoveDialogChange={actions.setShowMoveDialog}
+                showRenameDialog={actions.showRenameDialog}
+                onRenameDialogChange={actions.setShowRenameDialog}
+                onColorChange={() => {}}
+                onDeleteConfirm={actions.confirmDelete}
+                onRename={(newName) => { actions.handleRename(newName); toast.success('Item renamed'); }}
+                onMove={onMoveItem ? actions.handleMove : undefined}
             />
-            {/* Move to Dialog */}
-            {onMoveItem && (
-                <MoveToDialog
-                    open={showMoveDialog}
-                    onOpenChange={setShowMoveDialog}
-                    item={item}
-                    allItems={allItems}
-                    workspaceName={workspaceName}
-                    workspaceIcon={workspaceIcon}
-                    workspaceColor={workspaceColor}
-                    onMove={handleMove}
-                />
-            )}
-        </SidebarMenuItem>
+        </Wrapper>
     );
+
+    return content;
 }
 
 interface SidebarFolderItemProps {
-    folder: Item; // Folder is now an item with type: 'folder'
+    folder: Item;
     isActive: boolean;
     isOpen: boolean;
-    allItems: Item[]; // All items for finding children
+    allItems: Item[];
     workspaceName: string;
     workspaceIcon?: string | null;
     workspaceColor?: string | null;
@@ -435,7 +217,7 @@ interface SidebarFolderItemProps {
     onToggleFolder: (folderId: string) => void;
     activeFolderId: string | null;
     onFolderClickHandler: (folderId: string) => void;
-    isNested?: boolean; // Whether this folder is nested inside another folder
+    isNested?: boolean;
     onDeleteItem?: (itemId: string) => void;
     onDeleteFolder?: (folderId: string) => void;
     onRenameFolder?: (folderId: string, newName: string) => void;
@@ -443,9 +225,6 @@ interface SidebarFolderItemProps {
     onMoveItem?: (itemId: string, folderId: string | null) => void;
 }
 
-/**
- * Sidebar item for a folder - recursively renders child folders and items
- */
 function SidebarFolderItem({
     folder,
     isActive,
@@ -470,9 +249,7 @@ function SidebarFolderItem({
 }: SidebarFolderItemProps) {
     const [isHovered, setIsHovered] = useState(false);
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-    const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-    const [showRenameDialog, setShowRenameDialog] = useState(false);
-    const [showMoveDialog, setShowMoveDialog] = useState(false);
+
     const handleChevronClick = useCallback((e: React.MouseEvent) => {
         e.stopPropagation();
         onToggle();
@@ -484,40 +261,25 @@ function SidebarFolderItem({
         onFolderClick();
     }, [onFolderClick, isActive]);
 
-    const handleDelete = useCallback(() => {
-        if (onDeleteFolder) {
-            onDeleteFolder(folder.id);
-        }
-        setShowDeleteDialog(false);
-    }, [folder.id, onDeleteFolder]);
-
-    const handleRename = useCallback((newName: string) => {
-        if (onRenameFolder) {
-            onRenameFolder(folder.id, newName);
-        }
-    }, [folder.id, onRenameFolder]);
-
-    const handleMove = useCallback((folderId: string | null) => {
-        if (onMoveItem) {
-            onMoveItem(folder.id, folderId);
-            toast.success('Folder moved');
-        }
-    }, [folder.id, onMoveItem]);
-
-
-    // Get child folders (folders with folderId === this folder's id)
     const childFolders = useMemo(() => {
         return getChildFolders(folder.id, allItems);
     }, [folder.id, allItems]);
 
-    // Get direct items (non-folders with folderId === this folder's id)
     const directItems = useMemo(() => {
-        return allItems.filter(i =>
-            i.type !== 'folder' && i.folderId === folder.id
+        return allItems.filter(
+            (item) => item.folderId === folder.id && item.type !== "folder"
         );
     }, [folder.id, allItems]);
 
     const totalItemCount = childFolders.length + directItems.length;
+
+    const actions = useItemActionDialogs({
+        item: folder,
+        itemCount: totalItemCount,
+        onDeleteItem: onDeleteFolder ? (id) => { onDeleteFolder(id); toast.success('Folder deleted'); } : () => {},
+        onUpdateItem: onRenameFolder ? (id, updates) => { if (updates.name !== undefined) onRenameFolder(id, updates.name as string); } : () => {},
+        onMoveItem: onMoveItem ? (id, folderId) => { onMoveItem(id, folderId); toast.success('Folder moved'); } : undefined,
+    });
 
     const folderContent = (
         <Collapsible open={isOpen} onOpenChange={onToggle}>
@@ -533,7 +295,6 @@ function SidebarFolderItem({
                         isActive ? "bg-blue-600/30 cursor-default hover:bg-blue-600/30" : "cursor-pointer"
                     )}
                     onClick={(e: React.MouseEvent) => {
-                        // Don't trigger folder click if clicking the menu button
                         if ((e.target as HTMLElement).closest('[data-menu-button]')) {
                             e.stopPropagation();
                             return;
@@ -541,7 +302,6 @@ function SidebarFolderItem({
                     }}
                 >
                     <div className="flex items-center w-full">
-                        {/* Icon/Chevron - shows icon by default, chevron on hover or when expanded */}
                         <div
                             onClick={handleChevronClick}
                             className={cn(
@@ -558,7 +318,6 @@ function SidebarFolderItem({
                                 }
                             }}
                         >
-                            {/* Show chevron when expanded or on hover, otherwise show icon */}
                             {isOpen || isHovered ? (
                                 <ChevronRight
                                     className={cn(
@@ -574,7 +333,6 @@ function SidebarFolderItem({
                                 )
                             )}
                         </div>
-                        {/* Folder div - handles folder filter */}
                         <div
                             onClick={handleFolderClick}
                             className={cn(
@@ -586,7 +344,6 @@ function SidebarFolderItem({
                         </div>
                     </div>
                 </SidebarMenuButton>
-                {/* Three dots menu button - appears on hover or when dropdown is open */}
                 {(isHovered || isDropdownOpen) && (onDeleteFolder || onRenameFolder) && (
                     <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
                         <DropdownMenuTrigger asChild>
@@ -619,7 +376,7 @@ function SidebarFolderItem({
                                     onClick={(e) => {
                                         e.stopPropagation();
                                         setIsDropdownOpen(false);
-                                        setShowRenameDialog(true);
+                                        actions.requestRename();
                                     }}
                                 >
                                     <Pencil className="mr-2 h-4 w-4" />
@@ -631,7 +388,7 @@ function SidebarFolderItem({
                                     onClick={(e) => {
                                         e.stopPropagation();
                                         setIsDropdownOpen(false);
-                                        setShowMoveDialog(true);
+                                        actions.requestMove();
                                     }}
                                 >
                                     <FolderInput className="mr-2 h-4 w-4" />
@@ -643,13 +400,7 @@ function SidebarFolderItem({
                                 onClick={(e) => {
                                     e.stopPropagation();
                                     setIsDropdownOpen(false);
-                                    if (totalItemCount === 0) {
-                                        if (onDeleteFolder) {
-                                            onDeleteFolder(folder.id);
-                                        }
-                                    } else {
-                                        setShowDeleteDialog(true);
-                                    }
+                                    actions.requestDelete();
                                 }}
                             >
                                 <Trash2 className="mr-2 h-4 w-4" />
@@ -661,7 +412,6 @@ function SidebarFolderItem({
             </div>
             <CollapsibleContent>
                 <SidebarMenuSub>
-                    {/* Child folders (recursive) */}
                     {childFolders.map((childFolder) => (
                         <SidebarFolderItem
                             key={childFolder.id}
@@ -687,9 +437,8 @@ function SidebarFolderItem({
                             onMoveItem={onMoveItem}
                         />
                     ))}
-                    {/* Direct items (non-folders) */}
                     {directItems.map((item) => (
-                        <SidebarItemButton
+                        <SidebarItem
                             key={item.id}
                             item={item}
                             allItems={allItems}
@@ -700,6 +449,7 @@ function SidebarFolderItem({
                             onDeleteItem={onDeleteItem}
                             onRenameItem={onRenameItem}
                             onMoveItem={onMoveItem}
+                            isNested={true}
                         />
                     ))}
                     {totalItemCount === 0 && (
@@ -711,51 +461,29 @@ function SidebarFolderItem({
                     )}
                 </SidebarMenuSub>
             </CollapsibleContent>
-            {/* Delete confirmation dialog */}
-            <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
-                <AlertDialogContent>
-                    <AlertDialogHeader>
-                        <AlertDialogTitle>Delete Folder</AlertDialogTitle>
-                        <AlertDialogDescription>
-                            Are you sure you want to delete &quot;{folder.name}&quot;? Items in this folder will be moved out, but not deleted.
-                        </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                        <AlertDialogCancel>Cancel</AlertDialogCancel>
-                        <AlertDialogAction
-                            onClick={handleDelete}
-                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                        >
-                            Delete
-                        </AlertDialogAction>
-                    </AlertDialogFooter>
-                </AlertDialogContent>
-            </AlertDialog>
-            {/* Rename Dialog */}
-            <RenameDialog
-                open={showRenameDialog}
-                onOpenChange={setShowRenameDialog}
-                currentName={folder.name}
-                itemType="folder"
-                onRename={handleRename}
+            <WorkspaceCardDialogs
+                item={folder}
+                allItems={allItems}
+                workspaceName={workspaceName}
+                workspaceIcon={workspaceIcon}
+                workspaceColor={workspaceColor}
+                isColorPickerOpen={false}
+                onColorPickerOpenChange={() => {}}
+                showDeleteDialog={actions.showDeleteDialog}
+                onDeleteDialogChange={actions.setShowDeleteDialog}
+                showMoveDialog={actions.showMoveDialog}
+                onMoveDialogChange={actions.setShowMoveDialog}
+                showRenameDialog={actions.showRenameDialog}
+                onRenameDialogChange={actions.setShowRenameDialog}
+                onColorChange={() => {}}
+                onDeleteConfirm={actions.confirmDelete}
+                onRename={(newName) => { actions.handleRename(newName); toast.success('Folder renamed'); }}
+                onMove={onMoveItem ? actions.handleMove : undefined}
+                itemCount={totalItemCount}
             />
-            {/* Move to Dialog */}
-            {onMoveItem && (
-                <MoveToDialog
-                    open={showMoveDialog}
-                    onOpenChange={setShowMoveDialog}
-                    item={folder}
-                    allItems={allItems}
-                    workspaceName={workspaceName}
-                    workspaceIcon={workspaceIcon}
-                    workspaceColor={workspaceColor}
-                    onMove={handleMove}
-                />
-            )}
         </Collapsible>
     );
 
-    // Wrap in appropriate container based on nesting level
     if (isNested) {
         return (
             <SidebarMenuSubItem>
@@ -771,9 +499,6 @@ function SidebarFolderItem({
     );
 }
 
-/**
- * SidebarCardList - Shows all folders in collapsible sections
- */
 function SidebarCardList() {
     const currentWorkspaceId = useCurrentWorkspaceId();
     const state = useWorkspaceItems();
@@ -783,19 +508,16 @@ function SidebarCardList() {
     const setActiveFolderId = useUIStore((state) => state.setActiveFolderId);
     const openWorkspaceItem = useUIStore((state) => state.openWorkspaceItem);
 
-    // Get current workspace details
     const currentWorkspace = useMemo(() => {
         return workspaces.find(w => w.id === currentWorkspaceId) || null;
     }, [workspaces, currentWorkspaceId]);
 
-    // Get workspace operations for delete functionality
     const operations = useWorkspaceOperations(currentWorkspaceId, state || { items: [] });
 
     const handleDeleteItem = useCallback(
         async (itemId: string) => {
             if (operations) {
                 await operations.deleteItem(itemId);
-                toast.success('Item deleted');
             }
         },
         [operations]
@@ -805,7 +527,6 @@ function SidebarCardList() {
         async (folderId: string) => {
             if (operations) {
                 operations.deleteFolder(folderId);
-                toast.success('Folder deleted');
             }
         },
         [operations]
@@ -815,7 +536,6 @@ function SidebarCardList() {
         async (itemId: string, newName: string) => {
             if (operations) {
                 operations.updateItem(itemId, { name: newName });
-                toast.success('Item renamed');
             }
         },
         [operations]
@@ -825,7 +545,6 @@ function SidebarCardList() {
         async (folderId: string, newName: string) => {
             if (operations) {
                 operations.updateItem(folderId, { name: newName });
-                toast.success('Folder renamed');
             }
         },
         [operations]
@@ -840,7 +559,6 @@ function SidebarCardList() {
         [operations]
     );
 
-    // Track which folders are open (for collapsible UI, not for filtering)
     const [openFolders, setOpenFolders] = useState<Set<string>>(new Set());
 
     const toggleFolder = useCallback((folderId: string) => {
@@ -855,24 +573,20 @@ function SidebarCardList() {
         });
     }, []);
 
-    // Get all items
     const allItems = useMemo(() => {
         return state || [];
     }, [state]);
 
-    // Get root-level folders (folders with no folderId)
     const rootFolders = useMemo(() => {
         return getChildFolders(null, allItems);
     }, [allItems]);
 
-    // Get loose items (non-folders not in any folder)
     const looseItems = useMemo(() => {
         return allItems.filter(item =>
             item.type !== 'folder' && !item.folderId
         );
     }, [allItems]);
 
-    // Handle clicking on a folder - switch folder filter (keeps panels open; breadcrumb handles "navigate back")
     const handleFolderClick = useCallback(
         (folderId: string) => {
             if (activeFolderId === folderId) {
@@ -884,13 +598,10 @@ function SidebarCardList() {
         [activeFolderId, setActiveFolderId]
     );
 
-    // Handle clicking on an item - open parent folders, set active folder, and open the item's modal (matches Cmd+K)
     const handleItemClick = useCallback(
         (item: Item) => {
-            // Skip folders - they use handleFolderClick
             if (item.type === "folder") return;
 
-            // If item is in a folder, open all parent folders in the sidebar and set active folder
             if (item.folderId) {
                 const folderPath = getFolderPath(item.folderId, allItems);
                 setOpenFolders((prev) => {
@@ -905,7 +616,6 @@ function SidebarCardList() {
                 setActiveFolderId(null);
             }
 
-            // Open the item in its detail modal (same as clicking the card)
             openWorkspaceItem(item.id);
         },
         [allItems, setActiveFolderId, openWorkspaceItem]
@@ -929,7 +639,6 @@ function SidebarCardList() {
         );
     }
 
-    // Get workspace name, icon, and color
     const workspaceName = currentWorkspace?.name || "Workspace";
     const workspaceIcon = currentWorkspace?.icon;
     const workspaceColor = currentWorkspace?.color;
@@ -937,7 +646,6 @@ function SidebarCardList() {
     return (
         <div className="group-data-[collapsible=icon]:hidden">
             <SidebarMenu>
-                {/* Root-level folders (recursively render children) */}
                 {rootFolders.map((folder) => (
                     <SidebarFolderItem
                         key={folder.id}
@@ -963,9 +671,8 @@ function SidebarCardList() {
                     />
                 ))}
 
-                {/* Loose items (not in any folder) */}
                 {looseItems.map((item) => (
-                    <SidebarRootItem
+                    <SidebarItem
                         key={item.id}
                         item={item}
                         allItems={allItems}
@@ -976,6 +683,7 @@ function SidebarCardList() {
                         onDeleteItem={handleDeleteItem}
                         onRenameItem={handleRenameItem}
                         onMoveItem={handleMoveItem}
+                        isNested={false}
                     />
                 ))}
             </SidebarMenu>

--- a/src/components/workspace/SidebarCardList.tsx
+++ b/src/components/workspace/SidebarCardList.tsx
@@ -58,7 +58,7 @@ function SidebarItem({ item, allItems, workspaceName, workspaceIcon, workspaceCo
 
     const actions = useItemActionDialogs({
         item,
-        onDeleteItem: onDeleteItem ? (id) => { onDeleteItem(id); toast.success('Item deleted'); } : () => {},
+        onDeleteItem: onDeleteItem ? (id) => { onDeleteItem(id); } : () => {},
         onUpdateItem: onRenameItem ? (id, updates) => { if (updates.name !== undefined) onRenameItem(id, updates.name as string); } : () => {},
         onMoveItem: onMoveItem ? (id, folderId) => { onMoveItem(id, folderId); toast.success('Item moved'); } : undefined,
     });
@@ -276,7 +276,7 @@ function SidebarFolderItem({
     const actions = useItemActionDialogs({
         item: folder,
         itemCount: totalItemCount,
-        onDeleteItem: onDeleteFolder ? (id) => { onDeleteFolder(id); toast.success('Folder deleted'); } : () => {},
+        onDeleteItem: onDeleteFolder ? (id) => { onDeleteFolder(id); } : () => {},
         onUpdateItem: onRenameFolder ? (id, updates) => { if (updates.name !== undefined) onRenameFolder(id, updates.name as string); } : () => {},
         onMoveItem: onMoveItem ? (id, folderId) => { onMoveItem(id, folderId); toast.success('Folder moved'); } : undefined,
     });

--- a/src/components/workspace/SidebarCardList.tsx
+++ b/src/components/workspace/SidebarCardList.tsx
@@ -643,7 +643,13 @@ function SidebarFolderItem({
                                 onClick={(e) => {
                                     e.stopPropagation();
                                     setIsDropdownOpen(false);
-                                    setShowDeleteDialog(true);
+                                    if (totalItemCount === 0) {
+                                        if (onDeleteFolder) {
+                                            onDeleteFolder(folder.id);
+                                        }
+                                    } else {
+                                        setShowDeleteDialog(true);
+                                    }
                                 }}
                             >
                                 <Trash2 className="mr-2 h-4 w-4" />

--- a/src/hooks/workspace/use-item-action-dialogs.ts
+++ b/src/hooks/workspace/use-item-action-dialogs.ts
@@ -1,0 +1,135 @@
+import { useState, useCallback, useEffect } from "react";
+import type { ColorResult } from "react-color";
+import type { Item } from "@/lib/workspace-state/types";
+import type { CardColor } from "@/lib/workspace-state/colors";
+
+export interface UseItemActionDialogsOptions {
+  item: Item;
+  itemCount?: number;
+  onDeleteItem: (id: string) => void;
+  onDeleteFolderWithContents?: (id: string) => void;
+  onUpdateItem: (id: string, updates: Partial<Item>) => void;
+  onMoveItem?: (id: string, folderId: string | null) => void;
+}
+
+export interface ItemActionDialogsState {
+  showDeleteDialog: boolean;
+  setShowDeleteDialog: (open: boolean) => void;
+  showRenameDialog: boolean;
+  setShowRenameDialog: (open: boolean) => void;
+  showMoveDialog: boolean;
+  setShowMoveDialog: (open: boolean) => void;
+  showColorPicker: boolean;
+  setShowColorPicker: (open: boolean) => void;
+
+  deleteOption: "keep" | "delete" | null;
+  setDeleteOption: (opt: "keep" | "delete" | null) => void;
+
+  requestDelete: () => void;
+  requestRename: () => void;
+  requestMove: () => void;
+  requestColorPicker: () => void;
+
+  confirmDelete: () => void;
+  handleRename: (newName: string) => void;
+  handleColorChange: (color: ColorResult) => void;
+  handleMove: (folderId: string | null) => void;
+}
+
+export function useItemActionDialogs({
+  item,
+  itemCount,
+  onDeleteItem,
+  onDeleteFolderWithContents,
+  onUpdateItem,
+  onMoveItem,
+}: UseItemActionDialogsOptions): ItemActionDialogsState {
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [showRenameDialog, setShowRenameDialog] = useState(false);
+  const [showMoveDialog, setShowMoveDialog] = useState(false);
+  const [showColorPicker, setShowColorPicker] = useState(false);
+  const [deleteOption, setDeleteOption] = useState<"keep" | "delete" | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!showDeleteDialog) {
+      setDeleteOption(null);
+    }
+  }, [showDeleteDialog]);
+
+  const requestDelete = useCallback(() => {
+    if (item.type === "folder" && (itemCount ?? 0) === 0) {
+      onDeleteItem(item.id);
+    } else {
+      setShowDeleteDialog(true);
+    }
+  }, [item.id, item.type, itemCount, onDeleteItem]);
+
+  const requestRename = useCallback(() => {
+    setShowRenameDialog(true);
+  }, []);
+
+  const requestMove = useCallback(() => {
+    setShowMoveDialog(true);
+  }, []);
+
+  const requestColorPicker = useCallback(() => {
+    setShowColorPicker(true);
+  }, []);
+
+  const confirmDelete = useCallback(() => {
+    if (deleteOption === "delete" && onDeleteFolderWithContents) {
+      onDeleteFolderWithContents(item.id);
+    } else {
+      onDeleteItem(item.id);
+    }
+    setShowDeleteDialog(false);
+    setDeleteOption(null);
+  }, [item.id, onDeleteItem, onDeleteFolderWithContents, deleteOption]);
+
+  const handleRename = useCallback(
+    (newName: string) => {
+      onUpdateItem(item.id, { name: newName });
+    },
+    [item.id, onUpdateItem],
+  );
+
+  const handleColorChange = useCallback(
+    (color: ColorResult) => {
+      onUpdateItem(item.id, { color: color.hex as CardColor });
+      setShowColorPicker(false);
+    },
+    [item.id, onUpdateItem],
+  );
+
+  const handleMove = useCallback(
+    (folderId: string | null) => {
+      if (onMoveItem) {
+        onMoveItem(item.id, folderId);
+      }
+    },
+    [item.id, onMoveItem],
+  );
+
+  return {
+    showDeleteDialog,
+    setShowDeleteDialog,
+    showRenameDialog,
+    setShowRenameDialog,
+    showMoveDialog,
+    setShowMoveDialog,
+    showColorPicker,
+    setShowColorPicker,
+    deleteOption,
+    setDeleteOption,
+    requestDelete,
+    requestRename,
+    requestMove,
+    requestColorPicker,
+    confirmDelete,
+    handleRename,
+    handleColorChange,
+    handleMove,
+  };
+}


### PR DESCRIPTION
This PR bypasses the delete confirmation dialog when deleting an empty folder, since there are no items to keep or delete.

- In `FolderCard.tsx`, check `itemCount === 0` before showing dialog—call `onDeleteItem` directly if empty
- In `SidebarCardList.tsx`, check `totalItemCount === 0` before showing dialog—call `onDeleteFolder` directly if empty

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/ef8293a8-4265-4ed6-a6d3-de660620f9a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-078" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/ef8293a8-4265-4ed6-a6d3-de660620f9a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-078&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-078"><img alt="ENG-078" src="https://capy.ai/api/badge/thread.svg?label=ENG-078"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete confirmation dialogs are item-type-aware with contextual titles and messaging; folders with contents show radio options to keep or delete contents and disable Delete until an option is chosen.
  * More consistent dialog flows for rename, move, color, and delete across workspace and sidebar items; UI sizing tweak for nested vs root overflow trigger.

* **Refactor**
  * Centralized management of workspace card action dialogs and state for unified behavior and toast handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->