### PR TITLE
feat(quiz): inject quiz progress into AI context via workspace_read

### DIFF
--- a/src/lib/ai/tools/read-workspace.ts
+++ b/src/lib/ai/tools/read-workspace.ts
@@ -7,6 +7,7 @@ import { formatItemContent } from "@/lib/utils/format-workspace-context";
 import { getVirtualPath } from "@/lib/utils/workspace-fs";
 import type { WorkspaceToolContext } from "./workspace-tools";
 import type { DocumentData } from "@/lib/workspace-state/types";
+import type { QuizProgressState } from "@/lib/workspace-state/quiz-progress-types";
 import { normalizeWorkspaceItems } from "@/lib/workspace-state/state";
 
 const DEFAULT_LIMIT = 500;
@@ -153,10 +154,19 @@ export function createReadWorkspaceTool(ctx: WorkspaceToolContext) {
                     ? { pageStart, pageEnd }
                     : undefined;
 
+            let quizProgress: QuizProgressState | null = null;
+            if (item.type === "quiz" && ctx.userId) {
+                const { loadQuizProgress } = await import("@/lib/workspace/quiz-progress-server");
+                quizProgress = await loadQuizProgress(ctx.workspaceId!, item.id, ctx.userId);
+            }
+
             const fullContent =
                 item.type === "document"
                     ? ((item.data as DocumentData).markdown ?? "")
-                    : formatItemContent(item, pdfPageRange);
+                    : formatItemContent(item, {
+                        ...pdfPageRange,
+                        quizProgress,
+                    });
             const allLines = fullContent.split(/\r?\n/);
             const totalLines = allLines.length;
             const startIdx = Math.max(0, lineStart - 1);

--- a/src/lib/ai/tools/read-workspace.ts
+++ b/src/lib/ai/tools/read-workspace.ts
@@ -155,9 +155,9 @@ export function createReadWorkspaceTool(ctx: WorkspaceToolContext) {
                     : undefined;
 
             let quizProgress: QuizProgressState | null = null;
-            if (item.type === "quiz" && ctx.userId) {
+            if (item.type === "quiz" && ctx.userId && ctx.workspaceId) {
                 const { loadQuizProgress } = await import("@/lib/workspace/quiz-progress-server");
-                quizProgress = await loadQuizProgress(ctx.workspaceId!, item.id, ctx.userId);
+                quizProgress = await loadQuizProgress(ctx.workspaceId, item.id, ctx.userId);
             }
 
             const fullContent =

--- a/src/lib/utils/format-workspace-context.ts
+++ b/src/lib/utils/format-workspace-context.ts
@@ -14,6 +14,7 @@ import { getPdfSourceUrl } from "@/lib/pdf/pdf-item";
 import { getCodeExecutionSystemInstructions } from "@/lib/ai/code-execute-environment";
 
 import type { ItemViewContext } from "@/lib/stores/ui-store";
+import type { QuizProgressState } from "@/lib/workspace-state/quiz-progress-types";
 
 /**
  * Formats item metadata only (no content). Used for workspace context in system prompt.
@@ -477,6 +478,8 @@ export interface FormatItemContentOptions {
   pageStart?: number;
   /** For PDFs: 1-indexed end page (inclusive) */
   pageEnd?: number;
+  /** For quizzes: user progress state */
+  quizProgress?: QuizProgressState | null;
 }
 
 /**
@@ -506,7 +509,7 @@ export function formatItemContent(
       lines.push(...formatYouTubeDetailsFull(item.data as YouTubeData));
       break;
     case "quiz":
-      lines.push(...formatQuizDetailsFull(item.data as QuizData));
+      lines.push(...formatQuizDetailsFull(item.data as QuizData, options?.quizProgress));
       break;
     case "image":
       lines.push(...formatImageDetailsFull(item.data as ImageData));
@@ -681,10 +684,34 @@ function formatFlashcardDetailsFull(data: FlashcardData): string[] {
 
 /**
  * Formats quiz details as raw JSON (editable by item_edit).
+ * When progress is available, prepends a read-only summary block.
  */
-function formatQuizDetailsFull(data: QuizData): string[] {
+function formatQuizDetailsFull(
+  data: QuizData,
+  progress?: QuizProgressState | null,
+): string[] {
+  const lines: string[] = [];
+
+  if (progress && progress.answers.length > 0) {
+    lines.push("--- Progress (read-only) ---");
+    const score = progress.score ?? progress.answers.filter(a => a.isCorrect).length;
+    const total = progress.totalQuestions ?? data.questions?.length ?? 0;
+    const pct = total > 0 ? Math.round((score / total) * 100) : 0;
+    lines.push(`Attempt ${progress.attemptNumber} | Score: ${score}/${total} (${pct}%)${progress.completedAt ? ' | Completed' : ' | In progress'}`);
+
+    const answerMap = new Map(progress.answers.map(a => [a.questionId, a]));
+    const statuses = (data.questions || []).map((q, i) => {
+      const answer = answerMap.get(q.id);
+      if (!answer) return `Q${i + 1} unanswered`;
+      return `Q${i + 1} ${answer.isCorrect ? '\u2713' : '\u2717'}`;
+    });
+    lines.push(`Questions: ${statuses.join(', ')}`);
+    lines.push("---");
+  }
+
   const payload = { questions: data.questions || [] };
-  return [JSON.stringify(payload, null, 2)];
+  lines.push(JSON.stringify(payload, null, 2));
+  return lines;
 }
 
 /**

--- a/src/lib/workspace/quiz-progress-server.ts
+++ b/src/lib/workspace/quiz-progress-server.ts
@@ -1,0 +1,26 @@
+import { db } from "@/lib/db/client";
+import { workspaceItemUserState } from "@/lib/db/schema";
+import { and, eq } from "drizzle-orm";
+import type { QuizProgressState } from "@/lib/workspace-state/quiz-progress-types";
+
+export async function loadQuizProgress(
+  workspaceId: string,
+  itemId: string,
+  userId: string,
+): Promise<QuizProgressState | null> {
+  const rows = await db
+    .select({ state: workspaceItemUserState.state })
+    .from(workspaceItemUserState)
+    .where(
+      and(
+        eq(workspaceItemUserState.workspaceId, workspaceId),
+        eq(workspaceItemUserState.itemId, itemId),
+        eq(workspaceItemUserState.userId, userId),
+        eq(workspaceItemUserState.stateKey, "quiz_progress"),
+      ),
+    )
+    .limit(1);
+
+  if (rows.length === 0) return null;
+  return rows[0].state as QuizProgressState;
+}

--- a/src/lib/workspace/quiz-progress-server.ts
+++ b/src/lib/workspace/quiz-progress-server.ts
@@ -22,5 +22,7 @@ export async function loadQuizProgress(
     .limit(1);
 
   if (rows.length === 0) return null;
-  return rows[0].state as QuizProgressState;
+  const state = rows[0].state as QuizProgressState;
+  if (!state || !Array.isArray(state.answers)) return null;
+  return state;
 }


### PR DESCRIPTION
Stacked continuation of #510 (merged). When the AI reads a quiz via workspace_read, injects a read-only progress summary (score, per-question status) so the AI can give contextual help.

Closes the original #509 which was auto-closed when its base branch merged.