### PR TITLE
fix: include PDF item name in capture filenames

### DIFF
--- a/src/components/pdf/PdfPanelHeader.tsx
+++ b/src/components/pdf/PdfPanelHeader.tsx
@@ -119,6 +119,9 @@ export const PdfPanelHeader = memo(function PdfPanelHeader({
   const promptInputRef = useRef(promptInput);
   promptInputRef.current = promptInput;
 
+  const itemNameRef = useRef(itemName);
+  itemNameRef.current = itemName;
+
   const isChatExpanded = useUIStore((state) => state.isChatExpanded);
   const setIsChatExpanded = useUIStore((state) => state.setIsChatExpanded);
 
@@ -145,7 +148,7 @@ export const PdfPanelHeader = memo(function PdfPanelHeader({
           result.imageType,
         );
 
-        const filename = `capture-${itemName.replace(/[^a-zA-Z0-9]/g, "_")}-page-${result.pageIndex + 1}-${Date.now()}.png`;
+        const filename = `capture-${itemNameRef.current.replace(/[^a-zA-Z0-9]/g, "_")}-page-${result.pageIndex + 1}-${Date.now()}.png`;
         await addCaptureToChat(orientedBlob, filename, result.imageType, promptInputRef.current);
         captureRef.current?.toggleMarqueeCapture();
       } catch (error) {

--- a/src/components/pdf/PdfPanelHeader.tsx
+++ b/src/components/pdf/PdfPanelHeader.tsx
@@ -145,7 +145,7 @@ export const PdfPanelHeader = memo(function PdfPanelHeader({
           result.imageType,
         );
 
-        const filename = `capture-page-${result.pageIndex + 1}-${Date.now()}.png`;
+        const filename = `capture-${itemName.replace(/[^a-zA-Z0-9]/g, "_")}-page-${result.pageIndex + 1}-${Date.now()}.png`;
         await addCaptureToChat(orientedBlob, filename, result.imageType, promptInputRef.current);
         captureRef.current?.toggleMarqueeCapture();
       } catch (error) {


### PR DESCRIPTION
This PR includes the PDF item name in the screenshot filename when capturing a region from the PDF viewer. This makes it easier to identify which PDF a capture came from, matching the behavior already used for image viewer captures.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/29103e41-e4f4-4a0c-9856-acb4a5fd7c3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-100" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/29103e41-e4f4-4a0c-9856-acb4a5fd7c3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-100&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-100"><img alt="ENG-100" src="https://capy.ai/api/badge/thread.svg?label=ENG-100"></picture></a>
<!-- capy-pr-badge:end -->