### PR TITLE
feat(pdf): add keyboard shortcut to capture button tooltip

### DIFF
--- a/src/components/pdf/PdfPanelHeader.tsx
+++ b/src/components/pdf/PdfPanelHeader.tsx
@@ -263,6 +263,12 @@ export const PdfPanelHeader = memo(function PdfPanelHeader({
     const onKeyDown = (e: KeyboardEvent) => {
       // Only the topmost panel responds to the shortcut.
       if (_mountedPanelStack[_mountedPanelStack.length - 1] !== documentId) return;
+      // Don't fire while the user is typing in an editable control.
+      const target = e.target;
+      if (
+        target instanceof HTMLElement &&
+        target.closest("input, textarea, select, [contenteditable='true']")
+      ) return;
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === "c") {
         e.preventDefault();
         captureRef.current?.toggleMarqueeCapture();

--- a/src/components/pdf/PdfPanelHeader.tsx
+++ b/src/components/pdf/PdfPanelHeader.tsx
@@ -299,7 +299,7 @@ export const PdfPanelHeader = memo(function PdfPanelHeader({
       </TooltipTrigger>
       <TooltipContent>
         {captureState.isMarqueeCaptureActive
-          ? <>Cancel capture <Kbd className="ml-1">Esc</Kbd></>
+          ? <>Cancel capture <Kbd className="ml-1">Esc</Kbd> <Kbd>{formatKeyboardShortcut("C", true)}</Kbd></>
           : <>Capture Area <Kbd className="ml-1">{formatKeyboardShortcut("C", true)}</Kbd></>}
       </TooltipContent>
     </Tooltip>

--- a/src/components/pdf/PdfPanelHeader.tsx
+++ b/src/components/pdf/PdfPanelHeader.tsx
@@ -28,6 +28,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { Kbd } from "@/components/ui/kbd";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -243,6 +244,17 @@ export const PdfPanelHeader = memo(function PdfPanelHeader({
     };
   }, [captureState.isMarqueeCaptureActive]);
 
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === "c") {
+        e.preventDefault();
+        captureRef.current?.toggleMarqueeCapture();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
+
   const zoomPercent = zoomState?.currentZoomLevel
     ? Math.round(zoomState.currentZoomLevel * 100)
     : 100;
@@ -270,8 +282,8 @@ export const PdfPanelHeader = memo(function PdfPanelHeader({
       </TooltipTrigger>
       <TooltipContent>
         {captureState.isMarqueeCaptureActive
-          ? "Cancel capture (Esc)"
-          : "Capture Area"}
+          ? <>Cancel capture <Kbd className="ml-1">Esc</Kbd></>
+          : <>Capture Area <Kbd className="ml-1">{formatKeyboardShortcut("C", true)}</Kbd></>}
       </TooltipContent>
     </Tooltip>
   );

--- a/src/components/pdf/PdfPanelHeader.tsx
+++ b/src/components/pdf/PdfPanelHeader.tsx
@@ -124,6 +124,11 @@ async function rotateCaptureBlob(
   }
 }
 
+// Track mounted PdfPanelHeader instances so only the most recent one
+// responds to the global Cmd+Shift+C shortcut (avoids firing on every
+// panel when multiple PDFs are open).
+const _mountedPanelStack: string[] = [];
+
 export const PdfPanelHeader = memo(function PdfPanelHeader({
   documentId,
   itemName,
@@ -244,8 +249,20 @@ export const PdfPanelHeader = memo(function PdfPanelHeader({
     };
   }, [captureState.isMarqueeCaptureActive]);
 
+  // Register / unregister this panel on the module-level stack so only
+  // the topmost (most-recently-mounted) panel owns the global shortcut.
+  useEffect(() => {
+    _mountedPanelStack.push(documentId);
+    return () => {
+      const idx = _mountedPanelStack.lastIndexOf(documentId);
+      if (idx >= 0) _mountedPanelStack.splice(idx, 1);
+    };
+  }, [documentId]);
+
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
+      // Only the topmost panel responds to the shortcut.
+      if (_mountedPanelStack[_mountedPanelStack.length - 1] !== documentId) return;
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === "c") {
         e.preventDefault();
         captureRef.current?.toggleMarqueeCapture();
@@ -253,7 +270,7 @@ export const PdfPanelHeader = memo(function PdfPanelHeader({
     };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, []);
+  }, [documentId]);
 
   const zoomPercent = zoomState?.currentZoomLevel
     ? Math.round(zoomState.currentZoomLevel * 100)


### PR DESCRIPTION
This PR adds keyboard shortcut display to the PDF viewer capture button tooltip, matching the pattern used in WorkspaceHeader and ChatHeader. The tooltip now shows the platform-specific shortcut (Cmd+Shift+C / Ctrl+Shift+C) for toggling capture mode and Esc for canceling. A new keyboard handler has been added to listen for the Cmd+Shift+C / Ctrl+Shift+C shortcut globally.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/c28980bb-975f-444b-8180-24ca2558e546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-084" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/c28980bb-975f-444b-8180-24ca2558e546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-084&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-084"><img alt="ENG-084" src="https://capy.ai/api/badge/thread.svg?label=ENG-084"></picture></a>
<!-- capy-pr-badge:end -->