### PR TITLE
fix(image): enable trackpad panning instead of zoom

### DIFF
--- a/src/components/image-viewer/ImageViewer.tsx
+++ b/src/components/image-viewer/ImageViewer.tsx
@@ -391,7 +391,7 @@ export default function ImageViewer({
           centerOnInit={true}
           smooth={true}
           wheel={{ step: 0.008, touchPadDisabled: true }}
-          trackPadPanning={{ disabled: false }}
+          trackPadPanning={{ disabled: isCapturing }}
           doubleClick={{ mode: "reset" }}
           panning={{ disabled: isCapturing }}
           onTransform={(_ref: ReactZoomPanPinchRef, state: { scale: number }) => {

--- a/src/components/image-viewer/ImageViewer.tsx
+++ b/src/components/image-viewer/ImageViewer.tsx
@@ -390,7 +390,8 @@ export default function ImageViewer({
           maxScale={10}
           centerOnInit={true}
           smooth={true}
-          wheel={{ step: 0.008 }}
+          wheel={{ step: 0.008, touchPadDisabled: true }}
+          trackPadPanning={{ disabled: false }}
           doubleClick={{ mode: "reset" }}
           panning={{ disabled: isCapturing }}
           onTransform={(_ref: ReactZoomPanPinchRef, state: { scale: number }) => {


### PR DESCRIPTION
This PR fixes image panel trackpad behavior by configuring `react-zoom-pan-pinch` to route trackpad gestures correctly. Two-finger trackpad scroll now pans the image instead of zooming, while pinch-to-zoom gestures continue to work as expected.

*   **Image Viewer**
    *   Set `wheel.touchPadDisabled: true` to prevent trackpad scroll from triggering zoom
    *   Set `trackPadPanning: { disabled: false }` to enable trackpad panning
    *   Keeps pinch-to-zoom enabled for actual zoom gestures

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/acb2cfd5-e4f0-4f40-9426-45f7cc72ed5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-095" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/acb2cfd5-e4f0-4f40-9426-45f7cc72ed5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-095&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-095"><img alt="ENG-095" src="https://capy.ai/api/badge/thread.svg?label=ENG-095"></picture></a>
<!-- capy-pr-badge:end -->