### PR TITLE
Inject quiz progress into context

### DIFF
--- a/src/app/api/workspace/[workspaceId]/quiz-progress/route.ts
+++ b/src/app/api/workspace/[workspaceId]/quiz-progress/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq, and } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { workspaceItemUserState } from "@/lib/db/schema";
+import {
+  requireAuth,
+  verifyWorkspaceAccess,
+  withErrorHandling,
+} from "@/lib/api/workspace-helpers";
+import type { QuizProgressState } from "@/lib/workspace-state/quiz-progress-types";
+
+const STATE_KEY = "quiz_progress";
+const STATE_TYPE = "quiz_progress";
+
+async function handleGET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ workspaceId: string }> },
+) {
+  const userId = await requireAuth();
+  const { workspaceId } = await params;
+
+  await verifyWorkspaceAccess(workspaceId, userId);
+
+  const itemId = _request.nextUrl.searchParams.get("itemId");
+  if (!itemId) {
+    return NextResponse.json({ error: "itemId is required" }, { status: 400 });
+  }
+
+  const [row] = await db
+    .select({ state: workspaceItemUserState.state })
+    .from(workspaceItemUserState)
+    .where(
+      and(
+        eq(workspaceItemUserState.workspaceId, workspaceId),
+        eq(workspaceItemUserState.itemId, itemId),
+        eq(workspaceItemUserState.userId, userId),
+        eq(workspaceItemUserState.stateKey, STATE_KEY),
+      ),
+    )
+    .limit(1);
+
+  return NextResponse.json({ state: (row?.state as QuizProgressState) ?? null });
+}
+
+async function handlePUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ workspaceId: string }> },
+) {
+  const userId = await requireAuth();
+  const { workspaceId } = await params;
+
+  await verifyWorkspaceAccess(workspaceId, userId);
+
+  const body = await request.json();
+  const { itemId, state } = body as { itemId: string; state: QuizProgressState };
+
+  if (!itemId || !state) {
+    return NextResponse.json(
+      { error: "itemId and state are required" },
+      { status: 400 },
+    );
+  }
+
+  await db
+    .insert(workspaceItemUserState)
+    .values({
+      workspaceId,
+      itemId,
+      userId,
+      stateKey: STATE_KEY,
+      stateType: STATE_TYPE,
+      stateSchemaVersion: 1,
+      state: state as unknown as Record<string, unknown>,
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: [
+        workspaceItemUserState.workspaceId,
+        workspaceItemUserState.itemId,
+        workspaceItemUserState.userId,
+        workspaceItemUserState.stateKey,
+      ],
+      set: {
+        state: state as unknown as Record<string, unknown>,
+        stateSchemaVersion: 1,
+        updatedAt: new Date(),
+      },
+    });
+
+  return NextResponse.json({ success: true });
+}
+
+export const GET = withErrorHandling(handleGET, "GET /api/workspace/[workspaceId]/quiz-progress");
+
+export const PUT = withErrorHandling(handlePUT, "PUT /api/workspace/[workspaceId]/quiz-progress");

--- a/src/components/chat/CardContextDisplay.tsx
+++ b/src/components/chat/CardContextDisplay.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo, memo } from "react";
 
 import { X, ChevronDown, ChevronUp, Eye } from "lucide-react";
-import { useUIStore } from "@/lib/stores/ui-store";
+import { useUIStore, type ItemViewContext } from "@/lib/stores/ui-store";
 import { useSelectedCardIds } from "@/hooks/ui/use-selected-card-ids";
 import { useViewingItemIds } from "@/hooks/ui/use-viewing-item-ids";
 import { cn } from "@/lib/utils";
@@ -17,9 +17,18 @@ interface CardContextDisplayProps {
  * Displays selected cards as context chips above the chat input.
  * Shows cards in a collapsible view - single line by default, expandable to show all.
  */
+function getItemContextBadge(ctx: ItemViewContext | undefined): string | null {
+  if (!ctx) return null;
+  switch (ctx.type) {
+    case 'pdf': return ctx.page >= 1 ? `p.${ctx.page}` : null;
+    case 'quiz': return `q.${ctx.questionIndex + 1}`;
+    default: return null;
+  }
+}
+
 function CardContextDisplayImpl({ items }: CardContextDisplayProps) {
   const { selectedCardIds } = useSelectedCardIds();
-  const activePdfPageByItemId = useUIStore((state) => state.activePdfPageByItemId);
+  const activeItemContext = useUIStore((state) => state.activeItemContext);
   const viewingItemIds = useViewingItemIds();
   const toggleCardSelection = useUIStore((state) => state.toggleCardSelection);
 
@@ -104,17 +113,18 @@ function CardContextDisplayImpl({ items }: CardContextDisplayProps) {
               )}
             </div>
 
-            {/* Card Title + Page number for PDFs */}
+            {/* Card Title + context badge */}
             <span className="text-xs max-w-[80px] truncate">
               {item.name || "Untitled"}
             </span>
-            {item.type === "pdf" &&
-              activePdfPageByItemId[item.id] != null &&
-              activePdfPageByItemId[item.id] >= 1 && (
-              <span className="text-xs text-muted-foreground flex-shrink-0">
-                p.{activePdfPageByItemId[item.id]}
-              </span>
-            )}
+            {(() => {
+              const badge = getItemContextBadge(activeItemContext[item.id]);
+              return badge ? (
+                <span className="text-xs text-muted-foreground flex-shrink-0">
+                  {badge}
+                </span>
+              ) : null;
+            })()}
           </div>
           );
         })}

--- a/src/components/chat/ChatProvider.tsx
+++ b/src/components/chat/ChatProvider.tsx
@@ -210,8 +210,8 @@ export function ChatProvider({ workspaceId, children }: ChatProviderProps) {
   const memoryEnabled = useUIStore((state) => state.memoryEnabled);
   const activeFolderId = useUIStore((state) => state.activeFolderId);
   const selectedCardIdsSet = useUIStore((state) => state.selectedCardIds);
-  const activePdfPageByItemId = useUIStore(
-    useShallow((state) => state.activePdfPageByItemId),
+  const activeItemContext = useUIStore(
+    useShallow((state) => state.activeItemContext),
   );
   const workspaceState = useWorkspaceItems();
   const viewingItemIds = useViewingItemIds();
@@ -237,10 +237,10 @@ export function ChatProvider({ workspaceId, children }: ChatProviderProps) {
     return formatSelectedCardsMetadata(
       contextItems,
       workspaceState,
-      activePdfPageByItemId,
+      activeItemContext,
       viewingItemIds,
     );
-  }, [workspaceState, contextCardIds, activePdfPageByItemId, viewingItemIds]);
+  }, [workspaceState, contextCardIds, activeItemContext, viewingItemIds]);
 
   const transportContext = useMemo(
     () => ({

--- a/src/components/pdf/AppPdfViewer.tsx
+++ b/src/components/pdf/AppPdfViewer.tsx
@@ -715,20 +715,20 @@ const PdfInitialPageScroll = ({
 /** Syncs current PDF page to UI store when PDF is open — used for selected-card context so the AI knows which page the user is viewing. */
 const PdfActivePageSync = ({ documentId, itemId }: { documentId: string; itemId?: string }) => {
   const { state: scrollState } = useScroll(documentId);
-  const setActivePdfPage = useUIStore((state) => state.setActivePdfPage);
+  const setActiveItemContext = useUIStore((state) => state.setActiveItemContext);
 
   useEffect(() => {
     if (!itemId) return;
     const page = scrollState?.currentPage;
     if (page != null && page >= 1) {
-      setActivePdfPage(itemId, page);
+      setActiveItemContext(itemId, { type: 'pdf', page });
     }
-  }, [itemId, scrollState?.currentPage, setActivePdfPage]);
+  }, [itemId, scrollState?.currentPage, setActiveItemContext]);
 
   useEffect(() => {
     if (!itemId) return;
-    return () => setActivePdfPage(itemId, null);
-  }, [itemId, setActivePdfPage]);
+    return () => setActiveItemContext(itemId, null);
+  }, [itemId, setActiveItemContext]);
 
   return null;
 };

--- a/src/components/workspace-canvas/QuizContent.tsx
+++ b/src/components/workspace-canvas/QuizContent.tsx
@@ -45,6 +45,7 @@ export function QuizContent({
   // UI store for card selection
   const selectedCardIds = useUIStore((state) => state.selectedCardIds);
   const toggleCardSelection = useUIStore((state) => state.toggleCardSelection);
+  const setActiveItemContext = useUIStore((state) => state.setActiveItemContext);
 
   // Session state
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -63,6 +64,22 @@ export function QuizContent({
 
   const currentQuestion = questions[currentIndex];
   const totalQuestions = questions.length;
+
+  useEffect(() => {
+    if (currentQuestion && !showResults) {
+      setActiveItemContext(item.id, {
+        type: 'quiz',
+        questionIndex: currentIndex,
+        questionId: currentQuestion.id,
+      });
+    } else {
+      setActiveItemContext(item.id, null);
+    }
+  }, [item.id, currentIndex, currentQuestion, showResults, setActiveItemContext]);
+
+  useEffect(() => {
+    return () => setActiveItemContext(item.id, null);
+  }, [item.id, setActiveItemContext]);
 
   // Sync effect: ensure showResults state matches reality of questions vs answered
   // and handle new questions being added

--- a/src/components/workspace-canvas/QuizContent.tsx
+++ b/src/components/workspace-canvas/QuizContent.tsx
@@ -18,18 +18,22 @@ import {
   Plus,
   Lightbulb,
   MessageCircleQuestion,
+  Loader2,
 } from "lucide-react";
 import { StreamdownMarkdown } from "@/components/ui/streamdown-markdown";
 import { toast } from "sonner";
 import { useOptionalComposerActions } from "@/lib/stores/composer-actions-store";
 import { useUIStore } from "@/lib/stores/ui-store";
 import { getQuestionText } from "@/lib/workspace-state/quiz-shuffle";
+import { useCurrentWorkspaceId } from "@/contexts/WorkspaceContext";
+import { useQuizProgress } from "@/hooks/use-quiz-progress";
+import type { QuizProgressState } from "@/lib/workspace-state/quiz-progress-types";
 
 interface QuizContentProps {
   item: Item;
   onUpdateData: (updater: (prev: ItemData) => ItemData) => void;
   isScrollLocked?: boolean;
-  className?: string; // Optional (e.g. padding when in modal)
+  className?: string;
 }
 
 export function QuizContent({
@@ -42,12 +46,16 @@ export function QuizContent({
   const questions = quizData.questions || [];
   const promptInput = useOptionalComposerActions();
 
-  // UI store for card selection
   const selectedCardIds = useUIStore((state) => state.selectedCardIds);
   const toggleCardSelection = useUIStore((state) => state.toggleCardSelection);
   const setActiveItemContext = useUIStore((state) => state.setActiveItemContext);
 
-  // Session state
+  const workspaceId = useCurrentWorkspaceId();
+  const { progress, isLoading, updateProgress } = useQuizProgress(
+    workspaceId ?? "",
+    item.id,
+  );
+
   const [currentIndex, setCurrentIndex] = useState(0);
   const [selectedAnswer, setSelectedAnswer] = useState<number | null>(null);
   const [isSubmitted, setIsSubmitted] = useState(false);
@@ -55,8 +63,43 @@ export function QuizContent({
     Array<{ questionId: string; userAnswer: number; isCorrect: boolean }>
   >([]);
   const [showResults, setShowResults] = useState(false);
+  const [attemptNumber, setAttemptNumber] = useState(1);
+  const [startedAt, setStartedAt] = useState<string>(
+    new Date().toISOString(),
+  );
 
-  // Track previous question count and IDs to detect when new questions are added
+  const initializedRef = useRef(false);
+
+  useEffect(() => {
+    if (isLoading || initializedRef.current) return;
+    initializedRef.current = true;
+
+    if (!progress || !progress.answers || progress.answers.length === 0) return;
+
+    const validAnswers = progress.answers.filter((a) =>
+      questions.some((q) => q.id === a.questionId),
+    );
+
+    setAnsweredQuestions(
+      validAnswers.map((a) => ({
+        questionId: a.questionId,
+        userAnswer: a.userAnswer,
+        isCorrect: a.isCorrect,
+      })),
+    );
+    setAttemptNumber(progress.attemptNumber ?? 1);
+    setStartedAt(progress.startedAt ?? new Date().toISOString());
+
+    if (progress.completedAt && validAnswers.length >= questions.length) {
+      setShowResults(true);
+    } else {
+      const firstUnanswered = questions.findIndex(
+        (q) => !validAnswers.some((a) => a.questionId === q.id),
+      );
+      setCurrentIndex(firstUnanswered >= 0 ? firstUnanswered : 0);
+    }
+  }, [isLoading, progress, questions]);
+
   const prevQuestionCountRef = useRef(questions.length);
   const prevQuestionIdsRef = useRef<Set<string>>(
     new Set(questions.map((q) => q.id)),
@@ -81,55 +124,42 @@ export function QuizContent({
     return () => setActiveItemContext(item.id, null);
   }, [item.id, setActiveItemContext]);
 
-  // Sync effect: ensure showResults state matches reality of questions vs answered
-  // and handle new questions being added
   useEffect(() => {
     const prevCount = prevQuestionCountRef.current;
     const currentCount = questions.length;
     const prevIds = prevQuestionIdsRef.current;
 
-    // Detect if new questions were actually added (not just a re-render)
     const currentIds = new Set(questions.map((q) => q.id));
     const questionsAdded = questions.filter((q) => !prevIds.has(q.id)).length;
 
-    // Check if we have unanswered questions
     const hasUnansweredQuestions = answeredQuestions.length < currentCount;
 
     if (questionsAdded > 0 && currentCount > prevCount) {
-      // New questions were added
-
       if (showResults) {
-        // If we were showing results, we need to hide them and let user answer new questions
         toast.success(
           `${questionsAdded} new question${questionsAdded > 1 ? "s" : ""} added! Continue your quiz.`,
         );
         setShowResults(false);
-        setCurrentIndex(prevCount); // Go to first new question
+        setCurrentIndex(prevCount);
         setSelectedAnswer(null);
         setIsSubmitted(false);
       } else {
-        // Just notify user
         toast.success(
           `${questionsAdded} new question${questionsAdded > 1 ? "s" : ""} added!`,
         );
       }
     } else if (showResults && hasUnansweredQuestions) {
-      // Sanity check: if showing results but we have unanswered questions (e.g. from sync mismatch),
-      // force exit results mode
       setShowResults(false);
     }
 
-    // Update refs for next comparison
     prevQuestionCountRef.current = currentCount;
     prevQuestionIdsRef.current = currentIds;
   }, [questions, showResults, answeredQuestions.length, currentIndex]);
 
-  // Check if current question was already answered
   const previousAnswer = useMemo(() => {
     return answeredQuestions.find((a) => a.questionId === currentQuestion?.id);
   }, [answeredQuestions, currentQuestion?.id]);
 
-  // Restore state when navigating to previously answered question
   useEffect(() => {
     if (previousAnswer) {
       setSelectedAnswer(previousAnswer.userAnswer);
@@ -140,13 +170,35 @@ export function QuizContent({
     }
   }, [currentIndex, previousAnswer]);
 
-  // Handle answer selection
+  const buildProgressState = useCallback(
+    (
+      answers: typeof answeredQuestions,
+      completed: boolean,
+    ): QuizProgressState => ({
+      answers: answers.map((a) => ({
+        ...a,
+        answeredAt:
+          progress?.answers?.find((pa) => pa.questionId === a.questionId)
+            ?.answeredAt ?? new Date().toISOString(),
+      })),
+      attemptNumber,
+      startedAt,
+      ...(completed
+        ? {
+            completedAt: new Date().toISOString(),
+            score: answers.filter((a) => a.isCorrect).length,
+            totalQuestions: questions.length,
+          }
+        : {}),
+    }),
+    [attemptNumber, startedAt, progress?.answers, questions.length],
+  );
+
   const handleSelectAnswer = (index: number) => {
     if (isSubmitted) return;
     setSelectedAnswer(index);
   };
 
-  // Handle answer submission
   const handleSubmit = () => {
     if (selectedAnswer === null || isSubmitted) return;
 
@@ -164,50 +216,60 @@ export function QuizContent({
 
     setAnsweredQuestions(newAnsweredQuestions);
     setIsSubmitted(true);
-  };
 
-  // Navigation
-  const handleNext = () => {
-    if (currentIndex < totalQuestions - 1) {
-      const nextIndex = currentIndex + 1;
-      setCurrentIndex(nextIndex);
-    } else {
-      // Show results
-      setShowResults(true);
+    if (workspaceId) {
+      updateProgress(buildProgressState(newAnsweredQuestions, false));
     }
   };
 
-  // Arrow navigation - only moves between questions, never shows results
+  const handleNext = () => {
+    if (currentIndex < totalQuestions - 1) {
+      setCurrentIndex(currentIndex + 1);
+    } else {
+      setShowResults(true);
+      if (workspaceId) {
+        updateProgress(buildProgressState(answeredQuestions, true));
+      }
+    }
+  };
+
   const handleArrowNext = () => {
     if (currentIndex < totalQuestions - 1) {
-      const nextIndex = currentIndex + 1;
-      setCurrentIndex(nextIndex);
+      setCurrentIndex(currentIndex + 1);
     }
   };
 
   const handlePrevious = () => {
     if (currentIndex > 0) {
-      const prevIndex = currentIndex - 1;
-      setCurrentIndex(prevIndex);
+      setCurrentIndex(currentIndex - 1);
     }
   };
 
   const handleRestart = () => {
+    const newAttempt = attemptNumber + 1;
+    const newStartedAt = new Date().toISOString();
     setCurrentIndex(0);
     setSelectedAnswer(null);
     setIsSubmitted(false);
     setAnsweredQuestions([]);
     setShowResults(false);
+    setAttemptNumber(newAttempt);
+    setStartedAt(newStartedAt);
+
+    if (workspaceId) {
+      updateProgress({
+        answers: [],
+        attemptNumber: newAttempt,
+        startedAt: newStartedAt,
+      });
+    }
   };
 
-  // Handle Update Quiz - programmatically send message to add more questions
   const handleUpdateQuiz = () => {
-    // First, ensure this card is selected for context
     if (!selectedCardIds.has(item.id)) {
       toggleCardSelection(item.id);
     }
 
-    // Then send the message via composer
     const composer = promptInput;
     if (composer) {
       try {
@@ -268,23 +330,32 @@ export function QuizContent({
     }
   };
 
-  // Calculate score
   const score = useMemo(() => {
     return answeredQuestions.filter((a) => a.isCorrect).length;
   }, [answeredQuestions]);
 
-  // Prevent focus stealing from chat input
   const preventFocusSteal = (e: React.MouseEvent) => {
     e.preventDefault();
   };
 
-  // Stop propagation so card click doesn't open modal when interacting with quiz
   const stopPropagation = (e: React.MouseEvent) => {
     e.stopPropagation();
   };
 
+  if (isLoading) {
+    return (
+      <div
+        className={cn(
+          "flex flex-col h-full items-center justify-center",
+          className,
+        )}
+      >
+        <Loader2 className="w-6 h-6 animate-spin text-foreground/40 dark:text-white/40" />
+      </div>
+    );
+  }
+
   if (!currentQuestion && !showResults) {
-    // Template-created items have "Update me" name and should show generating skeleton
     const isAwaitingGeneration =
       item.name === "Update me" && questions.length === 0;
 
@@ -376,7 +447,6 @@ export function QuizContent({
       );
     }
 
-    // User-created quiz with no questions - show empty state
     return (
       <div
         className={cn(
@@ -394,7 +464,6 @@ export function QuizContent({
     );
   }
 
-  // Results view
   if (showResults) {
     const percentage =
       totalQuestions > 0 ? Math.round((score / totalQuestions) * 100) : 0;

--- a/src/hooks/use-quiz-progress.ts
+++ b/src/hooks/use-quiz-progress.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import type { QuizProgressState } from "@/lib/workspace-state/quiz-progress-types";
+
+const DEBOUNCE_MS = 500;
+
+export function useQuizProgress(workspaceId: string, itemId: string) {
+  const [progress, setProgress] = useState<QuizProgressState | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    fetch(
+      `/api/workspace/${workspaceId}/quiz-progress?itemId=${encodeURIComponent(itemId)}`,
+      { signal: controller.signal },
+    )
+      .then((res) => res.json())
+      .then((data) => setProgress(data.state ?? null))
+      .catch((err) => {
+        if (err.name !== "AbortError") {
+          console.error("[useQuizProgress] load failed", err);
+        }
+      })
+      .finally(() => setIsLoading(false));
+
+    return () => {
+      controller.abort();
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [workspaceId, itemId]);
+
+  const saveProgress = useCallback(
+    (state: QuizProgressState) => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        fetch(`/api/workspace/${workspaceId}/quiz-progress`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ itemId, state }),
+        }).catch((err) =>
+          console.error("[useQuizProgress] save failed", err),
+        );
+      }, DEBOUNCE_MS);
+    },
+    [workspaceId, itemId],
+  );
+
+  const updateProgress = useCallback(
+    (state: QuizProgressState) => {
+      setProgress(state);
+      saveProgress(state);
+    },
+    [saveProgress],
+  );
+
+  const clearProgress = useCallback(() => {
+    setProgress(null);
+  }, []);
+
+  return { progress, isLoading, updateProgress, clearProgress };
+}

--- a/src/lib/ai/tools/read-workspace.ts
+++ b/src/lib/ai/tools/read-workspace.ts
@@ -7,6 +7,7 @@ import { formatItemContent } from "@/lib/utils/format-workspace-context";
 import { getVirtualPath } from "@/lib/utils/workspace-fs";
 import type { WorkspaceToolContext } from "./workspace-tools";
 import type { DocumentData } from "@/lib/workspace-state/types";
+import type { QuizProgressState } from "@/lib/workspace-state/quiz-progress-types";
 import { normalizeWorkspaceItems } from "@/lib/workspace-state/state";
 
 const DEFAULT_LIMIT = 500;
@@ -153,10 +154,19 @@ export function createReadWorkspaceTool(ctx: WorkspaceToolContext) {
                     ? { pageStart, pageEnd }
                     : undefined;
 
+            let quizProgress: QuizProgressState | null = null;
+            if (item.type === "quiz" && ctx.userId) {
+                const { loadQuizProgress } = await import("@/lib/workspace/quiz-progress-server");
+                quizProgress = await loadQuizProgress(ctx.workspaceId!, item.id, ctx.userId);
+            }
+
             const fullContent =
                 item.type === "document"
                     ? ((item.data as DocumentData).markdown ?? "")
-                    : formatItemContent(item, pdfPageRange);
+                    : formatItemContent(item, {
+                        ...pdfPageRange,
+                        quizProgress,
+                    });
             const allLines = fullContent.split(/\r?\n/);
             const totalLines = allLines.length;
             const startIdx = Math.max(0, lineStart - 1);

--- a/src/lib/ai/tools/read-workspace.ts
+++ b/src/lib/ai/tools/read-workspace.ts
@@ -155,9 +155,9 @@ export function createReadWorkspaceTool(ctx: WorkspaceToolContext) {
                     : undefined;
 
             let quizProgress: QuizProgressState | null = null;
-            if (item.type === "quiz" && ctx.userId) {
+            if (item.type === "quiz" && ctx.userId && ctx.workspaceId) {
                 const { loadQuizProgress } = await import("@/lib/workspace/quiz-progress-server");
-                quizProgress = await loadQuizProgress(ctx.workspaceId!, item.id, ctx.userId);
+                quizProgress = await loadQuizProgress(ctx.workspaceId, item.id, ctx.userId);
             }
 
             const fullContent =

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -750,3 +750,20 @@ export const chatMessages = pgTable(
     ),
   ],
 );
+
+export const workspaceItemUserState = pgTable(
+  "workspace_item_user_state",
+  {
+    workspaceId: uuid("workspace_id").notNull(),
+    itemId: text("item_id").notNull(),
+    userId: text("user_id").notNull(),
+    stateKey: text("state_key").default("item").notNull(),
+    stateType: text("state_type").notNull(),
+    stateSchemaVersion: integer("state_schema_version").default(1).notNull(),
+    state: jsonb("state").notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [{
+    pk: primaryKey({ columns: [table.workspaceId, table.itemId, table.userId, table.stateKey] }),
+  }]
+);

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -11,6 +11,7 @@ import {
   workspaceItemExtracted,
   userProfiles,
   workspaceCollaborators,
+  workspaceItemUserState,
 } from "./schema";
 import type { Item } from "@/lib/workspace-state/types";
 
@@ -42,6 +43,13 @@ export type WorkspaceCollaborator = InferSelectModel<
 >;
 export type WorkspaceCollaboratorInsert = InferInsertModel<
   typeof workspaceCollaborators
+>;
+
+export type WorkspaceItemUserState = InferSelectModel<
+  typeof workspaceItemUserState
+>;
+export type WorkspaceItemUserStateInsert = InferInsertModel<
+  typeof workspaceItemUserState
 >;
 
 export type PermissionLevel = "viewer" | "editor";

--- a/src/lib/stores/ui-store.ts
+++ b/src/lib/stores/ui-store.ts
@@ -11,6 +11,10 @@ import { getDefaultChatModelId } from "@/lib/ai/models";
 /** Column / keyboard focus when two items are open (split). */
 export type WorkspaceItemSlot = "primary" | "secondary";
 
+export type ItemViewContext =
+  | { type: 'pdf'; page: number }
+  | { type: 'quiz'; questionIndex: number; questionId: string };
+
 /**
  * Up to two workspace items “open” at once.
  * - Today: only `primary` is used; UI is fullscreen one-item view.
@@ -86,8 +90,8 @@ interface UIState {
     pageNumber?: number;
   } | null;
 
-  // PDF active page: itemId -> current page when PDF is open (for selected-card context)
-  activePdfPageByItemId: Record<string, number>;
+  // Active item context: itemId -> view context when item is open (for selected-card context)
+  activeItemContext: Record<string, ItemViewContext>;
 
   // Actions - Chat
   setIsChatExpanded: (expanded: boolean) => void;
@@ -140,7 +144,7 @@ interface UIState {
   setCitationHighlightQuery: (
     query: { itemId: string; query: string; pageNumber?: number } | null,
   ) => void;
-  setActivePdfPage: (itemId: string, page: number | null) => void;
+  setActiveItemContext: (itemId: string, context: ItemViewContext | null) => void;
 
   // Utility actions
   resetChatState: () => void;
@@ -174,7 +178,7 @@ const initialState = {
   // Reply selection
   replySelections: [],
   citationHighlightQuery: null,
-  activePdfPageByItemId: {},
+  activeItemContext: {},
 };
 
 export const useUIStore = create<UIState>()(
@@ -351,15 +355,15 @@ export const useUIStore = create<UIState>()(
         setCitationHighlightQuery: (query) => {
           set({ citationHighlightQuery: query });
         },
-        setActivePdfPage: (itemId, page) => {
+        setActiveItemContext: (itemId, context) => {
           set((state) => {
-            const next = { ...state.activePdfPageByItemId };
-            if (page == null) {
+            const next = { ...state.activeItemContext };
+            if (context == null) {
               delete next[itemId];
             } else {
-              next[itemId] = page;
+              next[itemId] = context;
             }
-            return { activePdfPageByItemId: next };
+            return { activeItemContext: next };
           });
         },
 

--- a/src/lib/utils/format-workspace-context.ts
+++ b/src/lib/utils/format-workspace-context.ts
@@ -13,15 +13,17 @@ import { getVirtualPath } from "./workspace-fs";
 import { getPdfSourceUrl } from "@/lib/pdf/pdf-item";
 import { getCodeExecutionSystemInstructions } from "@/lib/ai/code-execute-environment";
 
+import type { ItemViewContext } from "@/lib/stores/ui-store";
+
 /**
  * Formats item metadata only (no content). Used for workspace context in system prompt.
- * When activePdfPages is provided and item is a PDF, includes activePage if user is currently viewing it.
+ * When activeItemContext is provided, includes view-specific metadata (e.g. activePage for PDFs, activeQuestion for quizzes).
  * When viewingItemIds is provided and item's panel is open, includes (currently viewing) for any item type.
  */
 function formatItemMetadata(
   item: Item,
   items: Item[],
-  activePdfPages?: Record<string, number>,
+  activeItemContext?: Record<string, ItemViewContext>,
   viewingItemIds?: Set<string>,
 ): string {
   const path = getVirtualPath(item, items);
@@ -32,9 +34,9 @@ function formatItemMetadata(
     case "pdf": {
       const d = item.data as PdfData;
       if (d?.filename) parts.push(`filename=${d.filename}`);
-      const activePage = activePdfPages?.[item.id];
-      if (activePage != null && activePage >= 1) {
-        parts.push(`activePage=${activePage}`);
+      const ctx = activeItemContext?.[item.id];
+      if (ctx?.type === 'pdf' && ctx.page >= 1) {
+        parts.push(`activePage=${ctx.page}`);
       }
       break;
     }
@@ -47,6 +49,10 @@ function formatItemMetadata(
     case "quiz": {
       const d = item.data as QuizData;
       parts.push(`questions=${d?.questions?.length ?? 0}`);
+      const ctx = activeItemContext?.[item.id];
+      if (ctx?.type === 'quiz') {
+        parts.push(`activeQuestion=${ctx.questionIndex + 1}`);
+      }
       break;
     }
     case "audio": {
@@ -115,7 +121,7 @@ Your knowledge cutoff date is January 2025.
 </time_and_knowledge>
 
 <context>
-The selected/open context lists what the user is working with: explicitly selected cards plus any item open in a workspace panel (no checkmark required). All listed items matter. Items marked (currently viewing) have highest priority — they are open right now, so prioritize them for ambiguous prompts ("this", "here", "that one", "what I'm looking at") and when relevant otherwise. For PDFs with activePage=N, that specific page is the focus.
+The selected/open context lists what the user is working with: explicitly selected cards plus any item open in a workspace panel (no checkmark required). All listed items matter. Items marked (currently viewing) have highest priority — they are open right now, so prioritize them for ambiguous prompts ("this", "here", "that one", "what I'm looking at") and when relevant otherwise. For PDFs with activePage=N, that specific page is the focus. For quizzes with activeQuestion=N, that specific question is what the user is looking at.
 Context entries provide paths and metadata only — use workspace_search or workspace_read for full text (audio: segment timeline via workspace_read, not raw audio; paginate with lineStart/limit when long).
 If no context is provided, explain how to add items: open a card, or select via checkmark, shift-click, or drag-select.
 Rely only on facts from fetched content. Do not invent or assume information.
@@ -149,7 +155,7 @@ ${getCodeExecutionSystemInstructions()}
 
 PDF: Always try workspace_read first for workspace PDFs (pageStart/pageEnd for page ranges). If content is not yet extracted, tell the user it is still being prepared and try again shortly.
 PDF VISUALS: PDF OCR in this workspace gives you textual structure from the PDF, including normal text and inline tables, but not visual understanding of charts, figures, diagrams, or screenshots embedded in the PDF. Do not claim you can see those visuals unless the user has separately attached a screenshot/image of that region. If the user needs help with a chart or figure from a PDF, tell them to open the PDF and use the camera button in the top right of the open pdf panelto add a screenshot of that area to chat.
-When selected card metadata includes (currently viewing) or activePage=N (for PDFs), the user has that item or page open. Prioritize these for ambiguous references ("this", "here", "this page", "what I'm looking at") and tailor responses to that context.
+When selected card metadata includes (currently viewing) or activePage=N (for PDFs) or activeQuestion=N (for quizzes), the user has that item or page/question open. Prioritize these for ambiguous references ("this", "here", "this page", "what I'm looking at") and tailor responses to that context.
 
 YOUTUBE: If user says "add a video" without a topic, infer from workspace context. Don't ask - just search.
 
@@ -366,12 +372,12 @@ function formatRichContentSection(richContent: RichContent): string {
 /**
  * Formats selected cards as metadata only (paths, names, types).
  * Use when the AI has grep/read tools — it fetches content on demand.
- * When activePdfPages is provided, PDF items include activePage (page user is currently viewing).
+ * When activeItemContext is provided, items include view-specific metadata (e.g. activePage for PDFs, activeQuestion for quizzes).
  */
 export function formatSelectedCardsMetadata(
   selectedItems: Item[],
   allItems?: Item[],
-  activePdfPages?: Record<string, number>,
+  activeItemContext?: Record<string, ItemViewContext>,
   viewingItemIds?: Set<string>,
 ): string {
   if (selectedItems.length === 0) {
@@ -396,7 +402,7 @@ No selected or open items.
     formatItemMetadata(
       item,
       allItems ?? effectiveItems,
-      activePdfPages,
+      activeItemContext,
       viewingItemIds,
     ),
   );

--- a/src/lib/utils/format-workspace-context.ts
+++ b/src/lib/utils/format-workspace-context.ts
@@ -14,6 +14,7 @@ import { getPdfSourceUrl } from "@/lib/pdf/pdf-item";
 import { getCodeExecutionSystemInstructions } from "@/lib/ai/code-execute-environment";
 
 import type { ItemViewContext } from "@/lib/stores/ui-store";
+import type { QuizProgressState } from "@/lib/workspace-state/quiz-progress-types";
 
 /**
  * Formats item metadata only (no content). Used for workspace context in system prompt.
@@ -477,6 +478,8 @@ export interface FormatItemContentOptions {
   pageStart?: number;
   /** For PDFs: 1-indexed end page (inclusive) */
   pageEnd?: number;
+  /** For quizzes: user progress state */
+  quizProgress?: QuizProgressState | null;
 }
 
 /**
@@ -506,7 +509,7 @@ export function formatItemContent(
       lines.push(...formatYouTubeDetailsFull(item.data as YouTubeData));
       break;
     case "quiz":
-      lines.push(...formatQuizDetailsFull(item.data as QuizData));
+      lines.push(...formatQuizDetailsFull(item.data as QuizData, options?.quizProgress));
       break;
     case "image":
       lines.push(...formatImageDetailsFull(item.data as ImageData));
@@ -681,10 +684,34 @@ function formatFlashcardDetailsFull(data: FlashcardData): string[] {
 
 /**
  * Formats quiz details as raw JSON (editable by item_edit).
+ * When progress is available, prepends a read-only summary block.
  */
-function formatQuizDetailsFull(data: QuizData): string[] {
+function formatQuizDetailsFull(
+  data: QuizData,
+  progress?: QuizProgressState | null,
+): string[] {
+  const lines: string[] = [];
+
+  if (progress && progress.answers.length > 0) {
+    lines.push("--- Progress (read-only) ---");
+    const score = progress.score ?? progress.answers.filter(a => a.isCorrect).length;
+    const total = progress.totalQuestions ?? data.questions?.length ?? 0;
+    const pct = total > 0 ? Math.round((score / total) * 100) : 0;
+    lines.push(`Attempt ${progress.attemptNumber} | Score: ${score}/${total} (${pct}%)${progress.completedAt ? ' | Completed' : ' | In progress'}`);
+
+    const answerMap = new Map(progress.answers.map(a => [a.questionId, a]));
+    const statuses = (data.questions || []).map((q, i) => {
+      const answer = answerMap.get(q.id);
+      if (!answer) return `Q${i + 1} unanswered`;
+      return `Q${i + 1} ${answer.isCorrect ? '\u2713' : '\u2717'}`;
+    });
+    lines.push(`Questions: ${statuses.join(', ')}`);
+    lines.push("---");
+  }
+
   const payload = { questions: data.questions || [] };
-  return [JSON.stringify(payload, null, 2)];
+  lines.push(JSON.stringify(payload, null, 2));
+  return lines;
 }
 
 /**

--- a/src/lib/workspace-state/quiz-progress-types.ts
+++ b/src/lib/workspace-state/quiz-progress-types.ts
@@ -1,0 +1,15 @@
+export interface QuizAnswerRecord {
+  questionId: string;
+  userAnswer: number;
+  isCorrect: boolean;
+  answeredAt: string;
+}
+
+export interface QuizProgressState {
+  answers: QuizAnswerRecord[];
+  attemptNumber: number;
+  startedAt: string;
+  completedAt?: string;
+  score?: number;
+  totalQuestions?: number;
+}

--- a/src/lib/workspace/quiz-progress-server.ts
+++ b/src/lib/workspace/quiz-progress-server.ts
@@ -1,0 +1,26 @@
+import { db } from "@/lib/db/client";
+import { workspaceItemUserState } from "@/lib/db/schema";
+import { and, eq } from "drizzle-orm";
+import type { QuizProgressState } from "@/lib/workspace-state/quiz-progress-types";
+
+export async function loadQuizProgress(
+  workspaceId: string,
+  itemId: string,
+  userId: string,
+): Promise<QuizProgressState | null> {
+  const rows = await db
+    .select({ state: workspaceItemUserState.state })
+    .from(workspaceItemUserState)
+    .where(
+      and(
+        eq(workspaceItemUserState.workspaceId, workspaceId),
+        eq(workspaceItemUserState.itemId, itemId),
+        eq(workspaceItemUserState.userId, userId),
+        eq(workspaceItemUserState.stateKey, "quiz_progress"),
+      ),
+    )
+    .limit(1);
+
+  if (rows.length === 0) return null;
+  return rows[0].state as QuizProgressState;
+}

--- a/src/lib/workspace/quiz-progress-server.ts
+++ b/src/lib/workspace/quiz-progress-server.ts
@@ -22,5 +22,7 @@ export async function loadQuizProgress(
     .limit(1);
 
   if (rows.length === 0) return null;
-  return rows[0].state as QuizProgressState;
+  const state = rows[0].state as QuizProgressState;
+  if (!state || !Array.isArray(state.answers)) return null;
+  return state;
 }


### PR DESCRIPTION
This PR enables the AI to see user quiz progress when reading a quiz via `workspace_read`. Progress is loaded from the `workspace_item_user_state` table and formatted as a read-only header block above the editable JSON.

**Workspace Context & Progress Loading**
*   Added `src/lib/workspace/quiz-progress-server.ts` with `loadQuizProgress` function that queries `workspace_item_user_state` by `state_key='quiz_progress'`, matching the existing API route pattern.
*   Imported `loadQuizProgress` in `src/lib/ai/tools/read-workspace.ts` and called it after item resolution for quiz items.

**Quiz Formatting**
*   Added optional `quizProgress` parameter to `FormatItemContentOptions` in `src/lib/utils/format-workspace-context.ts`.
*   Updated `formatQuizDetailsFull` to append a `--- Progress (read-only) ---` block when progress exists (attempt number, score, percentage, completion status, and per-question ✓/✗ statuses).
*   Updated `item_edit` tool description already includes text warning that the progress block is read‑only (no changes needed).

**Why**
Allows the AI to provide contextual help like "you got Q3 wrong — the concept here is..." or "you're struggling with thermodynamics questions" based on the user's actual answers and score.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/50e3f15c-d6e3-4fa0-859d-9359497a202f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-092" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/50e3f15c-d6e3-4fa0-859d-9359497a202f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-092&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-092"><img alt="ENG-092" src="https://capy.ai/api/badge/thread.svg?label=ENG-092"></picture></a>
<!-- capy-pr-badge:end -->