### PR TITLE
fix: allow removing attachments while uploading

### DIFF
--- a/src/components/chat/AttachmentChip.tsx
+++ b/src/components/chat/AttachmentChip.tsx
@@ -122,7 +122,7 @@ export const AttachmentChip: FC<AttachmentChipProps> = ({
               ) : null}
             </Dialog>
           )}
-          {!readOnly && onRemove && attachment.status !== "uploading" && (
+          {!readOnly && onRemove && (
             <TooltipIconButton
               tooltip="Remove file"
               className="absolute top-1.5 right-1.5 size-3.5 rounded-full bg-white text-muted-foreground opacity-100 shadow-sm hover:bg-white! [&_svg]:text-black hover:[&_svg]:text-destructive"
@@ -133,11 +133,9 @@ export const AttachmentChip: FC<AttachmentChipProps> = ({
             </TooltipIconButton>
           )}
         </div>
-        {attachment.status !== "uploading" && (
-          <div className="text-[11px] text-muted-foreground w-full truncate text-center px-1 leading-tight">
-            {attachment.name}
-          </div>
-        )}
+        <div className="text-[11px] text-muted-foreground w-full truncate text-center px-1 leading-tight">
+          {attachment.name}
+        </div>
       </div>
       <TooltipContent side="top">{attachment.name}</TooltipContent>
     </Tooltip>

--- a/src/components/home/HomeAttachmentCards.tsx
+++ b/src/components/home/HomeAttachmentCards.tsx
@@ -66,6 +66,17 @@ export function HomeAttachmentCards({
               <>
                 <Skeleton className="size-5 shrink-0 rounded" />
                 <Skeleton className="h-4 flex-1 min-w-[60px]" />
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRemoveFile(i);
+                  }}
+                  className="ml-1 shrink-0 rounded p-0.5 hover:bg-muted"
+                  aria-label="Remove file"
+                >
+                  <X className="size-3.5" />
+                </button>
               </>
             ) : (
               <>

--- a/src/components/home/HomeAttachmentCards.tsx
+++ b/src/components/home/HomeAttachmentCards.tsx
@@ -66,17 +66,6 @@ export function HomeAttachmentCards({
               <>
                 <Skeleton className="size-5 shrink-0 rounded" />
                 <Skeleton className="h-4 flex-1 min-w-[60px]" />
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onRemoveFile(i);
-                  }}
-                  className="ml-1 shrink-0 rounded p-0.5 hover:bg-muted"
-                  aria-label="Remove file"
-                >
-                  <X className="size-3.5" />
-                </button>
               </>
             ) : (
               <>
@@ -90,19 +79,19 @@ export function HomeAttachmentCards({
                 <span className="truncate text-sm" title={displayName}>
                   {truncateText(displayName, 24)}
                 </span>
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onRemoveFile(i);
-                  }}
-                  className="ml-1 shrink-0 rounded p-0.5 hover:bg-muted"
-                  aria-label="Remove file"
-                >
-                  <X className="size-3.5" />
-                </button>
               </>
             )}
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemoveFile(i);
+              }}
+              className="ml-1 shrink-0 rounded p-0.5 hover:bg-muted"
+              aria-label="Remove file"
+            >
+              <X className="size-3.5" />
+            </button>
           </div>
         );
       })}


### PR DESCRIPTION
Removes condition hiding the remove button when attachment status is uploading, allowing users to cancel stuck or unwanted uploads before completion. Backend cleanup handles in-flight upload termination via existing removeAttachment/removeFile logic.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/65aa523c-4062-48fc-a1d9-7e2f9ff99226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-087" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/65aa523c-4062-48fc-a1d9-7e2f9ff99226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-087&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-087"><img alt="ENG-087" src="https://capy.ai/api/badge/thread.svg?label=ENG-087"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can remove files while they are uploading, giving immediate control to cancel uploads.
  * File names are now consistently displayed during the upload process for clearer context.
  * Remove buttons are now shown on uploading file cards, making deletion easier and more discoverable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->