### PR TITLE
fix(editor): handle backslash-escaped characters in Markdown

### DIFF
--- a/src/components/editor/DocumentEditor.tsx
+++ b/src/components/editor/DocumentEditor.tsx
@@ -25,6 +25,7 @@ import { Selection } from "@tiptap/extensions";
 import { Mathematics } from "@tiptap/extension-mathematics";
 import { TableKit } from "@tiptap/extension-table";
 import { Markdown } from "@tiptap/markdown";
+import { MarkdownEscape } from "@/components/editor/markdown-escape-extension";
 import { CustomCodeBlock } from "@/components/tiptap-node/code-block-node/code-block-extension";
 import "katex/dist/katex.min.css";
 
@@ -889,6 +890,7 @@ export function DocumentEditor({
           throwOnError: false,
         },
       }),
+      MarkdownEscape,
       TableKit.configure({
         table: {
           resizable: false,

--- a/src/components/editor/markdown-escape-extension.ts
+++ b/src/components/editor/markdown-escape-extension.ts
@@ -1,0 +1,21 @@
+import { Extension } from "@tiptap/core";
+
+/**
+ * TipTap's MarkdownManager silently drops marked.js 'escape' tokens
+ * (e.g. \$ → $, \* → *, \[ → [). This extension registers a handler
+ * that converts them to text nodes so backslash-escaped characters
+ * are preserved in the rendered document.
+ *
+ * Without this, AI-generated content containing \$5 (escaped currency)
+ * loses the $ character entirely.
+ */
+export const MarkdownEscape = Extension.create({
+  name: "markdownEscapeHandler",
+
+  markdownTokenName: "escape",
+
+  parseMarkdown: (token: any) => ({
+    type: "text",
+    text: token.text ?? "",
+  }),
+});


### PR DESCRIPTION
This PR adds a TipTap extension to handle marked.js `escape` tokens that were previously silently dropped during markdown parsing.

*   **Editor Extensions**
    *   Create `MarkdownEscape` extension to convert `escape` tokens to text nodes
    *   Register extension in `DocumentEditor` between `Mathematics` and `TableKit`

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/3960cd64-caa7-46fa-8e0c-0a7d90981964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open ENG-098" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2d603241-c95f-46cc-a2a0-df03e2392f07/thread/3960cd64-caa7-46fa-8e0c-0a7d90981964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-098&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=ENG-098"><img alt="ENG-098" src="https://capy.ai/api/badge/thread.svg?label=ENG-098"></picture></a>
<!-- capy-pr-badge:end -->