### PR TITLE
feat(quiz): persist quiz progress to database

### DIFF
--- a/src/app/api/workspace/[workspaceId]/quiz-progress/route.ts
+++ b/src/app/api/workspace/[workspaceId]/quiz-progress/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq, and } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { workspaceItemUserState } from "@/lib/db/schema";
+import {
+  requireAuth,
+  verifyWorkspaceAccess,
+  withErrorHandling,
+} from "@/lib/api/workspace-helpers";
+import type { QuizProgressState } from "@/lib/workspace-state/quiz-progress-types";
+
+const STATE_KEY = "quiz_progress";
+const STATE_TYPE = "quiz_progress";
+
+async function handleGET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ workspaceId: string }> },
+) {
+  const userId = await requireAuth();
+  const { workspaceId } = await params;
+
+  await verifyWorkspaceAccess(workspaceId, userId);
+
+  const itemId = _request.nextUrl.searchParams.get("itemId");
+  if (!itemId) {
+    return NextResponse.json({ error: "itemId is required" }, { status: 400 });
+  }
+
+  const [row] = await db
+    .select({ state: workspaceItemUserState.state })
+    .from(workspaceItemUserState)
+    .where(
+      and(
+        eq(workspaceItemUserState.workspaceId, workspaceId),
+        eq(workspaceItemUserState.itemId, itemId),
+        eq(workspaceItemUserState.userId, userId),
+        eq(workspaceItemUserState.stateKey, STATE_KEY),
+      ),
+    )
+    .limit(1);
+
+  return NextResponse.json({ state: (row?.state as QuizProgressState) ?? null });
+}
+
+async function handlePUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ workspaceId: string }> },
+) {
+  const userId = await requireAuth();
+  const { workspaceId } = await params;
+
+  await verifyWorkspaceAccess(workspaceId, userId);
+
+  const body = await request.json();
+  const { itemId, state } = body as { itemId: string; state: QuizProgressState };
+
+  if (!itemId || !state) {
+    return NextResponse.json(
+      { error: "itemId and state are required" },
+      { status: 400 },
+    );
+  }
+
+  await db
+    .insert(workspaceItemUserState)
+    .values({
+      workspaceId,
+      itemId,
+      userId,
+      stateKey: STATE_KEY,
+      stateType: STATE_TYPE,
+      stateSchemaVersion: 1,
+      state: state as unknown as Record<string, unknown>,
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: [
+        workspaceItemUserState.workspaceId,
+        workspaceItemUserState.itemId,
+        workspaceItemUserState.userId,
+        workspaceItemUserState.stateKey,
+      ],
+      set: {
+        state: state as unknown as Record<string, unknown>,
+        stateSchemaVersion: 1,
+        updatedAt: new Date(),
+      },
+    });
+
+  return NextResponse.json({ success: true });
+}
+
+export const GET = withErrorHandling(handleGET, "GET /api/workspace/[workspaceId]/quiz-progress");
+
+export const PUT = withErrorHandling(handlePUT, "PUT /api/workspace/[workspaceId]/quiz-progress");

--- a/src/components/workspace-canvas/QuizContent.tsx
+++ b/src/components/workspace-canvas/QuizContent.tsx
@@ -18,18 +18,22 @@ import {
   Plus,
   Lightbulb,
   MessageCircleQuestion,
+  Loader2,
 } from "lucide-react";
 import { StreamdownMarkdown } from "@/components/ui/streamdown-markdown";
 import { toast } from "sonner";
 import { useOptionalComposerActions } from "@/lib/stores/composer-actions-store";
 import { useUIStore } from "@/lib/stores/ui-store";
 import { getQuestionText } from "@/lib/workspace-state/quiz-shuffle";
+import { useCurrentWorkspaceId } from "@/contexts/WorkspaceContext";
+import { useQuizProgress } from "@/hooks/use-quiz-progress";
+import type { QuizProgressState } from "@/lib/workspace-state/quiz-progress-types";
 
 interface QuizContentProps {
   item: Item;
   onUpdateData: (updater: (prev: ItemData) => ItemData) => void;
   isScrollLocked?: boolean;
-  className?: string; // Optional (e.g. padding when in modal)
+  className?: string;
 }
 
 export function QuizContent({
@@ -42,12 +46,16 @@ export function QuizContent({
   const questions = quizData.questions || [];
   const promptInput = useOptionalComposerActions();
 
-  // UI store for card selection
   const selectedCardIds = useUIStore((state) => state.selectedCardIds);
   const toggleCardSelection = useUIStore((state) => state.toggleCardSelection);
   const setActiveItemContext = useUIStore((state) => state.setActiveItemContext);
 
-  // Session state
+  const workspaceId = useCurrentWorkspaceId();
+  const { progress, isLoading, updateProgress } = useQuizProgress(
+    workspaceId ?? "",
+    item.id,
+  );
+
   const [currentIndex, setCurrentIndex] = useState(0);
   const [selectedAnswer, setSelectedAnswer] = useState<number | null>(null);
   const [isSubmitted, setIsSubmitted] = useState(false);
@@ -55,8 +63,43 @@ export function QuizContent({
     Array<{ questionId: string; userAnswer: number; isCorrect: boolean }>
   >([]);
   const [showResults, setShowResults] = useState(false);
+  const [attemptNumber, setAttemptNumber] = useState(1);
+  const [startedAt, setStartedAt] = useState<string>(
+    new Date().toISOString(),
+  );
 
-  // Track previous question count and IDs to detect when new questions are added
+  const initializedRef = useRef(false);
+
+  useEffect(() => {
+    if (isLoading || initializedRef.current) return;
+    initializedRef.current = true;
+
+    if (!progress || !progress.answers || progress.answers.length === 0) return;
+
+    const validAnswers = progress.answers.filter((a) =>
+      questions.some((q) => q.id === a.questionId),
+    );
+
+    setAnsweredQuestions(
+      validAnswers.map((a) => ({
+        questionId: a.questionId,
+        userAnswer: a.userAnswer,
+        isCorrect: a.isCorrect,
+      })),
+    );
+    setAttemptNumber(progress.attemptNumber ?? 1);
+    setStartedAt(progress.startedAt ?? new Date().toISOString());
+
+    if (progress.completedAt && validAnswers.length >= questions.length) {
+      setShowResults(true);
+    } else {
+      const firstUnanswered = questions.findIndex(
+        (q) => !validAnswers.some((a) => a.questionId === q.id),
+      );
+      setCurrentIndex(firstUnanswered >= 0 ? firstUnanswered : 0);
+    }
+  }, [isLoading, progress, questions]);
+
   const prevQuestionCountRef = useRef(questions.length);
   const prevQuestionIdsRef = useRef<Set<string>>(
     new Set(questions.map((q) => q.id)),
@@ -81,55 +124,42 @@ export function QuizContent({
     return () => setActiveItemContext(item.id, null);
   }, [item.id, setActiveItemContext]);
 
-  // Sync effect: ensure showResults state matches reality of questions vs answered
-  // and handle new questions being added
   useEffect(() => {
     const prevCount = prevQuestionCountRef.current;
     const currentCount = questions.length;
     const prevIds = prevQuestionIdsRef.current;
 
-    // Detect if new questions were actually added (not just a re-render)
     const currentIds = new Set(questions.map((q) => q.id));
     const questionsAdded = questions.filter((q) => !prevIds.has(q.id)).length;
 
-    // Check if we have unanswered questions
     const hasUnansweredQuestions = answeredQuestions.length < currentCount;
 
     if (questionsAdded > 0 && currentCount > prevCount) {
-      // New questions were added
-
       if (showResults) {
-        // If we were showing results, we need to hide them and let user answer new questions
         toast.success(
           `${questionsAdded} new question${questionsAdded > 1 ? "s" : ""} added! Continue your quiz.`,
         );
         setShowResults(false);
-        setCurrentIndex(prevCount); // Go to first new question
+        setCurrentIndex(prevCount);
         setSelectedAnswer(null);
         setIsSubmitted(false);
       } else {
-        // Just notify user
         toast.success(
           `${questionsAdded} new question${questionsAdded > 1 ? "s" : ""} added!`,
         );
       }
     } else if (showResults && hasUnansweredQuestions) {
-      // Sanity check: if showing results but we have unanswered questions (e.g. from sync mismatch),
-      // force exit results mode
       setShowResults(false);
     }
 
-    // Update refs for next comparison
     prevQuestionCountRef.current = currentCount;
     prevQuestionIdsRef.current = currentIds;
   }, [questions, showResults, answeredQuestions.length, currentIndex]);
 
-  // Check if current question was already answered
   const previousAnswer = useMemo(() => {
     return answeredQuestions.find((a) => a.questionId === currentQuestion?.id);
   }, [answeredQuestions, currentQuestion?.id]);
 
-  // Restore state when navigating to previously answered question
   useEffect(() => {
     if (previousAnswer) {
       setSelectedAnswer(previousAnswer.userAnswer);
@@ -140,13 +170,35 @@ export function QuizContent({
     }
   }, [currentIndex, previousAnswer]);
 
-  // Handle answer selection
+  const buildProgressState = useCallback(
+    (
+      answers: typeof answeredQuestions,
+      completed: boolean,
+    ): QuizProgressState => ({
+      answers: answers.map((a) => ({
+        ...a,
+        answeredAt:
+          progress?.answers?.find((pa) => pa.questionId === a.questionId)
+            ?.answeredAt ?? new Date().toISOString(),
+      })),
+      attemptNumber,
+      startedAt,
+      ...(completed
+        ? {
+            completedAt: new Date().toISOString(),
+            score: answers.filter((a) => a.isCorrect).length,
+            totalQuestions: questions.length,
+          }
+        : {}),
+    }),
+    [attemptNumber, startedAt, progress?.answers, questions.length],
+  );
+
   const handleSelectAnswer = (index: number) => {
     if (isSubmitted) return;
     setSelectedAnswer(index);
   };
 
-  // Handle answer submission
   const handleSubmit = () => {
     if (selectedAnswer === null || isSubmitted) return;
 
@@ -164,50 +216,60 @@ export function QuizContent({
 
     setAnsweredQuestions(newAnsweredQuestions);
     setIsSubmitted(true);
-  };
 
-  // Navigation
-  const handleNext = () => {
-    if (currentIndex < totalQuestions - 1) {
-      const nextIndex = currentIndex + 1;
-      setCurrentIndex(nextIndex);
-    } else {
-      // Show results
-      setShowResults(true);
+    if (workspaceId) {
+      updateProgress(buildProgressState(newAnsweredQuestions, false));
     }
   };
 
-  // Arrow navigation - only moves between questions, never shows results
+  const handleNext = () => {
+    if (currentIndex < totalQuestions - 1) {
+      setCurrentIndex(currentIndex + 1);
+    } else {
+      setShowResults(true);
+      if (workspaceId) {
+        updateProgress(buildProgressState(answeredQuestions, true));
+      }
+    }
+  };
+
   const handleArrowNext = () => {
     if (currentIndex < totalQuestions - 1) {
-      const nextIndex = currentIndex + 1;
-      setCurrentIndex(nextIndex);
+      setCurrentIndex(currentIndex + 1);
     }
   };
 
   const handlePrevious = () => {
     if (currentIndex > 0) {
-      const prevIndex = currentIndex - 1;
-      setCurrentIndex(prevIndex);
+      setCurrentIndex(currentIndex - 1);
     }
   };
 
   const handleRestart = () => {
+    const newAttempt = attemptNumber + 1;
+    const newStartedAt = new Date().toISOString();
     setCurrentIndex(0);
     setSelectedAnswer(null);
     setIsSubmitted(false);
     setAnsweredQuestions([]);
     setShowResults(false);
+    setAttemptNumber(newAttempt);
+    setStartedAt(newStartedAt);
+
+    if (workspaceId) {
+      updateProgress({
+        answers: [],
+        attemptNumber: newAttempt,
+        startedAt: newStartedAt,
+      });
+    }
   };
 
-  // Handle Update Quiz - programmatically send message to add more questions
   const handleUpdateQuiz = () => {
-    // First, ensure this card is selected for context
     if (!selectedCardIds.has(item.id)) {
       toggleCardSelection(item.id);
     }
 
-    // Then send the message via composer
     const composer = promptInput;
     if (composer) {
       try {
@@ -268,23 +330,32 @@ export function QuizContent({
     }
   };
 
-  // Calculate score
   const score = useMemo(() => {
     return answeredQuestions.filter((a) => a.isCorrect).length;
   }, [answeredQuestions]);
 
-  // Prevent focus stealing from chat input
   const preventFocusSteal = (e: React.MouseEvent) => {
     e.preventDefault();
   };
 
-  // Stop propagation so card click doesn't open modal when interacting with quiz
   const stopPropagation = (e: React.MouseEvent) => {
     e.stopPropagation();
   };
 
+  if (isLoading) {
+    return (
+      <div
+        className={cn(
+          "flex flex-col h-full items-center justify-center",
+          className,
+        )}
+      >
+        <Loader2 className="w-6 h-6 animate-spin text-foreground/40 dark:text-white/40" />
+      </div>
+    );
+  }
+
   if (!currentQuestion && !showResults) {
-    // Template-created items have "Update me" name and should show generating skeleton
     const isAwaitingGeneration =
       item.name === "Update me" && questions.length === 0;
 
@@ -376,7 +447,6 @@ export function QuizContent({
       );
     }
 
-    // User-created quiz with no questions - show empty state
     return (
       <div
         className={cn(
@@ -394,7 +464,6 @@ export function QuizContent({
     );
   }
 
-  // Results view
   if (showResults) {
     const percentage =
       totalQuestions > 0 ? Math.round((score / totalQuestions) * 100) : 0;

--- a/src/components/workspace-canvas/QuizContent.tsx
+++ b/src/components/workspace-canvas/QuizContent.tsx
@@ -69,6 +69,14 @@ export function QuizContent({
   );
 
   const initializedRef = useRef(false);
+  const initializedItemIdRef = useRef(item.id);
+
+  useEffect(() => {
+    if (initializedItemIdRef.current !== item.id) {
+      initializedRef.current = false;
+      initializedItemIdRef.current = item.id;
+    }
+  }, [item.id]);
 
   useEffect(() => {
     if (isLoading || initializedRef.current) return;

--- a/src/hooks/use-quiz-progress.ts
+++ b/src/hooks/use-quiz-progress.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import type { QuizProgressState } from "@/lib/workspace-state/quiz-progress-types";
+
+const DEBOUNCE_MS = 500;
+
+export function useQuizProgress(workspaceId: string, itemId: string) {
+  const [progress, setProgress] = useState<QuizProgressState | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    fetch(
+      `/api/workspace/${workspaceId}/quiz-progress?itemId=${encodeURIComponent(itemId)}`,
+      { signal: controller.signal },
+    )
+      .then((res) => res.json())
+      .then((data) => setProgress(data.state ?? null))
+      .catch((err) => {
+        if (err.name !== "AbortError") {
+          console.error("[useQuizProgress] load failed", err);
+        }
+      })
+      .finally(() => setIsLoading(false));
+
+    return () => {
+      controller.abort();
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [workspaceId, itemId]);
+
+  const saveProgress = useCallback(
+    (state: QuizProgressState) => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        fetch(`/api/workspace/${workspaceId}/quiz-progress`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ itemId, state }),
+        }).catch((err) =>
+          console.error("[useQuizProgress] save failed", err),
+        );
+      }, DEBOUNCE_MS);
+    },
+    [workspaceId, itemId],
+  );
+
+  const updateProgress = useCallback(
+    (state: QuizProgressState) => {
+      setProgress(state);
+      saveProgress(state);
+    },
+    [saveProgress],
+  );
+
+  const clearProgress = useCallback(() => {
+    setProgress(null);
+  }, []);
+
+  return { progress, isLoading, updateProgress, clearProgress };
+}

--- a/src/hooks/use-quiz-progress.ts
+++ b/src/hooks/use-quiz-progress.ts
@@ -12,6 +12,9 @@ export function useQuizProgress(workspaceId: string, itemId: string) {
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
+    setIsLoading(true);
+    setProgress(null);
+
     const controller = new AbortController();
     abortRef.current = controller;
 
@@ -19,11 +22,21 @@ export function useQuizProgress(workspaceId: string, itemId: string) {
       `/api/workspace/${workspaceId}/quiz-progress?itemId=${encodeURIComponent(itemId)}`,
       { signal: controller.signal },
     )
-      .then((res) => res.json())
-      .then((data) => setProgress(data.state ?? null))
+      .then((res) => {
+        if (!res.ok) {
+          console.error("[useQuizProgress] load returned", res.status);
+          setProgress(null);
+          return;
+        }
+        return res.json();
+      })
+      .then((data) => {
+        if (data) setProgress(data.state ?? null);
+      })
       .catch((err) => {
         if (err.name !== "AbortError") {
           console.error("[useQuizProgress] load failed", err);
+          setProgress(null);
         }
       })
       .finally(() => setIsLoading(false));
@@ -58,9 +71,5 @@ export function useQuizProgress(workspaceId: string, itemId: string) {
     [saveProgress],
   );
 
-  const clearProgress = useCallback(() => {
-    setProgress(null);
-  }, []);
-
-  return { progress, isLoading, updateProgress, clearProgress };
+  return { progress, isLoading, updateProgress };
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -750,3 +750,20 @@ export const chatMessages = pgTable(
     ),
   ],
 );
+
+export const workspaceItemUserState = pgTable(
+  "workspace_item_user_state",
+  {
+    workspaceId: uuid("workspace_id").notNull(),
+    itemId: text("item_id").notNull(),
+    userId: text("user_id").notNull(),
+    stateKey: text("state_key").default("item").notNull(),
+    stateType: text("state_type").notNull(),
+    stateSchemaVersion: integer("state_schema_version").default(1).notNull(),
+    state: jsonb("state").notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [{
+    pk: primaryKey({ columns: [table.workspaceId, table.itemId, table.userId, table.stateKey] }),
+  }]
+);

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -11,6 +11,7 @@ import {
   workspaceItemExtracted,
   userProfiles,
   workspaceCollaborators,
+  workspaceItemUserState,
 } from "./schema";
 import type { Item } from "@/lib/workspace-state/types";
 
@@ -42,6 +43,13 @@ export type WorkspaceCollaborator = InferSelectModel<
 >;
 export type WorkspaceCollaboratorInsert = InferInsertModel<
   typeof workspaceCollaborators
+>;
+
+export type WorkspaceItemUserState = InferSelectModel<
+  typeof workspaceItemUserState
+>;
+export type WorkspaceItemUserStateInsert = InferInsertModel<
+  typeof workspaceItemUserState
 >;
 
 export type PermissionLevel = "viewer" | "editor";

--- a/src/lib/workspace-state/quiz-progress-types.ts
+++ b/src/lib/workspace-state/quiz-progress-types.ts
@@ -1,0 +1,15 @@
+export interface QuizAnswerRecord {
+  questionId: string;
+  userAnswer: number;
+  isCorrect: boolean;
+  answeredAt: string;
+}
+
+export interface QuizProgressState {
+  answers: QuizAnswerRecord[];
+  attemptNumber: number;
+  startedAt: string;
+  completedAt?: string;
+  score?: number;
+  totalQuestions?: number;
+}


### PR DESCRIPTION
This PR adds persistence for quiz progress, ensuring users can resume quizzes across sessions. Progress is stored in the existing `workspace_item_user_state` table (which already has RLS policies) and loaded on component mount.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/50e3f15c-d6e3-4fa0-859d-9359497a202f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-092" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/50e3f15c-d6e3-4fa0-859d-9359497a202f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-092&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-092"><img alt="ENG-092" src="https://capy.ai/api/badge/thread.svg?label=ENG-092"></picture></a>
<!-- capy-pr-badge:end -->