### PR TITLE
feat: add useEffect guardrails hooks and oxlint rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -23,7 +23,19 @@
     "eslint/no-cond-assign": "warn",
     "unicorn/prefer-string-starts-ends-with": "warn",
     "unicorn/no-new-array": "warn",
-    "unicorn/no-invalid-fetch-options": "warn"
+    "unicorn/no-invalid-fetch-options": "warn",
+    "eslint/no-restricted-imports": [
+      "warn",
+      {
+        "paths": [
+          {
+            "name": "react",
+            "importNames": ["useEffect"],
+            "message": "Avoid direct useEffect. Use useMountEffect, useEventListener, useBodyScrollLock, or create a purpose-named hook."
+          }
+        ]
+      }
+    ]
   },
   "env": {
     "builtin": true

--- a/src/hooks/use-body-scroll-lock.ts
+++ b/src/hooks/use-body-scroll-lock.ts
@@ -1,0 +1,17 @@
+/* oxlint-disable eslint(no-restricted-imports) */
+import { useEffect } from "react";
+
+/**
+ * Locks `document.body` scroll when `locked` is true.
+ * Restores the original overflow value on unlock or unmount.
+ */
+export function useBodyScrollLock(locked: boolean): void {
+  useEffect(() => {
+    if (!locked) return;
+    const original = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = original;
+    };
+  }, [locked]);
+}

--- a/src/hooks/use-event-listener.ts
+++ b/src/hooks/use-event-listener.ts
@@ -1,0 +1,30 @@
+/* oxlint-disable eslint(no-restricted-imports) */
+import { useEffect, useRef } from "react";
+
+/**
+ * Attaches a DOM event listener with automatic cleanup.
+ * The handler is always fresh (no stale closures) via a ref.
+ */
+export function useEventListener<K extends keyof WindowEventMap>(
+  eventName: K,
+  handler: (event: WindowEventMap[K]) => void,
+  options?: {
+    enabled?: boolean;
+    target?: EventTarget | null;
+    capture?: boolean;
+  }
+): void {
+  const savedHandler = useRef(handler);
+  savedHandler.current = handler;
+
+  const { enabled = true, target, capture = false } = options ?? {};
+
+  useEffect(() => {
+    const el = target ?? window;
+    if (!enabled || !el) return;
+
+    const listener = (event: Event) => savedHandler.current(event as WindowEventMap[K]);
+    el.addEventListener(eventName, listener, { capture });
+    return () => el.removeEventListener(eventName, listener, { capture });
+  }, [eventName, enabled, target, capture]);
+}

--- a/src/hooks/use-mount-effect.ts
+++ b/src/hooks/use-mount-effect.ts
@@ -1,0 +1,14 @@
+/* oxlint-disable eslint(no-restricted-imports) */
+import { useEffect } from "react";
+
+/**
+ * Runs an effect exactly once on mount (and cleanup on unmount).
+ * This is the only sanctioned way to call useEffect with an empty dependency array.
+ * For all other cases, use derived state, event handlers, or a purpose-named hook.
+ *
+ * @see https://gist.github.com/alvinsng/5dd68c6ece355dbdbd65340ec2927b1d
+ */
+export function useMountEffect(effect: () => void | (() => void)): void {
+  // oxlint-disable-next-line react-hooks/exhaustive-deps -- mount-only by design
+  useEffect(effect, []);
+}


### PR DESCRIPTION
This PR adds infrastructure to constrain direct `useEffect` usage across the codebase: three shared replacement hooks and an oxlint lint rule.

*   **Hooks (`src/hooks/`)**
    *   `use-mount-effect.ts` — escape hatch for mount-only effects with empty dependency array; suppresses `exhaustive-deps`
    *   `use-event-listener.ts` — typed DOM event listener with auto-cleanup; keeps handler fresh via `useRef`
    *   `use-body-scroll-lock.ts` — locks `document.body` overflow for modals/overlays and restores on unlock/unmount

*   **Lint Configuration (`.oxlintrc.json`)**
    *   Add `eslint/no-restricted-imports` at `warn` level to flag direct `useEffect` imports from `react`
    *   Message directs developers to the sanctioned hooks or creating purpose-named hooks
    *   All three hook files use file-level suppression (`/* oxlint-disable eslint(no-restricted-imports) */`)

Run `pnpm lint` to see 116 warnings on existing `useEffect` imports. TypeScript compiles clean.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/85fe4fe1-312c-4ad7-83af-44b6d501dbcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-094" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/85fe4fe1-312c-4ad7-83af-44b6d501dbcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-094&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-094"><img alt="ENG-094" src="https://capy.ai/api/badge/thread.svg?label=ENG-094"></picture></a>
<!-- capy-pr-badge:end -->