### PR TITLE
fix: align copy transcript button and expand audio scrubber

### DIFF
--- a/src/components/ai-elements/audio-player.tsx
+++ b/src/components/ai-elements/audio-player.tsx
@@ -107,7 +107,7 @@ export const AudioPlayerControlBar = ({
   ...props
 }: AudioPlayerControlBarProps) => (
   <MediaControlBar data-slot="audio-player-control-bar" {...props}>
-    <ButtonGroup orientation="horizontal">{children}</ButtonGroup>
+    <ButtonGroup orientation="horizontal" className="w-full">{children}</ButtonGroup>
   </MediaControlBar>
 );
 
@@ -183,7 +183,7 @@ export const AudioPlayerTimeRange = ({
   className,
   ...props
 }: AudioPlayerTimeRangeProps) => (
-  <ButtonGroupText asChild className="bg-transparent">
+  <ButtonGroupText asChild className="flex-1 min-w-0 bg-transparent">
     <MediaTimeRange
       className={className}
       data-slot="audio-player-time-range"

--- a/src/components/workspace-canvas/AudioCardContent.tsx
+++ b/src/components/workspace-canvas/AudioCardContent.tsx
@@ -397,27 +397,27 @@ function AudioCardComplete({
     <div className="flex flex-col">
       {/* Sticky header: player + Copy Transcript button */}
       <div className="sticky top-0 z-10 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b border-border/40">
-        <div className="px-4 pt-3 pb-2">
-          <AudioPlayer className="w-full">
-            <AudioPlayerElement
-              ref={audioRef}
-              src={audioData.fileUrl}
-              preload="metadata"
-            />
-            <AudioPlayerControlBar>
-              <AudioPlayerPlayButton />
-              <AudioPlayerSeekBackwardButton />
-              <AudioPlayerSeekForwardButton />
-              <AudioPlayerTimeDisplay />
-              <AudioPlayerTimeRange />
-              <AudioPlayerDurationDisplay />
-              <AudioPlayerMuteButton />
-              <AudioPlayerVolumeRange />
-            </AudioPlayerControlBar>
-          </AudioPlayer>
-        </div>
-        {!!transcript && (
-          <div className="px-4 pb-2 flex justify-end">
+        <div className="px-4 pt-3 pb-2 flex items-center gap-2">
+          <div className="flex-1 min-w-0">
+            <AudioPlayer className="w-full">
+              <AudioPlayerElement
+                ref={audioRef}
+                src={audioData.fileUrl}
+                preload="metadata"
+              />
+              <AudioPlayerControlBar>
+                <AudioPlayerPlayButton />
+                <AudioPlayerSeekBackwardButton />
+                <AudioPlayerSeekForwardButton />
+                <AudioPlayerTimeDisplay />
+                <AudioPlayerTimeRange />
+                <AudioPlayerDurationDisplay />
+                <AudioPlayerMuteButton />
+                <AudioPlayerVolumeRange />
+              </AudioPlayerControlBar>
+            </AudioPlayer>
+          </div>
+          {!!transcript && (
             <button
               type="button"
               onClick={() => {
@@ -426,7 +426,7 @@ function AudioCardComplete({
                   setTimeout(() => setCopied(false), 2000);
                 });
               }}
-              className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md bg-muted/60 hover:bg-muted text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+              className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md bg-muted/60 hover:bg-muted text-muted-foreground hover:text-foreground transition-colors cursor-pointer shrink-0"
             >
               {copied ? (
                 <Check className="h-3 w-3 text-green-500" />
@@ -435,8 +435,8 @@ function AudioCardComplete({
               )}
               {copied ? "Copied!" : "Copy Transcript"}
             </button>
-          </div>
-        )}
+          )}
+        </div>
       </div>
 
       {/* Body — flows naturally; the parent ItemPanelContent provides scroll */}


### PR DESCRIPTION
This PR fixes layout issues in the audio recording card UI. The copy transcript button is now inline with the player controls instead of in a separate row below, and the timeline scrubber expands to fill available horizontal space while keeping other controls responsive.

*   **Audio Player Controls**
    *   Add `w-full` to `ButtonGroup` in `AudioPlayerControlBar` to stretch control bar full width
    *   Add `flex-1 min-w-0` to `AudioPlayerTimeRange` wrapper so scrubber consumes remaining horizontal space
*   **Audio Card Layout** (`src/components/workspace-canvas/AudioCardContent.tsx`)
    *   Wrap audio player in `flex-1 min-w-0` container
    *   Move copy transcript button into same flex row as player with `shrink-0` to prevent compression

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/836a249c-9f8d-4952-8914-0ac9a54546b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-097" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/836a249c-9f8d-4952-8914-0ac9a54546b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-097&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-097"><img alt="ENG-097" src="https://capy.ai/api/badge/thread.svg?label=ENG-097"></picture></a>
<!-- capy-pr-badge:end -->