### PR TITLE
Fix: enable PDF internal hyperlink navigation

### DIFF
--- a/src/components/pdf/AppPdfViewer.tsx
+++ b/src/components/pdf/AppPdfViewer.tsx
@@ -16,7 +16,7 @@ import { FullscreenPluginPackage } from '@embedpdf/plugin-fullscreen/react';
 import { InteractionManagerPluginPackage, PagePointerProvider } from '@embedpdf/plugin-interaction-manager/react';
 import { TilingPluginPackage, TilingLayer } from '@embedpdf/plugin-tiling/react';
 import { ThumbnailPluginPackage, ThumbnailsPane, ThumbImg } from '@embedpdf/plugin-thumbnail/react';
-import { AnnotationPluginPackage, AnnotationLayer, useAnnotationCapability, AnnotationSelectionMenuProps } from '@embedpdf/plugin-annotation/react';
+import { AnnotationPluginPackage, AnnotationLayer, useAnnotationCapability, AnnotationSelectionMenuProps, LockModeType } from '@embedpdf/plugin-annotation/react';
 import { CapturePluginPackage, MarqueeCapture, useCapture } from '@embedpdf/plugin-capture/react';
 import { HistoryPluginPackage } from '@embedpdf/plugin-history/react';
 import { SearchPluginPackage, SearchLayer, useSearch } from '@embedpdf/plugin-search/react';
@@ -893,8 +893,15 @@ const AppPdfViewer = ({ pdfSrc, showThumbnails = false, renderHeader, itemName, 
     // Dependencies first for Annotations
     createPluginRegistration(HistoryPluginPackage),
     createPluginRegistration(AnnotationPluginPackage, {
-      // You can add configuration here like author name if we had user profiles
       annotationAuthor: "User",
+      tools: [{
+        id: 'link',
+        categories: ['annotation', 'markup', 'link-nav'],
+      }],
+      locked: {
+        type: LockModeType.Include,
+        categories: ['link-nav'],
+      },
     }),
     createPluginRegistration(ThumbnailPluginPackage, {
       width: 180,


### PR DESCRIPTION
PDF internal hyperlinks were not working because link annotations were rendered in editable mode (clicking only selected the annotation). Configure the annotation plugin to lock link annotations, which activates LinkLockedMode that calls navigateTarget() on click to jump to goto destinations.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/9a293ca7-74cc-4c08-8438-e762c4b8eff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-082" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/9a293ca7-74cc-4c08-8438-e762c4b8eff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-082&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-082"><img alt="ENG-082" src="https://capy.ai/api/badge/thread.svg?label=ENG-082"></picture></a>
<!-- capy-pr-badge:end -->