### PR TITLE
fix: sanitize PDF text extraction using toWellFormed

### DIFF
--- a/src/components/pdf/AppPdfViewer.tsx
+++ b/src/components/pdf/AppPdfViewer.tsx
@@ -224,7 +224,7 @@ const TextSelectionMenu = ({
       // Use the .wait(successCb, errorCb) pattern
       // Casting to any to avoid strict TS issues if the type definition is slightly off for 'wait'
       (textTask as any).wait((lines: string[]) => {
-        const text = lines.join('\n');
+        const text = lines.join('\n').toWellFormed();
 
         if (text && text.trim().length > 0) {
           const page = scrollState?.currentPage;


### PR DESCRIPTION
PostgreSQL jsonb rejects unpaired UTF-16 surrogates as invalid Unicode per RFC 8259. PDF text extraction for mathematical symbols (supplementary plane characters like U+1D400–U+1D7FF) can return lone high/low surrogates when selection boundaries split surrogate pairs. Use String.toWellFormed() (ES2024, built into Node 20+) to replace lone surrogates with U+FFFD at the source, preventing the insert failure from reaching the database layer.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/786a9c74-84d4-40c0-b7b2-215f57409c6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-089" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/786a9c74-84d4-40c0-b7b2-215f57409c6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-089&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-089"><img alt="ENG-089" src="https://capy.ai/api/badge/thread.svg?label=ENG-089"></picture></a>
<!-- capy-pr-badge:end -->