### PR TITLE
fix: change capture shortcut from Cmd+Shift+C to Cmd+Shift+X

### DIFF
--- a/src/components/pdf/PdfPanelHeader.tsx
+++ b/src/components/pdf/PdfPanelHeader.tsx
@@ -125,7 +125,7 @@ async function rotateCaptureBlob(
 }
 
 // Track mounted PdfPanelHeader instances so only the most recent one
-// responds to the global Cmd+Shift+C shortcut (avoids firing on every
+// responds to the global Cmd+Shift+X shortcut (avoids firing on every
 // panel when multiple PDFs are open).
 const _mountedPanelStack: string[] = [];
 
@@ -269,7 +269,7 @@ export const PdfPanelHeader = memo(function PdfPanelHeader({
         target instanceof HTMLElement &&
         target.closest("input, textarea, select, [contenteditable='true']")
       ) return;
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === "c") {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === "x") {
         e.preventDefault();
         captureRef.current?.toggleMarqueeCapture();
       }
@@ -305,8 +305,8 @@ export const PdfPanelHeader = memo(function PdfPanelHeader({
       </TooltipTrigger>
       <TooltipContent>
         {captureState.isMarqueeCaptureActive
-          ? <>Cancel capture <Kbd className="ml-1">Esc</Kbd> <Kbd>{formatKeyboardShortcut("C", true)}</Kbd></>
-          : <>Capture Area <Kbd className="ml-1">{formatKeyboardShortcut("C", true)}</Kbd></>}
+          ? <>Cancel capture <Kbd className="ml-1">Esc</Kbd> <Kbd>{formatKeyboardShortcut("X", true)}</Kbd></>
+          : <>Capture Area <Kbd className="ml-1">{formatKeyboardShortcut("X", true)}</Kbd></>}
       </TooltipContent>
     </Tooltip>
   );


### PR DESCRIPTION
Cmd+Shift+C conflicts with browser DevTools element inspector in Chrome/Edge/Firefox. Changed to Cmd+Shift+X which has no browser or application conflicts. Updates tooltip display, keyboard handler, and comment references.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/c28980bb-975f-444b-8180-24ca2558e546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-084" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/c28980bb-975f-444b-8180-24ca2558e546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-084&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-084"><img alt="ENG-084" src="https://capy.ai/api/badge/thread.svg?label=ENG-084"></picture></a>
<!-- capy-pr-badge:end -->