### PR TITLE
fix(feedback): autofocus textarea when survey form mounts

### DIFF
--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -85,7 +85,7 @@ function FeedbackDialogForm({
 		<>
 			<form id={formId} className="space-y-6" onSubmit={handleSubmit}>
 				<FieldGroup>
-					{openQuestions.map((question) => (
+					{openQuestions.map((question, index) => (
 						<Field key={question.id}>
 							<FieldLabel htmlFor={`${formId}-${question.id}`}>
 								{feedbackQuestionLabel}
@@ -100,6 +100,7 @@ function FeedbackDialogForm({
 								placeholder={feedbackPlaceholder}
 								rows={4}
 								required={!question.optional}
+								autoFocus={index === 0}
 								onChange={(event) => {
 									const value = event.target.value;
 									setResponses((current) => ({


### PR DESCRIPTION
## Summary
- Focus the first feedback textarea when the survey form mounts after async load
- Matches the rename dialog pattern so users can start typing immediately

## Test plan
- [ ] Open account menu → Feedback
- [ ] Wait for survey to load
- [ ] Confirm cursor is in the textarea without clicking

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785352140&installation_id=142604731&pr_number=553&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F553&signature=35f2ca94eaed9645522ac6afa99c914375e4de0bf4f06c07186a337347f0297e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The first feedback text field now automatically receives focus when the dialog opens, making it faster to start typing.
* **Bug Fixes**
  * Improved the feedback form’s initial input behavior for a smoother, more intuitive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->