### PR TITLE
refactor: generalize active item context for PDFs and quizzes

### DIFF
--- a/src/components/chat/CardContextDisplay.tsx
+++ b/src/components/chat/CardContextDisplay.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo, memo } from "react";
 
 import { X, ChevronDown, ChevronUp, Eye } from "lucide-react";
-import { useUIStore } from "@/lib/stores/ui-store";
+import { useUIStore, type ItemViewContext } from "@/lib/stores/ui-store";
 import { useSelectedCardIds } from "@/hooks/ui/use-selected-card-ids";
 import { useViewingItemIds } from "@/hooks/ui/use-viewing-item-ids";
 import { cn } from "@/lib/utils";
@@ -17,9 +17,18 @@ interface CardContextDisplayProps {
  * Displays selected cards as context chips above the chat input.
  * Shows cards in a collapsible view - single line by default, expandable to show all.
  */
+function getItemContextBadge(ctx: ItemViewContext | undefined): string | null {
+  if (!ctx) return null;
+  switch (ctx.type) {
+    case 'pdf': return ctx.page >= 1 ? `p.${ctx.page}` : null;
+    case 'quiz': return `q.${ctx.questionIndex + 1}`;
+    default: return null;
+  }
+}
+
 function CardContextDisplayImpl({ items }: CardContextDisplayProps) {
   const { selectedCardIds } = useSelectedCardIds();
-  const activePdfPageByItemId = useUIStore((state) => state.activePdfPageByItemId);
+  const activeItemContext = useUIStore((state) => state.activeItemContext);
   const viewingItemIds = useViewingItemIds();
   const toggleCardSelection = useUIStore((state) => state.toggleCardSelection);
 
@@ -104,17 +113,18 @@ function CardContextDisplayImpl({ items }: CardContextDisplayProps) {
               )}
             </div>
 
-            {/* Card Title + Page number for PDFs */}
+            {/* Card Title + context badge */}
             <span className="text-xs max-w-[80px] truncate">
               {item.name || "Untitled"}
             </span>
-            {item.type === "pdf" &&
-              activePdfPageByItemId[item.id] != null &&
-              activePdfPageByItemId[item.id] >= 1 && (
-              <span className="text-xs text-muted-foreground flex-shrink-0">
-                p.{activePdfPageByItemId[item.id]}
-              </span>
-            )}
+            {(() => {
+              const badge = getItemContextBadge(activeItemContext[item.id]);
+              return badge ? (
+                <span className="text-xs text-muted-foreground flex-shrink-0">
+                  {badge}
+                </span>
+              ) : null;
+            })()}
           </div>
           );
         })}

--- a/src/components/chat/ChatProvider.tsx
+++ b/src/components/chat/ChatProvider.tsx
@@ -210,8 +210,8 @@ export function ChatProvider({ workspaceId, children }: ChatProviderProps) {
   const memoryEnabled = useUIStore((state) => state.memoryEnabled);
   const activeFolderId = useUIStore((state) => state.activeFolderId);
   const selectedCardIdsSet = useUIStore((state) => state.selectedCardIds);
-  const activePdfPageByItemId = useUIStore(
-    useShallow((state) => state.activePdfPageByItemId),
+  const activeItemContext = useUIStore(
+    useShallow((state) => state.activeItemContext),
   );
   const workspaceState = useWorkspaceItems();
   const viewingItemIds = useViewingItemIds();
@@ -237,10 +237,10 @@ export function ChatProvider({ workspaceId, children }: ChatProviderProps) {
     return formatSelectedCardsMetadata(
       contextItems,
       workspaceState,
-      activePdfPageByItemId,
+      activeItemContext,
       viewingItemIds,
     );
-  }, [workspaceState, contextCardIds, activePdfPageByItemId, viewingItemIds]);
+  }, [workspaceState, contextCardIds, activeItemContext, viewingItemIds]);
 
   const transportContext = useMemo(
     () => ({

--- a/src/components/pdf/AppPdfViewer.tsx
+++ b/src/components/pdf/AppPdfViewer.tsx
@@ -715,20 +715,20 @@ const PdfInitialPageScroll = ({
 /** Syncs current PDF page to UI store when PDF is open — used for selected-card context so the AI knows which page the user is viewing. */
 const PdfActivePageSync = ({ documentId, itemId }: { documentId: string; itemId?: string }) => {
   const { state: scrollState } = useScroll(documentId);
-  const setActivePdfPage = useUIStore((state) => state.setActivePdfPage);
+  const setActiveItemContext = useUIStore((state) => state.setActiveItemContext);
 
   useEffect(() => {
     if (!itemId) return;
     const page = scrollState?.currentPage;
     if (page != null && page >= 1) {
-      setActivePdfPage(itemId, page);
+      setActiveItemContext(itemId, { type: 'pdf', page });
     }
-  }, [itemId, scrollState?.currentPage, setActivePdfPage]);
+  }, [itemId, scrollState?.currentPage, setActiveItemContext]);
 
   useEffect(() => {
     if (!itemId) return;
-    return () => setActivePdfPage(itemId, null);
-  }, [itemId, setActivePdfPage]);
+    return () => setActiveItemContext(itemId, null);
+  }, [itemId, setActiveItemContext]);
 
   return null;
 };

--- a/src/components/workspace-canvas/QuizContent.tsx
+++ b/src/components/workspace-canvas/QuizContent.tsx
@@ -45,6 +45,7 @@ export function QuizContent({
   // UI store for card selection
   const selectedCardIds = useUIStore((state) => state.selectedCardIds);
   const toggleCardSelection = useUIStore((state) => state.toggleCardSelection);
+  const setActiveItemContext = useUIStore((state) => state.setActiveItemContext);
 
   // Session state
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -63,6 +64,22 @@ export function QuizContent({
 
   const currentQuestion = questions[currentIndex];
   const totalQuestions = questions.length;
+
+  useEffect(() => {
+    if (currentQuestion && !showResults) {
+      setActiveItemContext(item.id, {
+        type: 'quiz',
+        questionIndex: currentIndex,
+        questionId: currentQuestion.id,
+      });
+    } else {
+      setActiveItemContext(item.id, null);
+    }
+  }, [item.id, currentIndex, currentQuestion, showResults, setActiveItemContext]);
+
+  useEffect(() => {
+    return () => setActiveItemContext(item.id, null);
+  }, [item.id, setActiveItemContext]);
 
   // Sync effect: ensure showResults state matches reality of questions vs answered
   // and handle new questions being added

--- a/src/lib/stores/ui-store.ts
+++ b/src/lib/stores/ui-store.ts
@@ -11,6 +11,10 @@ import { getDefaultChatModelId } from "@/lib/ai/models";
 /** Column / keyboard focus when two items are open (split). */
 export type WorkspaceItemSlot = "primary" | "secondary";
 
+export type ItemViewContext =
+  | { type: 'pdf'; page: number }
+  | { type: 'quiz'; questionIndex: number; questionId: string };
+
 /**
  * Up to two workspace items “open” at once.
  * - Today: only `primary` is used; UI is fullscreen one-item view.
@@ -86,8 +90,8 @@ interface UIState {
     pageNumber?: number;
   } | null;
 
-  // PDF active page: itemId -> current page when PDF is open (for selected-card context)
-  activePdfPageByItemId: Record<string, number>;
+  // Active item context: itemId -> view context when item is open (for selected-card context)
+  activeItemContext: Record<string, ItemViewContext>;
 
   // Actions - Chat
   setIsChatExpanded: (expanded: boolean) => void;
@@ -140,7 +144,7 @@ interface UIState {
   setCitationHighlightQuery: (
     query: { itemId: string; query: string; pageNumber?: number } | null,
   ) => void;
-  setActivePdfPage: (itemId: string, page: number | null) => void;
+  setActiveItemContext: (itemId: string, context: ItemViewContext | null) => void;
 
   // Utility actions
   resetChatState: () => void;
@@ -174,7 +178,7 @@ const initialState = {
   // Reply selection
   replySelections: [],
   citationHighlightQuery: null,
-  activePdfPageByItemId: {},
+  activeItemContext: {},
 };
 
 export const useUIStore = create<UIState>()(
@@ -351,15 +355,15 @@ export const useUIStore = create<UIState>()(
         setCitationHighlightQuery: (query) => {
           set({ citationHighlightQuery: query });
         },
-        setActivePdfPage: (itemId, page) => {
+        setActiveItemContext: (itemId, context) => {
           set((state) => {
-            const next = { ...state.activePdfPageByItemId };
-            if (page == null) {
+            const next = { ...state.activeItemContext };
+            if (context == null) {
               delete next[itemId];
             } else {
-              next[itemId] = page;
+              next[itemId] = context;
             }
-            return { activePdfPageByItemId: next };
+            return { activeItemContext: next };
           });
         },
 

--- a/src/lib/utils/format-workspace-context.ts
+++ b/src/lib/utils/format-workspace-context.ts
@@ -13,15 +13,17 @@ import { getVirtualPath } from "./workspace-fs";
 import { getPdfSourceUrl } from "@/lib/pdf/pdf-item";
 import { getCodeExecutionSystemInstructions } from "@/lib/ai/code-execute-environment";
 
+import type { ItemViewContext } from "@/lib/stores/ui-store";
+
 /**
  * Formats item metadata only (no content). Used for workspace context in system prompt.
- * When activePdfPages is provided and item is a PDF, includes activePage if user is currently viewing it.
+ * When activeItemContext is provided, includes view-specific metadata (e.g. activePage for PDFs, activeQuestion for quizzes).
  * When viewingItemIds is provided and item's panel is open, includes (currently viewing) for any item type.
  */
 function formatItemMetadata(
   item: Item,
   items: Item[],
-  activePdfPages?: Record<string, number>,
+  activeItemContext?: Record<string, ItemViewContext>,
   viewingItemIds?: Set<string>,
 ): string {
   const path = getVirtualPath(item, items);
@@ -32,9 +34,9 @@ function formatItemMetadata(
     case "pdf": {
       const d = item.data as PdfData;
       if (d?.filename) parts.push(`filename=${d.filename}`);
-      const activePage = activePdfPages?.[item.id];
-      if (activePage != null && activePage >= 1) {
-        parts.push(`activePage=${activePage}`);
+      const ctx = activeItemContext?.[item.id];
+      if (ctx?.type === 'pdf' && ctx.page >= 1) {
+        parts.push(`activePage=${ctx.page}`);
       }
       break;
     }
@@ -47,6 +49,10 @@ function formatItemMetadata(
     case "quiz": {
       const d = item.data as QuizData;
       parts.push(`questions=${d?.questions?.length ?? 0}`);
+      const ctx = activeItemContext?.[item.id];
+      if (ctx?.type === 'quiz') {
+        parts.push(`activeQuestion=${ctx.questionIndex + 1}`);
+      }
       break;
     }
     case "audio": {
@@ -115,7 +121,7 @@ Your knowledge cutoff date is January 2025.
 </time_and_knowledge>
 
 <context>
-The selected/open context lists what the user is working with: explicitly selected cards plus any item open in a workspace panel (no checkmark required). All listed items matter. Items marked (currently viewing) have highest priority — they are open right now, so prioritize them for ambiguous prompts ("this", "here", "that one", "what I'm looking at") and when relevant otherwise. For PDFs with activePage=N, that specific page is the focus.
+The selected/open context lists what the user is working with: explicitly selected cards plus any item open in a workspace panel (no checkmark required). All listed items matter. Items marked (currently viewing) have highest priority — they are open right now, so prioritize them for ambiguous prompts ("this", "here", "that one", "what I'm looking at") and when relevant otherwise. For PDFs with activePage=N, that specific page is the focus. For quizzes with activeQuestion=N, that specific question is what the user is looking at.
 Context entries provide paths and metadata only — use workspace_search or workspace_read for full text (audio: segment timeline via workspace_read, not raw audio; paginate with lineStart/limit when long).
 If no context is provided, explain how to add items: open a card, or select via checkmark, shift-click, or drag-select.
 Rely only on facts from fetched content. Do not invent or assume information.
@@ -149,7 +155,7 @@ ${getCodeExecutionSystemInstructions()}
 
 PDF: Always try workspace_read first for workspace PDFs (pageStart/pageEnd for page ranges). If content is not yet extracted, tell the user it is still being prepared and try again shortly.
 PDF VISUALS: PDF OCR in this workspace gives you textual structure from the PDF, including normal text and inline tables, but not visual understanding of charts, figures, diagrams, or screenshots embedded in the PDF. Do not claim you can see those visuals unless the user has separately attached a screenshot/image of that region. If the user needs help with a chart or figure from a PDF, tell them to open the PDF and use the camera button in the top right of the open pdf panelto add a screenshot of that area to chat.
-When selected card metadata includes (currently viewing) or activePage=N (for PDFs), the user has that item or page open. Prioritize these for ambiguous references ("this", "here", "this page", "what I'm looking at") and tailor responses to that context.
+When selected card metadata includes (currently viewing) or activePage=N (for PDFs) or activeQuestion=N (for quizzes), the user has that item or page/question open. Prioritize these for ambiguous references ("this", "here", "this page", "what I'm looking at") and tailor responses to that context.
 
 YOUTUBE: If user says "add a video" without a topic, infer from workspace context. Don't ask - just search.
 
@@ -366,12 +372,12 @@ function formatRichContentSection(richContent: RichContent): string {
 /**
  * Formats selected cards as metadata only (paths, names, types).
  * Use when the AI has grep/read tools — it fetches content on demand.
- * When activePdfPages is provided, PDF items include activePage (page user is currently viewing).
+ * When activeItemContext is provided, items include view-specific metadata (e.g. activePage for PDFs, activeQuestion for quizzes).
  */
 export function formatSelectedCardsMetadata(
   selectedItems: Item[],
   allItems?: Item[],
-  activePdfPages?: Record<string, number>,
+  activeItemContext?: Record<string, ItemViewContext>,
   viewingItemIds?: Set<string>,
 ): string {
   if (selectedItems.length === 0) {
@@ -396,7 +402,7 @@ No selected or open items.
     formatItemMetadata(
       item,
       allItems ?? effectiveItems,
-      activePdfPages,
+      activeItemContext,
       viewingItemIds,
     ),
   );


### PR DESCRIPTION
This PR replaces the PDF-specific `activePdfPageByItemId` state with a generalized `activeItemContext` discriminated union, extending support to include quizzes alongside PDFs.

**State & Types** (`ui-store.ts`)
*   Define `ItemViewContext` union type (`{ type: 'pdf'; page } | { type: 'quiz'; questionIndex; questionId }`).
*   Replace `activePdfPageByItemId` state and action with `activeItemContext` and `setActiveItemContext`.

**Viewer Sync** (`AppPdfViewer.tsx`, `QuizContent.tsx`)
*   Update `PdfActivePageSync` to dispatch `{ type: 'pdf', page }` objects.
*   Add question sync in `QuizContent` to dispatch `{ type: 'quiz', ... }` on navigation; clears on results/unmount.

**Context & AI** (`ChatProvider.tsx`, `format-workspace-context.ts`)
*   Update `ChatProvider` to read and pass `activeItemContext` to metadata formatter.
*   Update `formatItemMetadata` and `formatSelectedCardsMetadata` to handle PDF page and quiz question indexing.
*   Update system prompt instructions to reflect quiz context support.

**UI** (`CardContextDisplay.tsx`)
*   Refactor badge rendering with `getItemContextBadge` helper to display `p.N` or `q.N` based on context type.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/50e3f15c-d6e3-4fa0-859d-9359497a202f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-092" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/50e3f15c-d6e3-4fa0-859d-9359497a202f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-092&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-092"><img alt="ENG-092" src="https://capy.ai/api/badge/thread.svg?label=ENG-092"></picture></a>
<!-- capy-pr-badge:end -->