### PR TITLE
feat(workspaces): add AI item links

### DIFF
--- a/src/features/workspaces/ai/ai-tool-presentation.ts
+++ b/src/features/workspaces/ai/ai-tool-presentation.ts
@@ -1,0 +1,57 @@
+export type AiToolVisibility = "hidden" | "visible";
+
+interface AiToolPresentation {
+	title?: string;
+	visibility: AiToolVisibility;
+}
+
+const defaultToolPresentation = {
+	visibility: "visible",
+} as const satisfies AiToolPresentation;
+
+const aiToolPresentationByName: Readonly<Record<string, AiToolPresentation>> = {
+	compute: { title: "Computing", visibility: "visible" },
+	orchestrate: { title: "Working", visibility: "visible" },
+	research_deepen: { title: "Researching sources", visibility: "visible" },
+	research_discover: { title: "Researching sources", visibility: "visible" },
+	sandbox_bash: { visibility: "hidden" },
+	web_links: { title: "Reading the web", visibility: "visible" },
+	web_markdown: { title: "Reading the web", visibility: "visible" },
+	web_search: { title: "Reading the web", visibility: "visible" },
+	workspace_create_items: { title: "Updating workspace", visibility: "visible" },
+	workspace_delete_items: { title: "Updating workspace", visibility: "visible" },
+	workspace_edit_item: { title: "Updating workspace", visibility: "visible" },
+	workspace_link_items: { visibility: "hidden" },
+	workspace_list_items: { title: "Reading workspace", visibility: "visible" },
+	workspace_move_items: { title: "Updating workspace", visibility: "visible" },
+	workspace_read_items: { title: "Reading workspace", visibility: "visible" },
+	workspace_rename_item: { title: "Updating workspace", visibility: "visible" },
+};
+
+export function getAiToolPresentation(toolName: string): AiToolPresentation {
+	if (toolName.startsWith("time_")) {
+		return { visibility: "hidden" };
+	}
+
+	return aiToolPresentationByName[toolName] ?? defaultToolPresentation;
+}
+
+export function getAiToolActivityTitle(input: { title?: string; toolName: string }) {
+	const title = input.title?.trim();
+
+	if (title) {
+		return title;
+	}
+
+	return getAiToolPresentation(input.toolName).title ?? humanizeToolName(input.toolName);
+}
+
+function humanizeToolName(value: string) {
+	return value
+		.split("_")
+		.filter(Boolean)
+		.map((segment, index) =>
+			index === 0 ? segment.charAt(0).toUpperCase() + segment.slice(1) : segment,
+		)
+		.join(" ");
+}

--- a/src/features/workspaces/components/ai-chat/ai-chat-display-state.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-display-state.ts
@@ -6,6 +6,10 @@ import type {
 	AiChatStatus,
 	AiChatToolPart,
 } from "#/features/workspaces/components/ai-chat/types";
+import {
+	getAiToolActivityTitle,
+	getAiToolPresentation,
+} from "#/features/workspaces/ai/ai-tool-presentation";
 import { getFinishedToolReceipt } from "#/features/workspaces/components/ai-chat/ai-chat-tool-receipts";
 
 export type AssistantPendingKind = "thinking" | "recovering";
@@ -225,7 +229,7 @@ export function getToolActivityForPart(part: AiChatToolPart): AiChatToolActivity
 
 export function isVisibleToolPart(part: AiChatToolPart) {
 	const toolName = getToolPartName(part);
-	return toolName !== "sandbox_bash" && !toolName.startsWith("time_");
+	return getAiToolPresentation(toolName).visibility === "visible";
 }
 
 function getToolPartName(part: AiChatToolPart) {
@@ -233,36 +237,10 @@ function getToolPartName(part: AiChatToolPart) {
 }
 
 function getToolActivityTitle(part: AiChatToolPart, toolName: string) {
-	const title = part.title?.trim();
-
-	if (title) {
-		return title;
-	}
-
-	switch (toolName) {
-		case "orchestrate":
-			return "Working";
-		case "compute":
-			return "Computing";
-		case "workspace_create_items":
-		case "workspace_delete_items":
-		case "workspace_edit_item":
-		case "workspace_move_items":
-		case "workspace_rename_item":
-			return "Updating workspace";
-		case "workspace_list_items":
-		case "workspace_read_items":
-			return "Reading workspace";
-		case "web_search":
-		case "web_markdown":
-		case "web_links":
-			return "Reading the web";
-		case "research_discover":
-		case "research_deepen":
-			return "Researching sources";
-		default:
-			return humanizeToolName(toolName);
-	}
+	return getAiToolActivityTitle({
+		title: part.title,
+		toolName,
+	});
 }
 
 function getToolActivityReceipt(
@@ -292,14 +270,4 @@ function getToolActivityReceipt(
 				summary: title,
 			};
 	}
-}
-
-function humanizeToolName(value: string) {
-	return value
-		.split("_")
-		.filter(Boolean)
-		.map((segment, index) =>
-			index === 0 ? segment.charAt(0).toUpperCase() + segment.slice(1) : segment,
-		)
-		.join(" ");
 }

--- a/src/features/workspaces/contracts.ts
+++ b/src/features/workspaces/contracts.ts
@@ -171,6 +171,12 @@ export const workspaceRoles = ["owner", "admin", "editor", "viewer"] as const;
 
 export const workspaceMembershipRoleSchema = z.enum(workspaceRoles);
 
+export const workspaceRelationKindValues = ["derived_from", "references"] as const;
+
+export const workspaceRelationKindSchema = z.enum(workspaceRelationKindValues);
+
+export type WorkspaceRelationKind = (typeof workspaceRelationKindValues)[number];
+
 export const workspaceSummarySchema = z.object({
 	id: z.string(),
 	name: z.string(),

--- a/src/features/workspaces/kernel/workspace-kernel-access.ts
+++ b/src/features/workspaces/kernel/workspace-kernel-access.ts
@@ -18,12 +18,15 @@ import {
 } from "#/features/workspaces/kernel/workspace-kernel-list";
 import type {
 	CreateWorkspaceKernelFileFromUploadArgs,
+	CreateWorkspaceKernelRelationArgs,
 	DeleteWorkspaceKernelItemsResult,
+	ListWorkspaceKernelItemRelationsArgs,
 	MoveWorkspaceKernelItemsResult,
 	ReadWorkspaceKernelFilePreviewResult,
 	ReadWorkspaceKernelFileProjectionArgs,
 	ReadWorkspaceKernelFileProjectionResult,
 	UpsertWorkspaceKernelFileProjectionArgs,
+	WorkspaceKernelItemRelation,
 	WorkspaceKernelNameConflictPolicy,
 } from "#/features/workspaces/kernel/workspace-kernel-types";
 import type { WorkspaceFileAssetKind } from "#/features/workspaces/model/workspace-file";
@@ -53,6 +56,10 @@ export interface WorkspaceKernelClient {
 		items: WorkspaceItemSummary[];
 		revision: number;
 	}>;
+	createRelations(input: { relations: CreateWorkspaceKernelRelationArgs[] }): Promise<void>;
+	listItemRelations(
+		input: ListWorkspaceKernelItemRelationsArgs,
+	): Promise<WorkspaceKernelItemRelation[]>;
 	createItem(input: {
 		id?: string;
 		parentId?: string | null;

--- a/src/features/workspaces/kernel/workspace-kernel-item-commands.ts
+++ b/src/features/workspaces/kernel/workspace-kernel-item-commands.ts
@@ -17,6 +17,7 @@ import {
 	type KernelItemRow,
 	mapKernelItemRow,
 } from "#/features/workspaces/kernel/workspace-kernel-rows";
+import type { WorkspaceKernelRelations } from "#/features/workspaces/kernel/workspace-kernel-relations";
 import type { WorkspaceKernelSql } from "#/features/workspaces/kernel/workspace-kernel-schema";
 import type { WorkspaceKernelStore } from "#/features/workspaces/kernel/workspace-kernel-store";
 import type {
@@ -38,6 +39,7 @@ import type { WorkspaceCommandResult } from "#/features/workspaces/realtime/mess
 
 export class WorkspaceKernelItemCommands {
 	private readonly events: WorkspaceKernelEventBus;
+	private readonly relations: WorkspaceKernelRelations;
 	private readonly sql: WorkspaceKernelSql;
 	private readonly store: WorkspaceKernelStore;
 	private readonly workspace: ShellWorkspace;
@@ -45,12 +47,14 @@ export class WorkspaceKernelItemCommands {
 
 	constructor(input: {
 		events: WorkspaceKernelEventBus;
+		relations: WorkspaceKernelRelations;
 		sql: WorkspaceKernelSql;
 		store: WorkspaceKernelStore;
 		workspace: ShellWorkspace;
 		workspaceId: () => string;
 	}) {
 		this.events = input.events;
+		this.relations = input.relations;
 		this.sql = input.sql;
 		this.store = input.store;
 		this.workspace = input.workspace;
@@ -245,6 +249,7 @@ export class WorkspaceKernelItemCommands {
 			.filter((row): row is KernelItemRow => Boolean(row));
 
 		this.store.softDeleteItems(deleteIds, Date.now());
+		this.relations.deleteRelationsForItems(deleteIds);
 		await Promise.all(
 			rowsToRemove.map((row) =>
 				this.workspace.rm(row.shell_path, {

--- a/src/features/workspaces/kernel/workspace-kernel-relations.ts
+++ b/src/features/workspaces/kernel/workspace-kernel-relations.ts
@@ -1,0 +1,85 @@
+import type { WorkspaceRelationKind } from "#/features/workspaces/contracts";
+import { workspaceRelationKindSchema } from "#/features/workspaces/contracts";
+import type { WorkspaceKernelSql } from "#/features/workspaces/kernel/workspace-kernel-schema";
+
+export interface CreateWorkspaceKernelRelationInput {
+	fromItemId: string;
+	kind: WorkspaceRelationKind;
+	note?: string | null;
+	toItemId: string;
+}
+
+export interface WorkspaceKernelRelation {
+	id: string;
+	fromItemId: string;
+	kind: WorkspaceRelationKind;
+	note: string | null;
+	toItemId: string;
+}
+
+type KernelRelationRow = {
+	id: string;
+	from_item_id: string;
+	kind: string;
+	note: string;
+	to_item_id: string;
+};
+
+export class WorkspaceKernelRelations {
+	constructor(private readonly sql: WorkspaceKernelSql) {}
+
+	createRelations(relations: CreateWorkspaceKernelRelationInput[]) {
+		for (const relation of relations) {
+			const kind = workspaceRelationKindSchema.parse(relation.kind);
+			const note = relation.note?.trim() ?? "";
+
+			this.sql`
+				INSERT OR IGNORE INTO kernel_relations (
+					id,
+					from_item_id,
+					to_item_id,
+					kind,
+					note,
+					created_at
+				)
+				VALUES (
+					${crypto.randomUUID()},
+					${relation.fromItemId},
+					${relation.toItemId},
+					${kind},
+					${note},
+					${Date.now()}
+				)
+			`;
+		}
+	}
+
+	deleteRelationsForItems(itemIds: string[]) {
+		for (const itemId of itemIds) {
+			this.sql`
+				DELETE FROM kernel_relations
+				WHERE from_item_id = ${itemId} OR to_item_id = ${itemId}
+			`;
+		}
+	}
+
+	listItemRelations(itemId: string, limit = 40): WorkspaceKernelRelation[] {
+		return this.sql<KernelRelationRow>`
+			SELECT id, from_item_id, to_item_id, kind, note
+			FROM kernel_relations
+			WHERE from_item_id = ${itemId} OR to_item_id = ${itemId}
+			ORDER BY created_at DESC, id ASC
+			LIMIT ${Math.max(1, Math.min(limit, 100))}
+		`.map(mapKernelRelationRow);
+	}
+}
+
+function mapKernelRelationRow(row: KernelRelationRow): WorkspaceKernelRelation {
+	return {
+		id: row.id,
+		fromItemId: row.from_item_id,
+		toItemId: row.to_item_id,
+		kind: workspaceRelationKindSchema.parse(row.kind),
+		note: row.note || null,
+	};
+}

--- a/src/features/workspaces/kernel/workspace-kernel-schema.ts
+++ b/src/features/workspaces/kernel/workspace-kernel-schema.ts
@@ -48,6 +48,22 @@ export function initializeWorkspaceKernelStorage(sql: WorkspaceKernelSql) {
 	sql`CREATE INDEX IF NOT EXISTS kernel_item_projections_status_idx
 		ON kernel_item_projections (status, updated_at)`;
 	sql`
+		CREATE TABLE IF NOT EXISTS kernel_relations (
+			id TEXT PRIMARY KEY,
+			from_item_id TEXT NOT NULL,
+			to_item_id TEXT NOT NULL,
+			kind TEXT NOT NULL,
+			note TEXT NOT NULL DEFAULT '',
+			created_at INTEGER NOT NULL
+		)
+	`;
+	sql`CREATE UNIQUE INDEX IF NOT EXISTS kernel_relations_unique_idx
+		ON kernel_relations (from_item_id, to_item_id, kind, note)`;
+	sql`CREATE INDEX IF NOT EXISTS kernel_relations_from_idx
+		ON kernel_relations (from_item_id, created_at)`;
+	sql`CREATE INDEX IF NOT EXISTS kernel_relations_to_idx
+		ON kernel_relations (to_item_id, created_at)`;
+	sql`
 		CREATE TABLE IF NOT EXISTS kernel_meta (
 			key TEXT PRIMARY KEY,
 			value TEXT NOT NULL,

--- a/src/features/workspaces/kernel/workspace-kernel-types.ts
+++ b/src/features/workspaces/kernel/workspace-kernel-types.ts
@@ -2,6 +2,7 @@ import type {
 	JsonValue,
 	WorkspaceItemColor,
 	WorkspaceItemSummary,
+	WorkspaceRelationKind,
 	WorkspaceItemType,
 } from "#/features/workspaces/contracts";
 import type {
@@ -13,6 +14,26 @@ export interface WorkspaceKernelPage {
 	workspaceId: string;
 	items: WorkspaceItemSummary[];
 	revision: number;
+}
+
+export interface CreateWorkspaceKernelRelationArgs {
+	fromItemId: string;
+	kind: WorkspaceRelationKind;
+	note?: string | null;
+	toItemId: string;
+}
+
+export interface ListWorkspaceKernelItemRelationsArgs {
+	itemId: string;
+	limit?: number;
+}
+
+export interface WorkspaceKernelItemRelation {
+	id: string;
+	fromItemId: string;
+	kind: WorkspaceRelationKind;
+	note: string | null;
+	toItemId: string;
 }
 
 export interface ListWorkspaceKernelItemsArgs {

--- a/src/features/workspaces/kernel/workspace-kernel.ts
+++ b/src/features/workspaces/kernel/workspace-kernel.ts
@@ -15,13 +15,16 @@ import {
 	initializeWorkspaceKernelStorage,
 	type WorkspaceKernelSql,
 } from "#/features/workspaces/kernel/workspace-kernel-schema";
+import { WorkspaceKernelRelations } from "#/features/workspaces/kernel/workspace-kernel-relations";
 import { WorkspaceKernelStore } from "#/features/workspaces/kernel/workspace-kernel-store";
 import type {
 	CreateWorkspaceKernelFileFromUploadArgs,
 	CreateWorkspaceKernelItemArgs,
+	CreateWorkspaceKernelRelationArgs,
 	DeleteWorkspaceKernelItemsArgs,
 	DeleteWorkspaceKernelItemsResult,
 	ListWorkspaceKernelEventsArgs,
+	ListWorkspaceKernelItemRelationsArgs,
 	ListWorkspaceKernelItemsArgs,
 	MoveWorkspaceKernelItemsArgs,
 	MoveWorkspaceKernelItemsResult,
@@ -65,8 +68,10 @@ export class WorkspaceKernel extends Agent<Cloudflare.Env> {
 		getNextRevision: () => this.store.getNextRevision(),
 		broadcast: (message) => this.broadcastRealtimeMessage(message),
 	});
+	private readonly relations = new WorkspaceKernelRelations(this.kernelSql);
 	private readonly itemCommands = new WorkspaceKernelItemCommands({
 		events: this.events,
+		relations: this.relations,
 		sql: this.kernelSql,
 		store: this.store,
 		workspace: this.workspace,
@@ -112,6 +117,20 @@ export class WorkspaceKernel extends Agent<Cloudflare.Env> {
 
 	async listItems(input: ListWorkspaceKernelItemsArgs = {}) {
 		return this.store.listItems(input);
+	}
+
+	async createRelations(input: { relations: CreateWorkspaceKernelRelationArgs[] }) {
+		for (const relation of input.relations) {
+			this.store.assertActiveItem(relation.fromItemId);
+			this.store.assertActiveItem(relation.toItemId);
+		}
+
+		this.relations.createRelations(input.relations);
+	}
+
+	async listItemRelations(input: ListWorkspaceKernelItemRelationsArgs) {
+		this.store.assertActiveItem(input.itemId);
+		return this.relations.listItemRelations(input.itemId, input.limit);
 	}
 
 	async createItem(

--- a/src/features/workspaces/operations/create-items.ts
+++ b/src/features/workspaces/operations/create-items.ts
@@ -2,6 +2,11 @@ import {
 	getWorkspaceOperationContext,
 	resolveWorkspaceOperationPath,
 } from "#/features/workspaces/operations/workspace-operation-context";
+import {
+	resolveWorkspaceRelations,
+	type WorkspaceRelationInput,
+	workspaceRelationFailureCodes,
+} from "#/features/workspaces/operations/relations";
 import type { WorkspaceAccessContext } from "#/features/workspaces/operations/workspace-access-context";
 import type { WorkspaceItemSummary } from "#/features/workspaces/contracts";
 import { parseMarkdownToTiptapDocumentProjection } from "#/features/workspaces/documents/document-markdown";
@@ -21,6 +26,7 @@ export interface CreateWorkspaceItemOperationInput {
 	type: "document" | "folder";
 	path: string;
 	initialContent?: string;
+	relations?: WorkspaceRelationInput[];
 }
 
 export interface CreateWorkspaceItemsOperationInput {
@@ -35,6 +41,7 @@ export const createWorkspaceItemsFailureCodes = [
 	"path_not_canonical",
 	"path_not_folder",
 	"path_not_found",
+	...workspaceRelationFailureCodes,
 ] as const;
 
 type CreateWorkspaceItemsFailureCode = (typeof createWorkspaceItemsFailureCodes)[number];
@@ -82,6 +89,7 @@ export async function createWorkspaceItemsOperation(
 	const createdItemsByPath = new Map<string, { id: string; type: WorkspaceItemSummary["type"] }>();
 
 	for (const [index, itemInput] of input.items.entries()) {
+		const id = crypto.randomUUID();
 		const path = resolveCreateWorkspaceItemPath(itemInput.path);
 
 		if (path.status === "failed") {
@@ -119,10 +127,27 @@ export async function createWorkspaceItemsOperation(
 			continue;
 		}
 
+		const relations = resolveWorkspaceRelations({
+			createdItemsByPath,
+			fromItemId: id,
+			relations: itemInput.relations,
+			tree: workspaceContext.tree,
+		});
+
+		if (relations.status === "failed") {
+			failed.push({
+				code: relations.failure.code,
+				index,
+				path: relations.failure.path,
+			});
+			continue;
+		}
+
 		let command: Awaited<ReturnType<WorkspaceKernelClient["createItem"]>>;
 
 		try {
 			command = await workspaceContext.kernel.createItem({
+				id,
 				parentId: parent.parentId,
 				type: itemInput.type,
 				name: path.name,
@@ -142,6 +167,10 @@ export async function createWorkspaceItemsOperation(
 			}
 
 			throw error;
+		}
+
+		if (relations.relations.length > 0) {
+			await workspaceContext.kernel.createRelations({ relations: relations.relations });
 		}
 
 		const createdPath = joinWorkspaceItemPath(parent.path, command.result.name);

--- a/src/features/workspaces/operations/edit-item.ts
+++ b/src/features/workspaces/operations/edit-item.ts
@@ -3,6 +3,11 @@ import {
 	getWorkspaceOperationContext,
 	resolveWorkspaceExistingItemPath,
 } from "#/features/workspaces/operations/workspace-operation-context";
+import {
+	resolveWorkspaceRelations,
+	type WorkspaceRelationInput,
+	workspaceRelationFailureCodes,
+} from "#/features/workspaces/operations/relations";
 import type { WorkspaceAccessContext } from "#/features/workspaces/operations/workspace-access-context";
 import {
 	type DocumentMarkdownEdit,
@@ -11,8 +16,10 @@ import {
 
 export const editWorkspaceItemFailureCodes = [
 	"cannot_edit_root",
+	"missing_edit_operation",
 	"path_not_absolute",
 	"path_not_found",
+	...workspaceRelationFailureCodes,
 	"unsupported_item_type",
 	...documentMarkdownEditFailureCodes,
 	"invalid_document_projection",
@@ -21,8 +28,9 @@ export const editWorkspaceItemFailureCodes = [
 type EditWorkspaceItemFailureCode = (typeof editWorkspaceItemFailureCodes)[number];
 
 export interface EditWorkspaceItemOperationInput {
-	edits: DocumentMarkdownEdit[];
+	edits?: DocumentMarkdownEdit[];
 	path: string;
+	relations?: WorkspaceRelationInput[];
 }
 
 interface EditWorkspaceItemFailure {
@@ -41,10 +49,21 @@ export async function editWorkspaceItemOperation(
 	accessContext: WorkspaceAccessContext,
 	input: EditWorkspaceItemOperationInput,
 ): Promise<EditWorkspaceItemOperationResult> {
+	const edits = input.edits ?? [];
+
+	if (edits.length === 0 && (input.relations?.length ?? 0) === 0) {
+		return {
+			path: input.path,
+			warnings: [],
+			...failedWorkspaceEditResult("missing_edit_operation", 1),
+		};
+	}
+
 	const workspaceContext = await getWorkspaceOperationContext({
 		access: "mutate",
 		context: accessContext,
 	});
+	const failureCount = Math.max(edits.length, 1);
 	const resolution = resolveWorkspaceExistingItemPath({
 		path: input.path,
 		rootFailureCode: "cannot_edit_root",
@@ -55,7 +74,35 @@ export async function editWorkspaceItemOperation(
 		return {
 			path: resolution.failure.path,
 			warnings: [],
-			...failedWorkspaceEditResult(resolution.failure.code, input.edits.length),
+			...failedWorkspaceEditResult(resolution.failure.code, failureCount),
+		};
+	}
+
+	const relations = resolveWorkspaceRelations({
+		excludeItemId: resolution.item.id,
+		fromItemId: resolution.item.id,
+		relations: input.relations,
+		tree: workspaceContext.tree,
+	});
+
+	if (relations.status === "failed") {
+		return {
+			path: relations.failure.path,
+			warnings: [],
+			...failedWorkspaceEditResult(relations.failure.code, failureCount),
+		};
+	}
+
+	if (edits.length === 0) {
+		if (relations.relations.length > 0) {
+			await workspaceContext.kernel.createRelations({ relations: relations.relations });
+		}
+
+		return {
+			applied: 0,
+			failed: [],
+			path: resolution.path,
+			warnings: [],
 		};
 	}
 
@@ -63,7 +110,7 @@ export async function editWorkspaceItemOperation(
 		return {
 			path: resolution.path,
 			warnings: [],
-			...failedWorkspaceEditResult("unsupported_item_type", input.edits.length),
+			...failedWorkspaceEditResult("unsupported_item_type", edits.length),
 		};
 	}
 
@@ -73,8 +120,12 @@ export async function editWorkspaceItemOperation(
 	});
 
 	const result = await documentSession.applyMarkdownEdits({
-		edits: input.edits,
+		edits,
 	});
+
+	if (result.failures.length === 0 && relations.relations.length > 0) {
+		await workspaceContext.kernel.createRelations({ relations: relations.relations });
+	}
 
 	return {
 		applied: result.applied,

--- a/src/features/workspaces/operations/link-items.ts
+++ b/src/features/workspaces/operations/link-items.ts
@@ -1,0 +1,92 @@
+import type { WorkspaceItemSummary } from "#/features/workspaces/contracts";
+import {
+	resolveWorkspaceRelations,
+	type WorkspaceRelationInput,
+	workspaceRelationFailureCodes,
+} from "#/features/workspaces/operations/relations";
+import type { WorkspaceAccessContext } from "#/features/workspaces/operations/workspace-access-context";
+import {
+	getWorkspaceOperationContext,
+	resolveWorkspaceExistingItemPath,
+} from "#/features/workspaces/operations/workspace-operation-context";
+
+export interface LinkWorkspaceItemsOperationInput {
+	path: string;
+	relations: WorkspaceRelationInput[];
+}
+
+export const linkWorkspaceItemsFailureCodes = [
+	"cannot_link_root",
+	"path_not_absolute",
+	"path_not_found",
+	...workspaceRelationFailureCodes,
+] as const;
+
+type LinkWorkspaceItemsFailureCode = (typeof linkWorkspaceItemsFailureCodes)[number];
+
+interface LinkWorkspaceItemsFailure {
+	code: LinkWorkspaceItemsFailureCode;
+	path: string;
+}
+
+export interface LinkWorkspaceItemsOperationResult {
+	failed: LinkWorkspaceItemsFailure[];
+	item?: {
+		path: string;
+		type: WorkspaceItemSummary["type"];
+	};
+}
+
+export async function linkWorkspaceItemsOperation(
+	accessContext: WorkspaceAccessContext,
+	input: LinkWorkspaceItemsOperationInput,
+): Promise<LinkWorkspaceItemsOperationResult> {
+	const workspaceContext = await getWorkspaceOperationContext({
+		access: "mutate",
+		context: accessContext,
+	});
+	const resolution = resolveWorkspaceExistingItemPath({
+		path: input.path,
+		rootFailureCode: "cannot_link_root",
+		tree: workspaceContext.tree,
+	});
+
+	if (resolution.status === "failed") {
+		return {
+			failed: [
+				{
+					code: resolution.failure.code,
+					path: resolution.failure.path,
+				},
+			],
+		};
+	}
+
+	const relations = resolveWorkspaceRelations({
+		excludeItemId: resolution.item.id,
+		fromItemId: resolution.item.id,
+		relations: input.relations,
+		tree: workspaceContext.tree,
+	});
+
+	if (relations.status === "failed") {
+		return {
+			failed: [
+				{
+					code: relations.failure.code,
+					path: relations.failure.path,
+				},
+			],
+		};
+	}
+
+	await workspaceContext.kernel.createRelations({ relations: relations.relations });
+
+	return {
+		failed: [],
+		item: {
+			path: resolution.path,
+			type: resolution.item.type,
+		},
+	};
+}

--- a/src/features/workspaces/operations/read-items.ts
+++ b/src/features/workspaces/operations/read-items.ts
@@ -3,6 +3,10 @@ import {
 	resolveWorkspaceOperationPath,
 } from "#/features/workspaces/operations/workspace-operation-context";
 import {
+	serializeWorkspaceRelations,
+	type WorkspaceRelationOutput,
+} from "#/features/workspaces/operations/relations";
+import {
 	parseWorkspacePageRange,
 	readWorkspaceProjectionPages,
 	WorkspacePageSelectionError,
@@ -13,6 +17,7 @@ import { serializeTiptapDocumentToMarkdown } from "#/features/workspaces/documen
 import { parseMarkdownPagesProjection } from "#/features/workspaces/extraction/page-markdown-projection";
 import { parseTiptapDocumentJson } from "#/features/workspaces/documents/tiptap-document";
 import type { WorkspaceKernelClient } from "#/features/workspaces/kernel/workspace-kernel-access";
+import { buildWorkspaceKernelItemPathIndex } from "#/features/workspaces/kernel/workspace-kernel-paths";
 import { resolveWorkspaceFileTypeFromItem } from "#/features/workspaces/model/workspace-file";
 import type { WorkspaceAccessContext } from "#/features/workspaces/operations/workspace-access-context";
 
@@ -25,6 +30,7 @@ export interface WorkspaceReadItem {
 	content?: string;
 	pages?: WorkspaceReadPages;
 	path: string;
+	relations?: WorkspaceRelationOutput[];
 	status: "failed" | "pending" | "ready" | "unsupported";
 	type: "document" | "file" | "flashcard" | "quiz";
 }
@@ -65,6 +71,7 @@ export async function readWorkspaceItemsOperation(
 		items: [],
 		failed: [],
 	};
+	const pathsByItemId = buildWorkspaceKernelItemPathIndex(workspaceContext.pageItems);
 
 	for (const [index, path] of input.paths.entries()) {
 		const resolution = resolveWorkspaceOperationPath({
@@ -109,14 +116,24 @@ export async function readWorkspaceItemsOperation(
 		}
 
 		try {
-			result.items.push(
-				await readWorkspaceItem({
-					item: resolution.item,
-					kernel: workspaceContext.kernel,
-					pages: input.pages,
-					path: resolution.path,
+			const item = await readWorkspaceItem({
+				item: resolution.item,
+				kernel: workspaceContext.kernel,
+				pages: input.pages,
+				path: resolution.path,
+			});
+			const relations = serializeWorkspaceRelations({
+				item: resolution.item,
+				pathsByItemId,
+				relations: await workspaceContext.kernel.listItemRelations({
+					itemId: resolution.item.id,
 				}),
-			);
+			});
+
+			result.items.push({
+				...item,
+				...(relations.length > 0 ? { relations } : {}),
+			});
 		} catch (error) {
 			if (error instanceof WorkspacePageSelectionError) {
 				result.failed.push({

--- a/src/features/workspaces/operations/relations.ts
+++ b/src/features/workspaces/operations/relations.ts
@@ -1,0 +1,178 @@
+import type { WorkspaceItemSummary, WorkspaceRelationKind } from "#/features/workspaces/contracts";
+import {
+	normalizeWorkspacePath,
+	resolveWorkspaceKernelItemPath,
+	WorkspaceKernelPathError,
+	type WorkspaceKernelTree,
+} from "#/features/workspaces/kernel/workspace-kernel-paths";
+import type {
+	CreateWorkspaceKernelRelationArgs,
+	WorkspaceKernelItemRelation,
+} from "#/features/workspaces/kernel/workspace-kernel-types";
+
+export interface WorkspaceRelationInput {
+	kind: WorkspaceRelationKind;
+	note?: string;
+	path: string;
+}
+
+export const workspaceRelationFailureCodes = [
+	"relation_path_is_root",
+	"relation_path_is_self",
+	"relation_path_not_absolute",
+	"relation_path_not_found",
+] as const;
+
+export type WorkspaceRelationFailureCode = (typeof workspaceRelationFailureCodes)[number];
+
+export interface WorkspaceRelationFailure {
+	code: WorkspaceRelationFailureCode;
+	path: string;
+}
+
+export interface WorkspaceRelationOutput {
+	direction: "incoming" | "outgoing";
+	kind: WorkspaceRelationKind;
+	note?: string;
+	path: string;
+}
+
+export function resolveWorkspaceRelations(input: {
+	createdItemsByPath?: ReadonlyMap<string, { id: string }>;
+	excludeItemId?: string;
+	fromItemId: string;
+	relations?: WorkspaceRelationInput[];
+	tree: WorkspaceKernelTree;
+}):
+	| {
+			relations: CreateWorkspaceKernelRelationArgs[];
+			status: "ready";
+	  }
+	| {
+			failure: WorkspaceRelationFailure;
+			status: "failed";
+	  } {
+	const relations: CreateWorkspaceKernelRelationArgs[] = [];
+
+	for (const relation of input.relations ?? []) {
+		const target = resolveWorkspaceRelationTarget({
+			createdItemsByPath: input.createdItemsByPath,
+			excludeItemId: input.excludeItemId,
+			path: relation.path,
+			tree: input.tree,
+		});
+
+		if (target.status === "failed") {
+			return target;
+		}
+
+		relations.push({
+			fromItemId: input.fromItemId,
+			toItemId: target.itemId,
+			kind: relation.kind,
+			note: relation.note,
+		});
+	}
+
+	return {
+		relations,
+		status: "ready",
+	};
+}
+
+export function serializeWorkspaceRelations(input: {
+	item: WorkspaceItemSummary;
+	pathsByItemId: ReadonlyMap<string, string>;
+	relations: WorkspaceKernelItemRelation[];
+}): WorkspaceRelationOutput[] {
+	const serialized: WorkspaceRelationOutput[] = [];
+
+	for (const relation of input.relations) {
+		const isOutgoing = relation.fromItemId === input.item.id;
+		const relatedItemId = isOutgoing ? relation.toItemId : relation.fromItemId;
+		const path = input.pathsByItemId.get(relatedItemId);
+
+		if (!path) {
+			continue;
+		}
+
+		serialized.push({
+			direction: isOutgoing ? "outgoing" : "incoming",
+			kind: relation.kind,
+			path,
+			...(relation.note ? { note: relation.note } : {}),
+		});
+	}
+
+	return serialized;
+}
+
+function resolveWorkspaceRelationTarget(input: {
+	createdItemsByPath?: ReadonlyMap<string, { id: string }>;
+	excludeItemId?: string;
+	path: string;
+	tree: WorkspaceKernelTree;
+}):
+	| {
+			itemId: string;
+			status: "ready";
+	  }
+	| {
+			failure: WorkspaceRelationFailure;
+			status: "failed";
+	  } {
+	try {
+		const normalizedPath = normalizeWorkspacePath(input.path);
+
+		if (normalizedPath === "/") {
+			return {
+				failure: {
+					code: "relation_path_is_root",
+					path: normalizedPath,
+				},
+				status: "failed",
+			};
+		}
+
+		const itemId =
+			input.createdItemsByPath?.get(normalizedPath)?.id ??
+			resolveWorkspaceKernelItemPath(normalizedPath, input.tree)?.id;
+
+		if (!itemId) {
+			return {
+				failure: {
+					code: "relation_path_not_found",
+					path: normalizedPath,
+				},
+				status: "failed",
+			};
+		}
+
+		if (input.excludeItemId && itemId === input.excludeItemId) {
+			return {
+				failure: {
+					code: "relation_path_is_self",
+					path: normalizedPath,
+				},
+				status: "failed",
+			};
+		}
+
+		return {
+			itemId,
+			status: "ready",
+		};
+	} catch (error) {
+		if (error instanceof WorkspaceKernelPathError && error.code === "path_not_absolute") {
+			return {
+				failure: {
+					code: "relation_path_not_absolute",
+					path: input.path,
+				},
+				status: "failed",
+			};
+		}
+
+		throw error;
+	}
+}

--- a/src/features/workspaces/operations/workspace-operation-context.ts
+++ b/src/features/workspaces/operations/workspace-operation-context.ts
@@ -24,6 +24,7 @@ export type WorkspaceOperationAccessMode = "read" | "mutate";
 
 export interface WorkspaceOperationContext {
 	kernel: WorkspaceKernelClient;
+	pageItems: WorkspaceItemSummary[];
 	tree: WorkspaceKernelTree;
 }
 
@@ -85,6 +86,7 @@ export async function getWorkspaceOperationContext(input: {
 
 		return {
 			kernel,
+			pageItems: page.items,
 			tree: buildWorkspaceKernelTree(page.items),
 		};
 	} finally {

--- a/src/features/workspaces/operations/workspace-tool-definitions.ts
+++ b/src/features/workspaces/operations/workspace-tool-definitions.ts
@@ -3,6 +3,7 @@ import type { z } from "zod";
 import { createWorkspaceItemsOperation } from "#/features/workspaces/operations/create-items";
 import { deleteWorkspaceItemsOperation } from "#/features/workspaces/operations/delete-items";
 import { editWorkspaceItemOperation } from "#/features/workspaces/operations/edit-item";
+import { linkWorkspaceItemsOperation } from "#/features/workspaces/operations/link-items";
 import { listWorkspaceItemsOperation } from "#/features/workspaces/operations/list-items";
 import { moveWorkspaceItemsOperation } from "#/features/workspaces/operations/move-items";
 import { readWorkspaceItemsOperation } from "#/features/workspaces/operations/read-items";
@@ -18,6 +19,9 @@ import {
 	workspaceEditItemInputExamples,
 	workspaceEditItemInputSchema,
 	workspaceEditItemOutputSchema,
+	workspaceLinkItemsInputExamples,
+	workspaceLinkItemsInputSchema,
+	workspaceLinkItemsOutputSchema,
 	workspaceListItemsInputExamples,
 	workspaceListItemsInputSchema,
 	workspaceListItemsOutputSchema,
@@ -161,16 +165,33 @@ export const workspaceToolDefinitions = [
 	}),
 	defineWorkspaceTool({
 		name: "workspace_edit_item",
-		description: `Edit one actual ThinkEx workspace document by absolute path. Read before editing unless the user requested a simple append or prepend. ${workspaceDocumentMarkdownMathInstruction}`,
+		description: `Edit one actual ThinkEx workspace document by absolute path, or add relationships from any workspace item. Read before editing unless the user requested a simple append or prepend. ${workspaceDocumentMarkdownMathInstruction}`,
 		inputSchema: workspaceEditItemInputSchema,
 		inputExamples: workspaceEditItemInputExamples,
 		outputSchema: workspaceEditItemOutputSchema,
 		scopes: workspaceWriteScopes,
 		mutating: true,
-		execute: async ({ path, edits }, context) => {
+		execute: async ({ path, edits, relations }, context) => {
 			return await editWorkspaceItemOperation(context, {
 				path,
 				edits,
+				relations,
+			});
+		},
+	}),
+	defineWorkspaceTool({
+		name: "workspace_link_items",
+		description:
+			"Create relationships from one actual ThinkEx workspace item to other workspace items by absolute path.",
+		inputSchema: workspaceLinkItemsInputSchema,
+		inputExamples: workspaceLinkItemsInputExamples,
+		outputSchema: workspaceLinkItemsOutputSchema,
+		scopes: workspaceWriteScopes,
+		mutating: true,
+		execute: async ({ path, relations }, context) => {
+			return await linkWorkspaceItemsOperation(context, {
+				path,
+				relations,
 			});
 		},
 	}),

--- a/src/features/workspaces/operations/workspace-tool-schemas.ts
+++ b/src/features/workspaces/operations/workspace-tool-schemas.ts
@@ -3,10 +3,15 @@ import { z } from "zod";
 import { createWorkspaceItemsFailureCodes } from "#/features/workspaces/operations/create-items";
 import { deleteWorkspaceItemsFailureCodes } from "#/features/workspaces/operations/delete-items";
 import { editWorkspaceItemFailureCodes } from "#/features/workspaces/operations/edit-item";
+import { linkWorkspaceItemsFailureCodes } from "#/features/workspaces/operations/link-items";
 import { moveWorkspaceItemsFailureCodes } from "#/features/workspaces/operations/move-items";
 import { readWorkspaceItemsFailureCodes } from "#/features/workspaces/operations/read-items";
 import { renameWorkspaceItemFailureCodes } from "#/features/workspaces/operations/rename-item";
-import { workspaceItemTypeSchema, workspaceSummarySchema } from "#/features/workspaces/contracts";
+import {
+	workspaceItemTypeSchema,
+	workspaceRelationKindSchema,
+	workspaceSummarySchema,
+} from "#/features/workspaces/contracts";
 import { documentMarkdownEditSchema } from "#/features/workspaces/documents/document-markdown-edits";
 
 export const workspaceDocumentMarkdownMathInstruction =
@@ -63,6 +68,19 @@ export const workspaceReadPagesSchema = z.object({
 	total: z.number().int().min(1).describe("Total pages available."),
 });
 
+const workspaceRelationInputSchema = z.object({
+	kind: workspaceRelationKindSchema.describe(
+		"`derived_from` means this item was created or materially changed from the linked item. `references` means this item cites or points to the linked item.",
+	),
+	note: z
+		.string()
+		.trim()
+		.max(240)
+		.optional()
+		.describe("Optional short source detail, like pages 12-14 or section on photosynthesis."),
+	path: z.string().min(1).describe("Absolute path of the related ThinkEx workspace item."),
+});
+
 export const workspacePageRangeSchema = z
 	.string()
 	.trim()
@@ -100,15 +118,42 @@ export const workspaceReadItemsInputSchema = z.object({
 		.describe("Absolute paths in the actual ThinkEx workspace to read."),
 });
 
-export const workspaceEditItemInputSchema = z.object({
-	path: z.string().min(1).describe("Absolute path of one actual ThinkEx workspace item to edit."),
-	edits: z
-		.array(documentMarkdownEditSchema)
+export const workspaceEditItemInputSchema = z
+	.object({
+		path: z.string().min(1).describe("Absolute path of one actual ThinkEx workspace item to edit."),
+		relations: z
+			.array(workspaceRelationInputSchema)
+			.max(20)
+			.optional()
+			.describe("Optional relationships from this item to other workspace items."),
+		edits: z
+			.array(documentMarkdownEditSchema)
+			.min(1)
+			.max(40)
+			.optional()
+			.describe(
+				`Ordered text edits to apply to a document projection. ${workspaceDocumentMarkdownMathInstruction}`,
+			),
+	})
+	.superRefine((input, ctx) => {
+		if ((input.edits?.length ?? 0) > 0 || (input.relations?.length ?? 0) > 0) {
+			return;
+		}
+
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			message: "Provide edits or relations.",
+			path: ["edits"],
+		});
+	});
+
+export const workspaceLinkItemsInputSchema = z.object({
+	path: z.string().min(1).describe("Absolute path of the workspace item to link from."),
+	relations: z
+		.array(workspaceRelationInputSchema)
 		.min(1)
-		.max(40)
-		.describe(
-			`Ordered text edits to apply to the item projection. ${workspaceDocumentMarkdownMathInstruction}`,
-		),
+		.max(20)
+		.describe("Relationships from this item to other workspace items."),
 });
 
 export const workspaceRenameItemInputSchema = z.object({
@@ -135,10 +180,20 @@ export const workspaceCreateItemsInputSchema = z.object({
 				z.object({
 					type: z.literal("folder"),
 					path: z.string().min(1).describe("Final absolute path for the folder to create."),
+					relations: z
+						.array(workspaceRelationInputSchema)
+						.max(20)
+						.optional()
+						.describe("Optional relationships from this new folder to other workspace items."),
 				}),
 				z.object({
 					type: z.literal("document"),
 					path: z.string().min(1).describe("Final absolute path for the document to create."),
+					relations: z
+						.array(workspaceRelationInputSchema)
+						.max(20)
+						.optional()
+						.describe("Optional relationships from this new document to other workspace items."),
 					initialContent: z
 						.string()
 						.describe(
@@ -210,6 +265,13 @@ export const workspaceCreateItemsInputExamples = createInputExamples<
 			type: "document",
 			path: "/Demo Folder/Demo Document",
 			initialContent: "# Demo Document\nThis document was created as part of a tool demo.",
+			relations: [
+				{
+					kind: "derived_from",
+					path: "/Demo Folder/Demo PDF.pdf",
+					note: "Pages 1-3",
+				},
+			],
 		},
 	],
 });
@@ -224,10 +286,30 @@ export const workspaceEditItemInputExamples = createInputExamples<
 	z.input<typeof workspaceEditItemInputSchema>
 >({
 	path: "/Demo Folder/Demo Document",
+	relations: [
+		{
+			kind: "references",
+			path: "/Demo Folder/Demo PDF.pdf",
+			note: "Source section used for the update.",
+		},
+	],
 	edits: [
 		{
 			type: "overwrite",
 			content: "# Demo Document\nThis document was updated as part of the demo.",
+		},
+	],
+});
+
+export const workspaceLinkItemsInputExamples = createInputExamples<
+	z.input<typeof workspaceLinkItemsInputSchema>
+>({
+	path: "/Demo Folder",
+	relations: [
+		{
+			kind: "references",
+			path: "/Demo Folder/Demo PDF.pdf",
+			note: "Source folder for related materials.",
 		},
 	],
 });
@@ -250,6 +332,16 @@ export const workspaceReadItemsOutputSchema = createWorkspaceItemsResultSchema({
 		status: z.enum(["failed", "pending", "ready", "unsupported"]),
 		content: z.string().optional(),
 		pages: workspaceReadPagesSchema.optional(),
+		relations: z
+			.array(
+				z.object({
+					direction: z.enum(["incoming", "outgoing"]),
+					kind: workspaceRelationKindSchema,
+					note: z.string().optional(),
+					path: workspacePathSchema,
+				}),
+			)
+			.optional(),
 	}),
 	failureSchema: createFailureSchema(readWorkspaceItemsFailureCodes),
 });
@@ -298,4 +390,9 @@ export const workspaceEditItemOutputSchema = z.object({
 		.array(z.string())
 		.describe("Content projection warnings after applying edits.")
 		.optional(),
+});
+
+export const workspaceLinkItemsOutputSchema = z.object({
+	item: workspacePathItemSchema.optional(),
+	failed: z.array(createFailureSchema(linkWorkspaceItemsFailureCodes, { includeIndex: false })),
 });


### PR DESCRIPTION
## Summary

- Adds AI item links through the existing `workspace_create_items`, `workspace_edit_item`, and `workspace_read_items` tools.
- Links are stored inside `kernel_items.metadata_json`, so this does not add a new database table.
- Reading an item now returns its links inline.
- Link creation remains a side effect of the model's existing item-tool usage: no background job, no embeddings/vector search, and no confidence threshold. Link judgement is left to the model, with intentionally open semantics per the design discussion.

## Behavioral Change

- `workspace_edit_item` now allows links-only edits by making `edits` optional.
- Either `edits` or `links` must be present.
- Existing callers that provide `edits` are unaffected.
- This was necessary so the AI can update an item's related workspace items without also changing document content.

## Out of Scope

- Separate links table
- Background job or periodic workspace scan
- Embeddings or vector similarity
- Confidence scoring
- Frontend/UI work, including graph view or backlinks display

## Test Plan

- `pnpm check`
- `pnpm test` (7 tests)
- `pnpm build`

All passing locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for workspace item relationships, including creating, viewing, and serializing related items.
  * Workspace create and edit actions can now include optional relations.
  * Read results now include related items when available.

* **Bug Fixes**
  * Deleting items now also removes their associated relationships.
  * Relationship entries are validated and limited to keep results consistent and manageable.

* **Chores**
  * Updated workspace schemas and supporting data structures to reflect the new relation fields and output shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->