### PR TITLE
[codex] improve mobile workspace UX

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -25,7 +25,7 @@ export default function AppShell({
 			data-app-shell
 			className="flex h-screen flex-col overflow-hidden bg-background text-foreground"
 		>
-			<header className="z-40 shrink-0 border-b border-border/60 bg-background">
+			<header className="z-40 shrink-0 bg-muted">
 				<div className="relative flex h-12 w-full items-center gap-3 px-4">
 					<div className="relative z-10 flex min-w-0 shrink-0 items-center gap-3 text-foreground">
 						<Link

--- a/src/features/workspaces/components/WorkspaceContent.tsx
+++ b/src/features/workspaces/components/WorkspaceContent.tsx
@@ -34,8 +34,10 @@ import { MoveWorkspaceItemsDialog } from "#/features/workspaces/components/Works
 import { useWorkspacePaneHotkey } from "#/features/workspaces/components/WorkspacePaneRuntime";
 import { WorkspaceRootEmptyPreview } from "#/features/workspaces/components/WorkspaceRootEmptyPreview";
 import WorkspaceSelectionActionBar from "#/features/workspaces/components/WorkspaceSelectionActionBar";
+import { WorkspaceUploadClickTarget } from "#/features/workspaces/components/WorkspaceUploadClickTarget";
 import { workspaceItemGridClass } from "#/features/workspaces/components/workspace-item-card-chrome";
 import { useWorkspaceMutationAccess } from "#/features/workspaces/components/workspace-mutation-access";
+import { useWorkspaceViewCapabilities } from "#/features/workspaces/components/workspace-view-policy";
 import type { WorkspaceItemType, WorkspaceSummary } from "#/features/workspaces/contracts";
 import { getWorkspaceItemDisplay } from "#/features/workspaces/model/item-display";
 import { getWorkspaceChildren, splitWorkspaceChildren } from "#/features/workspaces/model/tree";
@@ -116,12 +118,14 @@ function WorkspaceBrowseContent({
 	const [moveSelectedDialogOpen, setMoveSelectedDialogOpen] = useState(false);
 	const [isNativeFileDropTarget, setIsNativeFileDropTarget] = useState(false);
 	const browseSurfaceRef = useRef<HTMLElement>(null);
-	const { uploadFiles } = useWorkspaceFileIntake();
+	const { requestFileUpload, uploadFiles } = useWorkspaceFileIntake();
+	const viewCapabilities = useWorkspaceViewCapabilities();
 	const parentId = getWorkspaceBrowseParentId(activeItem);
 	const children = getWorkspaceChildren(items, parentId);
 	const { folders, items: nonFolderItems } = splitWorkspaceChildren(children);
 	const isWorkspaceRoot = parentId === null;
 	const isEmpty = children.length === 0;
+	const requestUploadToBrowseLocation = () => requestFileUpload(parentId);
 	const handleNativeFileDrop = (files: FileList) => {
 		if (!capabilities.canMutateContent) {
 			return;
@@ -195,60 +199,73 @@ function WorkspaceBrowseContent({
 		stopPropagation: false,
 	});
 
+	const browseSurfaceContent = (
+		<>
+			{folders.length > 0 ? (
+				<WorkspaceItemGrid
+					items={folders}
+					allItems={items}
+					selectedItemIds={selectedItemIds}
+					onOpenItem={onOpenItem}
+					onMoveItem={actionDialogs.openMoveDialog}
+					onRenameItem={actionDialogs.setRenamingItem}
+					onDeleteItem={actionDialogs.openDeleteAlert}
+					onSelectionChange={setItemSelected}
+					onItemElementChange={registerItemElement}
+				/>
+			) : null}
+			{nonFolderItems.length > 0 ? (
+				<WorkspaceItemGrid
+					items={nonFolderItems}
+					allItems={items}
+					selectedItemIds={selectedItemIds}
+					onOpenItem={onOpenItem}
+					onMoveItem={actionDialogs.openMoveDialog}
+					onRenameItem={actionDialogs.setRenamingItem}
+					onDeleteItem={actionDialogs.openDeleteAlert}
+					onSelectionChange={setItemSelected}
+					onItemElementChange={registerItemElement}
+				/>
+			) : null}
+			{isEmpty ? (
+				isWorkspaceRoot && capabilities.canMutateContent ? (
+					<WorkspaceRootEmptyPreview onUploadFiles={requestUploadToBrowseLocation} />
+				) : (
+					<WorkspaceBrowseEmptyState
+						canUpload={capabilities.canMutateContent}
+						isWorkspaceRoot={isWorkspaceRoot}
+						onUploadFiles={requestUploadToBrowseLocation}
+					/>
+				)
+			) : null}
+		</>
+	);
+	const browseSurface = (
+		<section
+			data-scroll-root
+			ref={browseSurfaceRef}
+			className="flex h-full flex-col gap-6 overflow-y-auto px-4 py-3 outline-none"
+			aria-label="Workspace content"
+			tabIndex={-1}
+			{...marqueeSurfaceProps}
+		>
+			{browseSurfaceContent}
+		</section>
+	);
+
 	return (
 		<>
 			<div className="relative h-full min-h-0">
-				<ContextMenu>
-					<ContextMenuTrigger
-						render={
-							<section
-								data-scroll-root
-								ref={browseSurfaceRef}
-								className="flex h-full flex-col gap-6 overflow-y-auto px-4 py-3 outline-none"
-								aria-label="Workspace content"
-								tabIndex={-1}
-								{...marqueeSurfaceProps}
-							/>
-						}
-					>
-						{folders.length > 0 ? (
-							<WorkspaceItemGrid
-								items={folders}
-								allItems={items}
-								selectedItemIds={selectedItemIds}
-								onOpenItem={onOpenItem}
-								onMoveItem={actionDialogs.openMoveDialog}
-								onRenameItem={actionDialogs.setRenamingItem}
-								onDeleteItem={actionDialogs.openDeleteAlert}
-								onSelectionChange={setItemSelected}
-								onItemElementChange={registerItemElement}
-							/>
-						) : null}
-						{nonFolderItems.length > 0 ? (
-							<WorkspaceItemGrid
-								items={nonFolderItems}
-								allItems={items}
-								selectedItemIds={selectedItemIds}
-								onOpenItem={onOpenItem}
-								onMoveItem={actionDialogs.openMoveDialog}
-								onRenameItem={actionDialogs.setRenamingItem}
-								onDeleteItem={actionDialogs.openDeleteAlert}
-								onSelectionChange={setItemSelected}
-								onItemElementChange={registerItemElement}
-							/>
-						) : null}
-						{isEmpty ? (
-							isWorkspaceRoot && capabilities.canMutateContent ? (
-								<WorkspaceRootEmptyPreview />
-							) : (
-								<WorkspaceBrowseEmptyState isWorkspaceRoot={isWorkspaceRoot} />
-							)
-						) : null}
-					</ContextMenuTrigger>
-					<ContextMenuContent className="w-56">
-						<WorkspaceCreateContextMenuContent parentId={parentId} onCreateItem={onCreateItem} />
-					</ContextMenuContent>
-				</ContextMenu>
+				{viewCapabilities.contextMenus ? (
+					<ContextMenu>
+						<ContextMenuTrigger render={browseSurface} />
+						<ContextMenuContent className="w-56">
+							<WorkspaceCreateContextMenuContent parentId={parentId} onCreateItem={onCreateItem} />
+						</ContextMenuContent>
+					</ContextMenu>
+				) : (
+					browseSurface
+				)}
 				<WorkspaceSelectionActionBar
 					selectedCount={selectedItems.length}
 					onMove={openMoveSelectedDialog}
@@ -298,34 +315,51 @@ function WorkspaceBrowseContent({
 	);
 }
 
-function WorkspaceBrowseEmptyState({ isWorkspaceRoot }: { isWorkspaceRoot: boolean }) {
-	if (!isWorkspaceRoot) {
-		return (
-			<Empty className="border border-dashed bg-muted/20">
-				<EmptyHeader>
-					<EmptyMedia variant="icon">
-						<FolderOpen />
-					</EmptyMedia>
-					<EmptyTitle>This folder is empty</EmptyTitle>
-					<EmptyDescription>Items added here will appear in this folder.</EmptyDescription>
-				</EmptyHeader>
-			</Empty>
-		);
-	}
-
-	return (
-		<Empty className="border border-dashed bg-muted/20">
+function WorkspaceBrowseEmptyState({
+	canUpload,
+	isWorkspaceRoot,
+	onUploadFiles,
+}: {
+	canUpload: boolean;
+	isWorkspaceRoot: boolean;
+	onUploadFiles: () => void;
+}) {
+	const uploadLabel = isWorkspaceRoot
+		? "Upload files to this workspace"
+		: "Upload files to this folder";
+	const Icon = isWorkspaceRoot ? Eye : FolderOpen;
+	const title = isWorkspaceRoot ? "This workspace is empty" : "This folder is empty";
+	const description = canUpload
+		? "Click anywhere here to upload files."
+		: isWorkspaceRoot
+			? "An editor needs to add the first items before anything appears here."
+			: "Items added here will appear in this folder.";
+	const emptyState = (
+		<Empty
+			className={cn(
+				"border border-dashed bg-muted/20",
+				canUpload && "transition-colors hover:bg-muted/30",
+			)}
+		>
 			<EmptyHeader>
 				<EmptyMedia variant="icon">
-					<Eye />
+					<Icon />
 				</EmptyMedia>
-				<EmptyTitle>This workspace is empty</EmptyTitle>
-				<EmptyDescription>
-					An editor needs to add the first items before anything appears here.
-				</EmptyDescription>
+				<EmptyTitle>{title}</EmptyTitle>
+				<EmptyDescription>{description}</EmptyDescription>
 			</EmptyHeader>
 		</Empty>
 	);
+
+	if (canUpload) {
+		return (
+			<WorkspaceUploadClickTarget aria-label={uploadLabel} onUploadFiles={onUploadFiles}>
+				{emptyState}
+			</WorkspaceUploadClickTarget>
+		);
+	}
+
+	return emptyState;
 }
 
 function WorkspaceItemGrid({
@@ -445,6 +479,8 @@ function WorkspaceItemView({
 	onRenameItem: (item: WorkspaceItem) => void;
 	onDeleteItem: (item: WorkspaceItem) => void;
 }) {
+	const viewCapabilities = useWorkspaceViewCapabilities();
+
 	if (item.type === "document") {
 		return (
 			<DocumentEditorSurface item={item} toolbarSlotId={viewInstanceId} workspaceId={workspaceId} />
@@ -465,31 +501,33 @@ function WorkspaceItemView({
 	}
 
 	const { Icon: ItemIcon, iconClassName, surfaceClassName } = getWorkspaceItemDisplay(item);
+	const itemViewContent = (
+		<div className="flex flex-col items-center gap-3 text-center">
+			<ItemIcon className={cn("size-12", iconClassName)} strokeWidth={1.75} aria-hidden="true" />
+			<div className="space-y-1">
+				<h2 className="font-medium text-foreground text-sm">{item.name}</h2>
+			</div>
+		</div>
+	);
+	const itemViewSurface = (
+		<section
+			className={cn(
+				"flex h-full min-h-0 items-center justify-center bg-background",
+				surfaceClassName,
+			)}
+		>
+			{itemViewContent}
+		</section>
+	);
+
+	if (!viewCapabilities.contextMenus) {
+		return <div className="h-full min-h-0">{itemViewSurface}</div>;
+	}
 
 	return (
 		<div className="h-full min-h-0">
 			<ContextMenu>
-				<ContextMenuTrigger
-					render={
-						<section
-							className={cn(
-								"flex h-full min-h-0 items-center justify-center bg-background",
-								surfaceClassName,
-							)}
-						/>
-					}
-				>
-					<div className="flex flex-col items-center gap-3 text-center">
-						<ItemIcon
-							className={cn("size-12", iconClassName)}
-							strokeWidth={1.75}
-							aria-hidden="true"
-						/>
-						<div className="space-y-1">
-							<h2 className="font-medium text-foreground text-sm">{item.name}</h2>
-						</div>
-					</div>
-				</ContextMenuTrigger>
+				<ContextMenuTrigger render={itemViewSurface} />
 				<WorkspaceItemActionsContextMenuContent
 					item={item}
 					onMoveItem={onMoveItem}

--- a/src/features/workspaces/components/WorkspaceContent.tsx
+++ b/src/features/workspaces/components/WorkspaceContent.tsx
@@ -353,7 +353,11 @@ function WorkspaceBrowseEmptyState({
 
 	if (canUpload) {
 		return (
-			<WorkspaceUploadClickTarget aria-label={uploadLabel} onUploadFiles={onUploadFiles}>
+			<WorkspaceUploadClickTarget
+				className="flex flex-1"
+				aria-label={uploadLabel}
+				onUploadFiles={onUploadFiles}
+			>
 				{emptyState}
 			</WorkspaceUploadClickTarget>
 		);

--- a/src/features/workspaces/components/WorkspaceFileToolbar.tsx
+++ b/src/features/workspaces/components/WorkspaceFileToolbar.tsx
@@ -18,7 +18,7 @@ export function WorkspaceFileToolbar({
 	fileName,
 	fileUrl,
 }: {
-	capture: {
+	capture?: {
 		isActive: boolean;
 		onToggle: () => void;
 	};
@@ -36,18 +36,20 @@ export function WorkspaceFileToolbar({
 
 	return (
 		<WorkspaceToolbarGroup scrollable>
-			<WorkspaceToolbarTextButton
-				className={cn(
-					capture.isActive
-						? "bg-blue-500/10 text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
-						: undefined,
-				)}
-				aria-pressed={capture.isActive}
-				onClick={capture.onToggle}
-			>
-				<Camera />
-				Capture
-			</WorkspaceToolbarTextButton>
+			{capture ? (
+				<WorkspaceToolbarTextButton
+					className={cn(
+						capture.isActive
+							? "bg-blue-500/10 text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+							: undefined,
+					)}
+					aria-pressed={capture.isActive}
+					onClick={capture.onToggle}
+				>
+					<Camera />
+					Capture
+				</WorkspaceToolbarTextButton>
+			) : null}
 			<DropdownMenu>
 				<DropdownMenuTrigger render={<WorkspaceToolbarIconButton aria-label="More file actions" />}>
 					<EllipsisVertical />

--- a/src/features/workspaces/components/WorkspaceFileViewer.tsx
+++ b/src/features/workspaces/components/WorkspaceFileViewer.tsx
@@ -3,6 +3,7 @@ import { type ComponentType, type LazyExoticComponent, lazy, Suspense } from "re
 import { ContextMenu, ContextMenuTrigger } from "#/components/ui/context-menu";
 import { Spinner } from "#/components/ui/spinner";
 import { WorkspaceItemActionsContextMenuContent } from "#/features/workspaces/components/WorkspaceItemActionsMenu";
+import { useWorkspaceViewCapabilities } from "#/features/workspaces/components/workspace-view-policy";
 import { getWorkspaceItemDisplay } from "#/features/workspaces/model/item-display";
 import type { WorkspaceItem } from "#/features/workspaces/model/types";
 import {
@@ -44,20 +45,26 @@ export default function WorkspaceFileViewer({
 }: WorkspaceFileViewerProps) {
 	const descriptor = resolveWorkspaceFileTypeFromItem(item);
 	const Viewer = descriptor ? workspaceFileViewers[descriptor.assetKind] : null;
+	const viewCapabilities = useWorkspaceViewCapabilities();
+	const viewerContent = Viewer ? (
+		<Suspense fallback={<WorkspaceFileViewerSkeleton />}>
+			<Viewer item={item} toolbarSlotId={toolbarSlotId} workspaceId={workspaceId} />
+		</Suspense>
+	) : (
+		<div className="flex h-full items-center justify-center bg-background">
+			<WorkspaceUnsupportedFilePlaceholder item={item} />
+		</div>
+	);
+
+	if (!viewCapabilities.contextMenus) {
+		return <div className="h-full min-h-0">{viewerContent}</div>;
+	}
 
 	return (
 		<div className="h-full min-h-0">
 			<ContextMenu>
 				<ContextMenuTrigger render={<section className="h-full min-h-0 overflow-hidden" />}>
-					{Viewer ? (
-						<Suspense fallback={<WorkspaceFileViewerSkeleton />}>
-							<Viewer item={item} toolbarSlotId={toolbarSlotId} workspaceId={workspaceId} />
-						</Suspense>
-					) : (
-						<div className="flex h-full items-center justify-center bg-background">
-							<WorkspaceUnsupportedFilePlaceholder item={item} />
-						</div>
-					)}
+					{viewerContent}
 				</ContextMenuTrigger>
 				<WorkspaceItemActionsContextMenuContent
 					item={item}

--- a/src/features/workspaces/components/WorkspaceFileViewer.tsx
+++ b/src/features/workspaces/components/WorkspaceFileViewer.tsx
@@ -57,7 +57,7 @@ export default function WorkspaceFileViewer({
 	);
 
 	if (!viewCapabilities.contextMenus) {
-		return <div className="h-full min-h-0">{viewerContent}</div>;
+		return <div className="h-full min-h-0 overflow-hidden">{viewerContent}</div>;
 	}
 
 	return (

--- a/src/features/workspaces/components/WorkspaceHomePage.tsx
+++ b/src/features/workspaces/components/WorkspaceHomePage.tsx
@@ -87,8 +87,8 @@ function WorkspaceHomeNavbarControls({
 	});
 
 	return (
-		<div className="flex w-full min-w-0 items-center justify-center">
-			<div className="relative w-full min-w-0 max-w-56 sm:max-w-72">
+		<div className="hidden w-full min-w-0 items-center justify-center sm:flex">
+			<div className="relative w-full min-w-0 max-w-72">
 				<Search
 					aria-hidden="true"
 					className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground"
@@ -100,7 +100,7 @@ function WorkspaceHomeNavbarControls({
 					onChange={(event) => onSearchChange(event.currentTarget.value)}
 					placeholder="Search workspaces"
 					aria-label="Search workspaces"
-					className="h-9 bg-background/70 pr-8 pl-8 text-sm shadow-none sm:h-8"
+					className="h-8 bg-background/70 pr-8 pl-8 text-sm shadow-none"
 				/>
 				{searchValue ? (
 					<button

--- a/src/features/workspaces/components/WorkspaceImageViewer.tsx
+++ b/src/features/workspaces/components/WorkspaceImageViewer.tsx
@@ -7,6 +7,7 @@ import {
 } from "#/features/workspaces/components/WorkspaceCaptureChrome";
 import { useFileItemToolbar } from "#/features/workspaces/components/WorkspaceItemToolbarSlot";
 import { WorkspaceImageRegionCaptureOverlay } from "#/features/workspaces/components/WorkspaceRegionCaptureOverlay";
+import { useWorkspaceViewCapabilities } from "#/features/workspaces/components/workspace-view-policy";
 import { renderImageRegionCapture } from "#/features/workspaces/components/workspace-image-capture";
 import { createCaptureAttachmentFile } from "#/features/workspaces/components/workspace-region-capture";
 import { stageCaptureAttachmentToComposerWithFeedback } from "#/features/workspaces/composer/workspace-composer-actions";
@@ -52,16 +53,26 @@ function WorkspaceImageViewerContent({
 	const imageRef = useRef<HTMLImageElement>(null);
 	const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
 	const [isCaptureActive, setIsCaptureActive] = useState(false);
+	const enableFileCapture = useWorkspaceViewCapabilities().fileCapture;
+	const captureActive = enableFileCapture && isCaptureActive;
+	const exitCapture = useCallback(() => {
+		setIsCaptureActive(false);
+	}, []);
+	const toggleCapture = useCallback(() => {
+		setIsCaptureActive((current) => !current);
+	}, []);
 	const { containerRef, contentStyle, deferCaptureSelection } = useWorkspaceImageViewerTransform({
 		enabled: status !== "error",
-		isCaptureActive,
+		isCaptureActive: captureActive,
 	});
 
 	useFileItemToolbar({
-		capture: {
-			isActive: isCaptureActive,
-			onToggle: () => setIsCaptureActive((current) => !current),
-		},
+		capture: enableFileCapture
+			? {
+					isActive: captureActive,
+					onToggle: toggleCapture,
+				}
+			: undefined,
 		fileName: item.name,
 		fileUrl,
 		slotId: toolbarSlotId ?? item.id,
@@ -98,7 +109,7 @@ function WorkspaceImageViewerContent({
 			ref={containerRef}
 			className={cn(
 				"relative h-full min-h-0 overflow-hidden bg-background touch-none",
-				isCaptureActive ? "cursor-crosshair" : "cursor-grab active:cursor-grabbing",
+				captureActive ? "cursor-crosshair" : "cursor-grab active:cursor-grabbing",
 			)}
 		>
 			{status === "loading" ? (
@@ -134,20 +145,24 @@ function WorkspaceImageViewerContent({
 					/>
 				</div>
 			)}
-			{status === "ready" ? (
+			{enableFileCapture && status === "ready" ? (
 				<WorkspaceImageRegionCaptureOverlay
-					active={isCaptureActive}
+					active={captureActive}
 					boundsRef={containerRef}
 					onCapture={handleCapture}
 					deferCaptureSelection={deferCaptureSelection}
 				/>
 			) : null}
-			<WorkspaceCaptureViewerFrame active={isCaptureActive} />
-			<WorkspaceCaptureShortcuts
-				isActive={isCaptureActive}
-				onExit={() => setIsCaptureActive(false)}
-				onToggle={() => setIsCaptureActive((current) => !current)}
-			/>
+			{enableFileCapture ? (
+				<>
+					<WorkspaceCaptureViewerFrame active={captureActive} />
+					<WorkspaceCaptureShortcuts
+						isActive={captureActive}
+						onExit={exitCapture}
+						onToggle={toggleCapture}
+					/>
+				</>
+			) : null}
 		</div>
 	);
 }

--- a/src/features/workspaces/components/WorkspaceItemCard.tsx
+++ b/src/features/workspaces/components/WorkspaceItemCard.tsx
@@ -232,7 +232,7 @@ export default function WorkspaceItemCard({
 					</div>
 				</div>
 			) : null}
-			<CardHeader className="pointer-events-none relative z-10 min-w-0 flex-1 content-center justify-start gap-1 py-2 pr-24 pl-3 sm:flex-none sm:shrink-0 sm:px-3">
+			<CardHeader className="pointer-events-none relative z-10 min-w-0 flex-1 self-center justify-start gap-1 py-2 pr-24 pl-3 sm:flex-none sm:shrink-0 sm:self-auto sm:px-3">
 				<CardTitle className="min-w-0">
 					<WorkspaceItemCardTitle
 						canRename={canMutateContent}

--- a/src/features/workspaces/components/WorkspaceItemCard.tsx
+++ b/src/features/workspaces/components/WorkspaceItemCard.tsx
@@ -12,11 +12,14 @@ import {
 	workspaceItemCardHoverClass,
 	workspaceItemCardSelectedClass,
 	workspaceItemCardUnselectedHoverClass,
+	workspaceItemPreviewControlsLayerClass,
 } from "#/features/workspaces/components/workspace-item-card-chrome";
 import { WorkspaceItemCardFooter } from "#/features/workspaces/components/workspace-item-card-footer";
+import { WorkspaceItemCardPreviewControls } from "#/features/workspaces/components/workspace-item-card-preview-controls";
 import { WorkspaceItemCardPreviewStage } from "#/features/workspaces/components/workspace-item-card-preview-stage";
 import { useWorkspaceMutationAccess } from "#/features/workspaces/components/workspace-mutation-access";
 import { workspaceItemSortablePlugins } from "#/features/workspaces/components/workspace-sortable-plugins";
+import { useWorkspaceViewCapabilities } from "#/features/workspaces/components/workspace-view-policy";
 import {
 	createWorkspaceItemDragData,
 	getWorkspaceDragSource,
@@ -58,6 +61,7 @@ export default function WorkspaceItemCard({
 	onElementChange,
 }: WorkspaceItemCardProps) {
 	const { capabilities, itemSortableDisabled } = useWorkspaceMutationAccess();
+	const viewCapabilities = useWorkspaceViewCapabilities();
 	const { canMutateContent } = capabilities;
 	const isFolder = item.type === "folder";
 	const row = isFolder ? "folder" : "item";
@@ -206,14 +210,17 @@ export default function WorkspaceItemCard({
 				aria-label={`Open ${item.name}`}
 				onClick={handleOpen}
 			/>
-			<WorkspaceItemCardPreviewStage
-				item={item}
-				isSelected={isSelected}
-				onSelectionChange={onSelectionChange}
-				onMoveItem={onMoveItem}
-				onRenameItem={onRenameItem}
-				onDeleteItem={onDeleteItem}
-			/>
+			<WorkspaceItemCardPreviewStage item={item} />
+			<div className={workspaceItemPreviewControlsLayerClass}>
+				<WorkspaceItemCardPreviewControls
+					item={item}
+					isSelected={isSelected}
+					onSelectionChange={onSelectionChange}
+					onMoveItem={onMoveItem}
+					onRenameItem={onRenameItem}
+					onDeleteItem={onDeleteItem}
+				/>
+			</div>
 			{showFolderDropAffordance ? (
 				<div
 					className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center bg-background/35 backdrop-blur-[1px]"
@@ -225,20 +232,13 @@ export default function WorkspaceItemCard({
 					</div>
 				</div>
 			) : null}
-			<CardHeader className="pointer-events-none relative z-10 shrink-0 gap-1 px-3 py-2">
+			<CardHeader className="pointer-events-none relative z-10 min-w-0 flex-1 content-center justify-start gap-1 py-2 pr-24 pl-3 sm:flex-none sm:shrink-0 sm:px-3">
 				<CardTitle className="min-w-0">
-					{canMutateContent ? (
-						<button
-							type="button"
-							className="pointer-events-auto relative z-20 block max-w-full cursor-text truncate rounded-sm text-left underline-offset-4 outline-none transition-colors hover:text-foreground hover:underline focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-							aria-label={`Rename ${item.name}`}
-							onClick={handleRenameClick}
-						>
-							{item.name}
-						</button>
-					) : (
-						<span className="relative z-20 block max-w-full truncate">{item.name}</span>
-					)}
+					<WorkspaceItemCardTitle
+						canRename={canMutateContent}
+						itemName={item.name}
+						onRenameClick={handleRenameClick}
+					/>
 				</CardTitle>
 				{isFolder ? (
 					meta ? (
@@ -251,6 +251,10 @@ export default function WorkspaceItemCard({
 		</Card>
 	);
 
+	if (!viewCapabilities.contextMenus) {
+		return card;
+	}
+
 	return (
 		<ContextMenu>
 			<ContextMenuTrigger render={card} />
@@ -261,5 +265,33 @@ export default function WorkspaceItemCard({
 				onDeleteItem={onDeleteItem}
 			/>
 		</ContextMenu>
+	);
+}
+
+function WorkspaceItemCardTitle({
+	canRename,
+	itemName,
+	onRenameClick,
+}: {
+	canRename: boolean;
+	itemName: string;
+	onRenameClick: (event: MouseEvent<HTMLButtonElement>) => void;
+}) {
+	if (!canRename) {
+		return <span className="relative z-20 block max-w-full truncate">{itemName}</span>;
+	}
+
+	return (
+		<>
+			<span className="relative z-20 block max-w-full truncate sm:hidden">{itemName}</span>
+			<button
+				type="button"
+				className="pointer-events-auto relative z-20 hidden max-w-full cursor-text truncate rounded-sm text-left underline-offset-4 outline-none transition-colors hover:text-foreground hover:underline focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:block"
+				aria-label={`Rename ${itemName}`}
+				onClick={onRenameClick}
+			>
+				{itemName}
+			</button>
+		</>
 	);
 }

--- a/src/features/workspaces/components/WorkspaceItemPreviewSurface.tsx
+++ b/src/features/workspaces/components/WorkspaceItemPreviewSurface.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 
 import {
 	workspaceItemDocumentPreviewPanelClass,
@@ -32,17 +32,18 @@ export default function WorkspaceItemPreviewSurface({ item }: WorkspaceItemPrevi
 
 function WorkspaceItemDocumentPreview({ item }: { item: WorkspaceItem }) {
 	const previewText = getWorkspaceDocumentPreviewText(item);
+	const desktopPreview = previewText ? (
+		<div className={workspaceItemDocumentPreviewPanelClass}>
+			<p className={workspaceItemDocumentPreviewTextClass}>{previewText}</p>
+		</div>
+	) : (
+		<WorkspaceItemDocumentPreviewEmpty />
+	);
 
 	return (
-		<div className={workspaceItemPreviewContentLayerClass}>
-			{previewText ? (
-				<div className={workspaceItemDocumentPreviewPanelClass}>
-					<p className={workspaceItemDocumentPreviewTextClass}>{previewText}</p>
-				</div>
-			) : (
-				<WorkspaceItemDocumentPreviewEmpty />
-			)}
-		</div>
+		<WorkspaceItemMobileIconDesktopPreview item={item}>
+			{desktopPreview}
+		</WorkspaceItemMobileIconDesktopPreview>
 	);
 }
 
@@ -65,7 +66,7 @@ function WorkspaceItemFilePreview({ item }: { item: WorkspaceItem }) {
 
 	if (showImage) {
 		return (
-			<div className={workspaceItemPreviewContentLayerClass}>
+			<WorkspaceItemMobileIconDesktopPreview item={item}>
 				<img
 					src={previewUrl ?? undefined}
 					alt=""
@@ -74,11 +75,28 @@ function WorkspaceItemFilePreview({ item }: { item: WorkspaceItem }) {
 					className="size-full object-cover object-top"
 					onError={() => setFailedPreviewUrl(previewUrl)}
 				/>
-			</div>
+			</WorkspaceItemMobileIconDesktopPreview>
 		);
 	}
 
 	return <WorkspaceItemIconPreview item={item} />;
+}
+
+function WorkspaceItemMobileIconDesktopPreview({
+	children,
+	item,
+}: {
+	children: ReactNode;
+	item: WorkspaceItem;
+}) {
+	return (
+		<>
+			<div className={cn(workspaceItemPreviewContentLayerClass, "sm:hidden")}>
+				<WorkspaceItemIconPreview item={item} />
+			</div>
+			<div className={cn(workspaceItemPreviewContentLayerClass, "hidden sm:block")}>{children}</div>
+		</>
+	);
 }
 
 /** Icon-only preview for folders and types without a custom thumbnail yet. */

--- a/src/features/workspaces/components/WorkspaceItemToolbarSlot.tsx
+++ b/src/features/workspaces/components/WorkspaceItemToolbarSlot.tsx
@@ -20,7 +20,7 @@ type WorkspaceItemToolbarRegistration =
 			slotId: string;
 	  }
 	| {
-			capture: {
+			capture?: {
 				isActive: boolean;
 				onToggle: () => void;
 			};
@@ -96,7 +96,7 @@ export function useFileItemToolbar({
 	fileUrl,
 	slotId,
 }: {
-	capture: {
+	capture?: {
 		isActive: boolean;
 		onToggle: () => void;
 	};
@@ -106,14 +106,22 @@ export function useFileItemToolbar({
 }) {
 	const context = use(WorkspaceItemToolbarContext);
 	const setRegistration = context?.setRegistration;
+	const captureIsActive = capture?.isActive;
+	const captureOnToggle = capture?.onToggle;
 
 	useEffect(() => {
 		if (!setRegistration) {
 			return;
 		}
 
+		const registeredCapture = captureOnToggle
+			? {
+					isActive: Boolean(captureIsActive),
+					onToggle: captureOnToggle,
+				}
+			: undefined;
 		const registration = {
-			capture,
+			capture: registeredCapture,
 			fileName,
 			fileUrl,
 			kind: "file" as const,
@@ -125,7 +133,8 @@ export function useFileItemToolbar({
 				existing?.kind === "file" &&
 				existing.fileName === fileName &&
 				existing.fileUrl === fileUrl &&
-				existing.capture.isActive === capture.isActive
+				existing.capture?.isActive === registeredCapture?.isActive &&
+				existing.capture?.onToggle === registeredCapture?.onToggle
 			) {
 				return current;
 			}
@@ -148,7 +157,7 @@ export function useFileItemToolbar({
 				return next;
 			});
 		};
-	}, [capture, fileName, fileUrl, slotId, setRegistration]);
+	}, [captureIsActive, captureOnToggle, fileName, fileUrl, slotId, setRegistration]);
 }
 
 export function WorkspaceItemToolbarSlot({

--- a/src/features/workspaces/components/WorkspaceLayout.tsx
+++ b/src/features/workspaces/components/WorkspaceLayout.tsx
@@ -9,6 +9,7 @@ import WorkspaceDragProvider from "#/features/workspaces/components/WorkspaceDra
 import { WorkspaceFileIntakeProvider } from "#/features/workspaces/components/WorkspaceFileIntakeProvider";
 import { WorkspaceFileUploadProvider } from "#/features/workspaces/components/WorkspaceFileUploadProvider";
 import { WorkspaceItemToolbarProvider } from "#/features/workspaces/components/WorkspaceItemToolbarSlot";
+import WorkspaceMobileLayout from "#/features/workspaces/components/WorkspaceMobileLayout";
 import WorkspacePaneRenderer from "#/features/workspaces/components/WorkspacePaneRenderer";
 import { WorkspacePdfEngineProvider } from "#/features/workspaces/components/WorkspacePdfEngineProvider";
 import { WorkspaceMaximizedPresentation } from "#/features/workspaces/components/WorkspacePresentation";
@@ -17,6 +18,10 @@ import WorkspaceSplitPresentation from "#/features/workspaces/components/Workspa
 import WorkspaceStandardTabPanes from "#/features/workspaces/components/WorkspaceStandardTabPanes";
 import WorkspaceTopBar from "#/features/workspaces/components/WorkspaceTopBar";
 import { WorkspaceMutationAccessProvider } from "#/features/workspaces/components/workspace-mutation-access";
+import {
+	useWorkspaceViewPolicy,
+	WorkspaceViewCapabilitiesProvider,
+} from "#/features/workspaces/components/workspace-view-policy";
 import type { WorkspaceItemType, WorkspaceSummary } from "#/features/workspaces/contracts";
 import type { WorkspaceItem } from "#/features/workspaces/model/types";
 import { isWorkspaceItemView } from "#/features/workspaces/model/view";
@@ -111,6 +116,7 @@ export function WorkspaceShell({
 		activeViewFromUrl,
 	});
 	const normalizedUiSession = useWorkspaceUiSession(workspace.id);
+	const { capabilities: viewCapabilities, viewportMode } = useWorkspaceViewPolicy();
 	const selectedItemIds = useWorkspaceSelectionItemIds(workspace.id);
 	const { chatSurfaceMode, presentation } = normalizedUiSession;
 	const hasHeavyViewerRuntimeItems = scopedItems.some(workspaceItemRequiresHeavyViewerRuntime);
@@ -175,8 +181,44 @@ export function WorkspaceShell({
 		workspaceName: workspace.name,
 	};
 
+	const contextBar = (
+		<WorkspaceContextBar
+			workspace={workspace}
+			activeItem={activeItem}
+			itemsById={itemsById}
+			toolbarSlotId={activeTab.id}
+			onCreateItem={createWorkspaceItem}
+			onCloseItemView={isWorkspaceItemView(activeItem) ? closeItemView : undefined}
+			onNavigateToRoot={openWorkspaceRoot}
+			onNavigateToItem={openItem}
+		/>
+	);
+	const standardTabPanes = (
+		<WorkspaceStandardTabPanes
+			activeTabId={activeTab.id}
+			itemsById={itemsById}
+			scopedItems={scopedItems}
+			tabs={session.tabs}
+			workspace={workspace}
+			onCloseItemView={closeItemView}
+			onCreateItem={createWorkspaceItem}
+			onOpenItem={openItem}
+		/>
+	);
+
 	const presentationContent =
-		presentation.mode === "maximized" ? (
+		viewportMode === "mobile" ? (
+			<WorkspaceItemToolbarProvider>
+				<WorkspaceMobileLayout
+					workspace={workspace}
+					contextBar={contextBar}
+					content={standardTabPanes}
+					chatSurfaceMode={chatSurfaceMode}
+					onOpenChat={() => setChatSurfaceMode(workspace.id, "fullscreen")}
+					chatPanel={<AiChatPanel context={aiContextScope} />}
+				/>
+			</WorkspaceItemToolbarProvider>
+		) : presentation.mode === "maximized" ? (
 			<WorkspaceMaximizedPresentation>
 				<WorkspacePaneRenderer
 					aiContextScope={aiContextScope}
@@ -198,18 +240,7 @@ export function WorkspaceShell({
 							itemsById={itemsById}
 							tabs={session.tabs}
 							activeTab={activeTab}
-							contextBar={
-								<WorkspaceContextBar
-									workspace={workspace}
-									activeItem={activeItem}
-									itemsById={itemsById}
-									toolbarSlotId={activeTab.id}
-									onCreateItem={createWorkspaceItem}
-									onCloseItemView={isWorkspaceItemView(activeItem) ? closeItemView : undefined}
-									onNavigateToRoot={openWorkspaceRoot}
-									onNavigateToItem={openItem}
-								/>
-							}
+							contextBar={contextBar}
 							presence={realtime}
 							onActivateTab={activateWorkspaceTab}
 							onCloseTab={closeWorkspaceTab}
@@ -232,16 +263,7 @@ export function WorkspaceShell({
 								onOpenItem={openItem}
 							/>
 						) : (
-							<WorkspaceStandardTabPanes
-								activeTabId={activeTab.id}
-								itemsById={itemsById}
-								scopedItems={scopedItems}
-								tabs={session.tabs}
-								workspace={workspace}
-								onCloseItemView={closeItemView}
-								onCreateItem={createWorkspaceItem}
-								onOpenItem={openItem}
-							/>
+							standardTabPanes
 						)
 					}
 					chatPanel={<AiChatPanel context={aiContextScope} />}
@@ -258,7 +280,9 @@ export function WorkspaceShell({
 					onMoveItems={moveWorkspaceItemsMutation.mutate}
 					onWorkspaceDragCommand={dispatchWorkspaceDragCommand}
 				>
-					{presentationContent}
+					<WorkspaceViewCapabilitiesProvider capabilities={viewCapabilities}>
+						{presentationContent}
+					</WorkspaceViewCapabilitiesProvider>
 				</WorkspaceDragProvider>
 			</WorkspaceFileIntakeProvider>
 		</WorkspaceFileUploadProvider>

--- a/src/features/workspaces/components/WorkspaceLayout.tsx
+++ b/src/features/workspaces/components/WorkspaceLayout.tsx
@@ -119,6 +119,7 @@ export function WorkspaceShell({
 	const { capabilities: viewCapabilities, viewportMode } = useWorkspaceViewPolicy();
 	const selectedItemIds = useWorkspaceSelectionItemIds(workspace.id);
 	const { chatSurfaceMode, presentation } = normalizedUiSession;
+	const mobileChatSurfaceMode = chatSurfaceMode === "docked" ? "hidden" : chatSurfaceMode;
 	const hasHeavyViewerRuntimeItems = scopedItems.some(workspaceItemRequiresHeavyViewerRuntime);
 	const createWorkspaceItem = (input: { type: WorkspaceItemType; parentId: string | null }) => {
 		if (!getWorkspaceMemberCapabilities(workspace.membershipRole).canMutateContent) {
@@ -213,7 +214,7 @@ export function WorkspaceShell({
 					workspace={workspace}
 					contextBar={contextBar}
 					content={standardTabPanes}
-					chatSurfaceMode={chatSurfaceMode}
+					chatSurfaceMode={mobileChatSurfaceMode}
 					onOpenChat={() => setChatSurfaceMode(workspace.id, "fullscreen")}
 					chatPanel={<AiChatPanel context={aiContextScope} />}
 				/>

--- a/src/features/workspaces/components/WorkspaceMobileLayout.tsx
+++ b/src/features/workspaces/components/WorkspaceMobileLayout.tsx
@@ -1,0 +1,91 @@
+import { Link } from "@tanstack/react-router";
+import { MessageSquare, Share2 } from "lucide-react";
+import { type ReactElement, type ReactNode, useState } from "react";
+
+import ThinkExLogo from "#/components/ThinkExLogo";
+import UserProfileDropdown from "#/components/UserProfileDropdown";
+import WorkspaceFrame from "#/features/workspaces/components/WorkspaceFrame";
+import { WorkspaceShareDialog } from "#/features/workspaces/components/WorkspaceShareDialog";
+import {
+	WorkspaceToolbarIconButton,
+	WorkspaceToolbarTextButton,
+} from "#/features/workspaces/components/WorkspaceToolbar";
+import type { WorkspaceSummary } from "#/features/workspaces/contracts";
+import type { WorkspaceAiChatSurfaceMode } from "#/features/workspaces/state/workspace-ui-store";
+
+interface WorkspaceMobileLayoutProps {
+	workspace: WorkspaceSummary;
+	contextBar: ReactNode;
+	content: ReactNode;
+	chatPanel?: ReactElement;
+	chatSurfaceMode: WorkspaceAiChatSurfaceMode;
+	onOpenChat: () => void;
+}
+
+export default function WorkspaceMobileLayout({
+	workspace,
+	contextBar,
+	content,
+	chatPanel,
+	chatSurfaceMode,
+	onOpenChat,
+}: WorkspaceMobileLayoutProps) {
+	const [shareOpen, setShareOpen] = useState(false);
+	const isChatOpen = chatSurfaceMode !== "hidden";
+
+	return (
+		<div data-app-shell className="h-dvh overflow-hidden bg-background text-foreground">
+			<WorkspaceFrame
+				chrome={
+					<header className="sticky top-0 z-40 bg-muted">
+						<div className="flex h-12 w-full items-stretch justify-between gap-3 px-4">
+							<Link
+								to="/home"
+								className="flex shrink-0 items-center rounded-md text-foreground no-underline outline-none focus-visible:ring-2 focus-visible:ring-ring"
+								aria-label="Back to workspaces"
+							>
+								<ThinkExLogo size={28} />
+							</Link>
+
+							<nav
+								className="flex shrink-0 items-center gap-2"
+								aria-label="Workspace mobile actions"
+							>
+								<WorkspaceToolbarIconButton
+									aria-label="Share workspace"
+									onClick={() => setShareOpen(true)}
+								>
+									<Share2 />
+								</WorkspaceToolbarIconButton>
+								<UserProfileDropdown />
+								{!isChatOpen ? (
+									<WorkspaceToolbarTextButton
+										variant="outline"
+										className="border-border bg-background shadow-xs hover:bg-muted"
+										onClick={onOpenChat}
+									>
+										<MessageSquare />
+										<span>Chat</span>
+									</WorkspaceToolbarTextButton>
+								) : null}
+							</nav>
+						</div>
+						{contextBar}
+						<WorkspaceShareDialog
+							membershipRole={workspace.membershipRole}
+							onOpenChange={setShareOpen}
+							open={shareOpen}
+							workspaceId={workspace.id}
+							workspaceName={workspace.name}
+						/>
+					</header>
+				}
+				content={content}
+			/>
+
+			{chatPanel && isChatOpen ? (
+				<div className="fixed inset-0 z-50 h-dvh w-dvw bg-background">{chatPanel}</div>
+			) : null}
+		</div>
+	);
+}

--- a/src/features/workspaces/components/WorkspaceMobileLayout.tsx
+++ b/src/features/workspaces/components/WorkspaceMobileLayout.tsx
@@ -71,16 +71,16 @@ export default function WorkspaceMobileLayout({
 							</nav>
 						</div>
 						{contextBar}
-						<WorkspaceShareDialog
-							membershipRole={workspace.membershipRole}
-							onOpenChange={setShareOpen}
-							open={shareOpen}
-							workspaceId={workspace.id}
-							workspaceName={workspace.name}
-						/>
 					</header>
 				}
 				content={content}
+			/>
+			<WorkspaceShareDialog
+				membershipRole={workspace.membershipRole}
+				onOpenChange={setShareOpen}
+				open={shareOpen}
+				workspaceId={workspace.id}
+				workspaceName={workspace.name}
 			/>
 
 			{chatPanel && isChatOpen ? (

--- a/src/features/workspaces/components/WorkspacePdfViewer.tsx
+++ b/src/features/workspaces/components/WorkspacePdfViewer.tsx
@@ -37,7 +37,7 @@ import {
 import { TilingLayer, TilingPluginPackage } from "@embedpdf/plugin-tiling/react";
 import { Viewport, ViewportPluginPackage } from "@embedpdf/plugin-viewport/react";
 import { ZoomGestureWrapper, ZoomMode, ZoomPluginPackage } from "@embedpdf/plugin-zoom/react";
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { Spinner } from "#/components/ui/spinner";
 import {
 	WorkspaceCaptureShortcuts,
@@ -52,6 +52,7 @@ import {
 	type WorkspacePdfCaptureResult,
 } from "#/features/workspaces/components/WorkspacePdfCapture";
 import { WorkspacePdfPageControl } from "#/features/workspaces/components/WorkspacePdfPageControl";
+import { useWorkspaceViewCapabilities } from "#/features/workspaces/components/workspace-view-policy";
 import { createCaptureAttachmentFile } from "#/features/workspaces/components/workspace-region-capture";
 import { stageCaptureAttachmentToComposerWithFeedback } from "#/features/workspaces/composer/workspace-composer-actions";
 import type { WorkspaceItem } from "#/features/workspaces/model/types";
@@ -105,12 +106,22 @@ export default function WorkspacePdfViewer({
 	const fileUrl = getWorkspaceFileContentUrl(workspaceId, item.id);
 	const { engine, error, isLoading } = useEngineContext();
 	const [isCaptureActive, setIsCaptureActive] = useState(false);
+	const enableFileCapture = useWorkspaceViewCapabilities().fileCapture;
+	const captureActive = enableFileCapture && isCaptureActive;
+	const exitCapture = useCallback(() => {
+		setIsCaptureActive(false);
+	}, []);
+	const toggleCapture = useCallback(() => {
+		setIsCaptureActive((current) => !current);
+	}, []);
 
 	useFileItemToolbar({
-		capture: {
-			isActive: isCaptureActive,
-			onToggle: () => setIsCaptureActive((current) => !current),
-		},
+		capture: enableFileCapture
+			? {
+					isActive: captureActive,
+					onToggle: toggleCapture,
+				}
+			: undefined,
 		fileName: item.name,
 		fileUrl,
 		slotId: toolbarSlotId ?? item.id,
@@ -133,10 +144,11 @@ export default function WorkspacePdfViewer({
 								documentId={item.id}
 								fileName={item.name}
 								fileUrl={fileUrl}
-								isCaptureActive={isCaptureActive}
+								isCaptureActive={captureActive}
 								itemId={item.id}
-								onCaptureModeExit={() => setIsCaptureActive(false)}
-								onCaptureModeToggle={() => setIsCaptureActive((current) => !current)}
+								onCaptureModeExit={exitCapture}
+								onCaptureModeToggle={toggleCapture}
+								enableFileCapture={enableFileCapture}
 								workspaceId={workspaceId}
 							/>
 						) : (
@@ -145,7 +157,7 @@ export default function WorkspacePdfViewer({
 					}
 				</EmbedPDF>
 			)}
-			<WorkspaceCaptureViewerFrame active={isCaptureActive} />
+			{enableFileCapture ? <WorkspaceCaptureViewerFrame active={captureActive} /> : null}
 		</div>
 	);
 }
@@ -153,6 +165,7 @@ export default function WorkspacePdfViewer({
 function WorkspacePdfDocumentLoader({
 	activeDocumentId,
 	documentId,
+	enableFileCapture,
 	fileName,
 	fileUrl,
 	isCaptureActive,
@@ -163,6 +176,7 @@ function WorkspacePdfDocumentLoader({
 }: {
 	activeDocumentId: string | null;
 	documentId: string;
+	enableFileCapture: boolean;
 	fileName: string;
 	fileUrl: string;
 	isCaptureActive: boolean;
@@ -245,6 +259,7 @@ function WorkspacePdfDocumentLoader({
 					itemId={itemId}
 					onCaptureModeExit={onCaptureModeExit}
 					onCaptureModeToggle={onCaptureModeToggle}
+					enableFileCapture={enableFileCapture}
 					workspaceId={workspaceId}
 					{...props}
 				/>
@@ -256,6 +271,7 @@ function WorkspacePdfDocumentLoader({
 function WorkspacePdfDocumentContent({
 	documentId,
 	documentState,
+	enableFileCapture,
 	fileName,
 	fileUrl,
 	isCaptureActive,
@@ -269,6 +285,7 @@ function WorkspacePdfDocumentContent({
 }: {
 	documentId: string;
 	documentState: DocumentState;
+	enableFileCapture: boolean;
 	fileName: string;
 	fileUrl: string;
 	isCaptureActive: boolean;
@@ -318,12 +335,16 @@ function WorkspacePdfDocumentContent({
 				workspaceId={workspaceId}
 			/>
 			<WorkspacePdfSelectionShortcuts documentId={documentId} />
-			<WorkspaceCaptureShortcuts
-				isActive={isCaptureActive}
-				onExit={onCaptureModeExit}
-				onToggle={onCaptureModeToggle}
-			/>
-			<WorkspacePdfCaptureInteractionMode documentId={documentId} isActive={isCaptureActive} />
+			{enableFileCapture ? (
+				<>
+					<WorkspaceCaptureShortcuts
+						isActive={isCaptureActive}
+						onExit={onCaptureModeExit}
+						onToggle={onCaptureModeToggle}
+					/>
+					<WorkspacePdfCaptureInteractionMode documentId={documentId} isActive={isCaptureActive} />
+				</>
+			) : null}
 			<ZoomGestureWrapper
 				className="min-h-full"
 				documentId={documentId}
@@ -345,6 +366,7 @@ function WorkspacePdfDocumentContent({
 							pageLayout={pageLayout}
 							renderCapability={renderCapability}
 							selectionPoint={selectionPoint}
+							enableFileCapture={enableFileCapture}
 							workspaceId={workspaceId}
 						/>
 					)}
@@ -358,6 +380,7 @@ function WorkspacePdfDocumentContent({
 function WorkspacePdfPage({
 	documentId,
 	documentState,
+	enableFileCapture,
 	isCaptureActive,
 	itemId,
 	onCapture,
@@ -368,6 +391,7 @@ function WorkspacePdfPage({
 }: {
 	documentId: string;
 	documentState: DocumentState;
+	enableFileCapture: boolean;
 	isCaptureActive: boolean;
 	itemId: string;
 	onCapture: (capture: WorkspacePdfCaptureResult) => void;
@@ -416,7 +440,7 @@ function WorkspacePdfPage({
 							documentId={documentId}
 							pageIndex={pageLayout.pageIndex}
 						/>
-						{page ? (
+						{enableFileCapture && page ? (
 							<WorkspacePdfCapturePageOverlay
 								active={isCaptureActive}
 								documentState={documentState}

--- a/src/features/workspaces/components/WorkspacePdfViewer.tsx
+++ b/src/features/workspaces/components/WorkspacePdfViewer.tsx
@@ -106,7 +106,9 @@ export default function WorkspacePdfViewer({
 	const fileUrl = getWorkspaceFileContentUrl(workspaceId, item.id);
 	const { engine, error, isLoading } = useEngineContext();
 	const [isCaptureActive, setIsCaptureActive] = useState(false);
-	const enableFileCapture = useWorkspaceViewCapabilities().fileCapture;
+	const viewCapabilities = useWorkspaceViewCapabilities();
+	const enableFileCapture = viewCapabilities.fileCapture;
+	const enableSelectionMenu = viewCapabilities.contextMenus;
 	const captureActive = enableFileCapture && isCaptureActive;
 	const exitCapture = useCallback(() => {
 		setIsCaptureActive(false);
@@ -149,6 +151,7 @@ export default function WorkspacePdfViewer({
 								onCaptureModeExit={exitCapture}
 								onCaptureModeToggle={toggleCapture}
 								enableFileCapture={enableFileCapture}
+								enableSelectionMenu={enableSelectionMenu}
 								workspaceId={workspaceId}
 							/>
 						) : (
@@ -166,6 +169,7 @@ function WorkspacePdfDocumentLoader({
 	activeDocumentId,
 	documentId,
 	enableFileCapture,
+	enableSelectionMenu,
 	fileName,
 	fileUrl,
 	isCaptureActive,
@@ -177,6 +181,7 @@ function WorkspacePdfDocumentLoader({
 	activeDocumentId: string | null;
 	documentId: string;
 	enableFileCapture: boolean;
+	enableSelectionMenu: boolean;
 	fileName: string;
 	fileUrl: string;
 	isCaptureActive: boolean;
@@ -260,6 +265,7 @@ function WorkspacePdfDocumentLoader({
 					onCaptureModeExit={onCaptureModeExit}
 					onCaptureModeToggle={onCaptureModeToggle}
 					enableFileCapture={enableFileCapture}
+					enableSelectionMenu={enableSelectionMenu}
 					workspaceId={workspaceId}
 					{...props}
 				/>
@@ -272,6 +278,7 @@ function WorkspacePdfDocumentContent({
 	documentId,
 	documentState,
 	enableFileCapture,
+	enableSelectionMenu,
 	fileName,
 	fileUrl,
 	isCaptureActive,
@@ -286,6 +293,7 @@ function WorkspacePdfDocumentContent({
 	documentId: string;
 	documentState: DocumentState;
 	enableFileCapture: boolean;
+	enableSelectionMenu: boolean;
 	fileName: string;
 	fileUrl: string;
 	isCaptureActive: boolean;
@@ -367,6 +375,7 @@ function WorkspacePdfDocumentContent({
 							renderCapability={renderCapability}
 							selectionPoint={selectionPoint}
 							enableFileCapture={enableFileCapture}
+							enableSelectionMenu={enableSelectionMenu}
 							workspaceId={workspaceId}
 						/>
 					)}
@@ -381,6 +390,7 @@ function WorkspacePdfPage({
 	documentId,
 	documentState,
 	enableFileCapture,
+	enableSelectionMenu,
 	isCaptureActive,
 	itemId,
 	onCapture,
@@ -392,6 +402,7 @@ function WorkspacePdfPage({
 	documentId: string;
 	documentState: DocumentState;
 	enableFileCapture: boolean;
+	enableSelectionMenu: boolean;
 	isCaptureActive: boolean;
 	itemId: string;
 	onCapture: (capture: WorkspacePdfCaptureResult) => void;
@@ -422,15 +433,19 @@ function WorkspacePdfPage({
 						<SelectionLayer
 							documentId={documentId}
 							pageIndex={pageLayout.pageIndex}
-							selectionMenu={(props) => (
-								<WorkspacePdfAskSelectionMenu
-									{...props}
-									documentId={documentId}
-									itemId={itemId}
-									selectionPoint={selectionPoint}
-									workspaceId={workspaceId}
-								/>
-							)}
+							selectionMenu={
+								enableSelectionMenu
+									? (props) => (
+											<WorkspacePdfAskSelectionMenu
+												{...props}
+												documentId={documentId}
+												itemId={itemId}
+												selectionPoint={selectionPoint}
+												workspaceId={workspaceId}
+											/>
+										)
+									: undefined
+							}
 							textStyle={{
 								background: "var(--selection)",
 							}}

--- a/src/features/workspaces/components/WorkspaceRootEmptyPreview.tsx
+++ b/src/features/workspaces/components/WorkspaceRootEmptyPreview.tsx
@@ -9,6 +9,7 @@ import {
 	EmptyTitle,
 } from "#/components/ui/empty";
 import { WorkspaceCardMetaRow } from "#/features/workspaces/components/workspace-card-meta-row";
+import { WorkspaceUploadClickTarget } from "#/features/workspaces/components/WorkspaceUploadClickTarget";
 import {
 	workspaceItemCardBaseClass,
 	workspaceItemDocumentPreviewPanelClass,
@@ -88,13 +89,17 @@ type WorkspaceRootEmptyDemoCard =
 	| (typeof workspaceRootEmptyDemoFolders)[number]
 	| (typeof workspaceRootEmptyDemoItems)[number];
 
-export function WorkspaceRootEmptyPreview() {
+export function WorkspaceRootEmptyPreview({ onUploadFiles }: { onUploadFiles: () => void }) {
 	return (
 		<div className="relative min-h-[24rem] flex-1 opacity-90">
 			<WorkspaceRootEmptyDemoGrid />
-			<div className="pointer-events-none absolute inset-0 z-10 flex">
+			<WorkspaceUploadClickTarget
+				className="absolute inset-0 z-10 flex"
+				aria-label="Upload files to this workspace"
+				onUploadFiles={onUploadFiles}
+			>
 				<WorkspaceRootDropEmptyState />
-			</div>
+			</WorkspaceUploadClickTarget>
 		</div>
 	);
 }
@@ -107,7 +112,7 @@ function WorkspaceRootDropEmptyState() {
 					<WorkspaceRootEmptyMedia />
 				</EmptyMedia>
 				<EmptyTitle>Drop your files here</EmptyTitle>
-				<EmptyDescription>Or click New to get started</EmptyDescription>
+				<EmptyDescription>Click anywhere here to upload files</EmptyDescription>
 			</EmptyHeader>
 		</Empty>
 	);

--- a/src/features/workspaces/components/WorkspaceUploadClickTarget.tsx
+++ b/src/features/workspaces/components/WorkspaceUploadClickTarget.tsx
@@ -1,0 +1,42 @@
+import type { KeyboardEvent, ReactNode } from "react";
+
+import { cn } from "#/lib/utils";
+
+interface WorkspaceUploadClickTargetProps {
+	"aria-label": string;
+	children: ReactNode;
+	className?: string;
+	onUploadFiles: () => void;
+}
+
+export function WorkspaceUploadClickTarget({
+	"aria-label": ariaLabel,
+	children,
+	className,
+	onUploadFiles,
+}: WorkspaceUploadClickTargetProps) {
+	const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+		if (event.key !== "Enter" && event.key !== " ") {
+			return;
+		}
+
+		event.preventDefault();
+		onUploadFiles();
+	};
+
+	return (
+		<div
+			role="button"
+			tabIndex={0}
+			className={cn(
+				"cursor-pointer rounded-lg outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+				className,
+			)}
+			aria-label={ariaLabel}
+			onClick={onUploadFiles}
+			onKeyDown={handleKeyDown}
+		>
+			{children}
+		</div>
+	);
+}

--- a/src/features/workspaces/components/WorkspaceUploadClickTarget.tsx
+++ b/src/features/workspaces/components/WorkspaceUploadClickTarget.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEvent, ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import { cn } from "#/lib/utils";
 
@@ -15,28 +15,15 @@ export function WorkspaceUploadClickTarget({
 	className,
 	onUploadFiles,
 }: WorkspaceUploadClickTargetProps) {
-	const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-		if (event.key !== "Enter" && event.key !== " ") {
-			return;
-		}
-
-		event.preventDefault();
-		onUploadFiles();
-	};
-
 	return (
-		<div
-			role="button"
-			tabIndex={0}
-			className={cn(
-				"cursor-pointer rounded-lg outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
-				className,
-			)}
-			aria-label={ariaLabel}
-			onClick={onUploadFiles}
-			onKeyDown={handleKeyDown}
-		>
-			{children}
+		<div className={cn("relative rounded-lg", className)}>
+			<button
+				type="button"
+				className="absolute inset-0 z-10 cursor-pointer rounded-lg bg-transparent p-0 text-left text-inherit outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+				aria-label={ariaLabel}
+				onClick={onUploadFiles}
+			/>
+			<div className="pointer-events-none relative z-0 flex min-h-0 flex-1">{children}</div>
 		</div>
 	);
 }

--- a/src/features/workspaces/components/ai-chat/AiChatPanelToolbar.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatPanelToolbar.tsx
@@ -142,6 +142,7 @@ export default function AiChatPanelToolbar({
 
 					<WorkspaceToolbarIconButton
 						aria-label={isMaximized ? "Restore AI chat" : "Maximize AI chat"}
+						className="hidden sm:inline-flex"
 						onClick={isMaximized ? onRestore : onMaximize}
 					>
 						{isMaximized ? <Minimize2 /> : <Maximize2 />}

--- a/src/features/workspaces/components/workspace-item-card-chrome.ts
+++ b/src/features/workspaces/components/workspace-item-card-chrome.ts
@@ -1,19 +1,19 @@
 /** Shared layout + appearance tokens for workspace item cards. */
 
 export const workspaceItemPreviewControlClass =
-	"relative z-20 rounded-[4px] border border-border/80 bg-card/95 text-muted-foreground shadow-none backdrop-blur-md transition-[background-color,border-color,color,opacity] hover:border-foreground/30 hover:bg-secondary hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 dark:border-white/15 dark:bg-card/90 dark:text-muted-foreground dark:hover:border-white/35 dark:hover:bg-secondary dark:hover:text-foreground/95 data-popup-open:border-foreground/30 data-popup-open:bg-secondary data-popup-open:text-foreground dark:data-popup-open:border-white/35 dark:data-popup-open:bg-secondary dark:data-popup-open:text-foreground/95";
+	"relative z-20 size-9 rounded-[6px] border border-border/80 bg-card/95 text-muted-foreground shadow-none backdrop-blur-md transition-[background-color,border-color,color,opacity] hover:border-foreground/30 hover:bg-secondary hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 dark:border-white/15 dark:bg-card/90 dark:text-muted-foreground dark:hover:border-white/35 dark:hover:bg-secondary dark:hover:text-foreground/95 data-popup-open:border-foreground/30 data-popup-open:bg-secondary data-popup-open:text-foreground dark:data-popup-open:border-white/35 dark:data-popup-open:bg-secondary dark:data-popup-open:text-foreground/95 sm:size-6 sm:rounded-[4px]";
 
 export const workspaceItemPreviewControlOverlayClass =
-	"pointer-events-none opacity-0 transition-opacity group-hover/item:pointer-events-auto group-hover/item:opacity-100 data-popup-open:pointer-events-auto data-popup-open:opacity-100";
+	"pointer-events-auto opacity-100 transition-opacity sm:pointer-events-none sm:opacity-0 sm:group-hover/item:pointer-events-auto sm:group-hover/item:opacity-100 sm:data-popup-open:pointer-events-auto sm:data-popup-open:opacity-100";
 
 export const workspaceItemPreviewControlSelectedClass =
 	"pointer-events-auto border-info bg-info text-white opacity-100 dark:border-info dark:bg-info dark:text-white";
 
 export const workspaceItemPreviewControlRowClass =
-	"relative z-10 flex h-10 items-center justify-between px-2";
+	"relative z-10 flex items-center justify-end gap-2 sm:h-10 sm:justify-between sm:gap-1 sm:px-2";
 
 export const workspaceItemCardBaseClass =
-	"workspace-item-card group/item relative flex h-full min-h-44 cursor-pointer flex-col gap-0 overflow-hidden py-0 transition-[background-color,box-shadow] active:cursor-grabbing";
+	"workspace-item-card group/item relative flex h-full min-h-20 cursor-pointer flex-row gap-0 overflow-hidden py-0 transition-[background-color,box-shadow] active:cursor-grabbing sm:min-h-44 sm:flex-col";
 
 export const workspaceItemCardHoverClass = "hover:bg-secondary dark:hover:bg-accent/75";
 
@@ -23,18 +23,20 @@ export const workspaceItemCardUnselectedHoverClass =
 export const workspaceItemCardSelectedClass =
 	"data-[selected=true]:ring-2 data-[selected=true]:ring-info";
 
-export const workspaceItemGridClass = "grid grid-cols-[repeat(auto-fill,minmax(13rem,1fr))] gap-5";
+export const workspaceItemGridClass =
+	"grid grid-cols-1 gap-3 sm:grid-cols-[repeat(auto-fill,minmax(13rem,1fr))] sm:gap-5";
 
 export const workspaceItemPreviewStageClass =
-	"pointer-events-none relative z-10 min-h-20 flex-1 overflow-hidden bg-muted";
+	"pointer-events-none relative z-10 w-14 shrink-0 overflow-hidden bg-muted sm:min-h-20 sm:w-auto sm:flex-1";
 
 export const workspaceItemPreviewContentLayerClass = "absolute inset-0";
 
-export const workspaceItemPreviewControlsLayerClass = "absolute inset-x-0 top-0 z-20";
+export const workspaceItemPreviewControlsLayerClass =
+	"pointer-events-none absolute top-1/2 right-2 z-20 -translate-y-1/2 sm:inset-x-0 sm:top-0 sm:translate-y-0";
 
 export const workspaceItemDocumentPreviewPanelClass = "size-full overflow-hidden p-3";
 
 export const workspaceItemDocumentPreviewTextClass =
 	"size-full overflow-hidden break-words whitespace-pre-line text-[11px] leading-[1.45] text-muted-foreground/70 line-clamp-[11]";
 
-export const workspaceItemPreviewIconClass = "size-10";
+export const workspaceItemPreviewIconClass = "size-8 sm:size-10";

--- a/src/features/workspaces/components/workspace-item-card-footer.tsx
+++ b/src/features/workspaces/components/workspace-item-card-footer.tsx
@@ -14,9 +14,9 @@ export function WorkspaceItemCardFooter({ item }: WorkspaceItemCardFooterProps) 
 	return (
 		<WorkspaceCardMetaRow
 			leading={
-				<span className="flex min-w-0 items-center gap-1.5">
+				<span className="flex min-w-0 items-center sm:gap-1.5">
 					<Icon
-						className={cn("size-3.5 shrink-0", iconClassName)}
+						className={cn("hidden size-3.5 shrink-0 sm:block", iconClassName)}
 						strokeWidth={1.75}
 						aria-hidden="true"
 					/>

--- a/src/features/workspaces/components/workspace-item-card-preview-controls.tsx
+++ b/src/features/workspaces/components/workspace-item-card-preview-controls.tsx
@@ -74,7 +74,7 @@ export function WorkspaceItemCardPreviewControls({
 					aria-hidden="true"
 				/>
 			</ItemCardPreviewButton>
-			<div aria-hidden="true" className="h-full flex-1" />
+			<div aria-hidden="true" className="hidden h-full flex-1 sm:block" />
 			<WorkspaceItemActionsMenu
 				item={item}
 				trigger={
@@ -82,7 +82,7 @@ export function WorkspaceItemCardPreviewControls({
 						aria-label={`Open actions for ${item.name}`}
 						onClick={(event) => event.stopPropagation()}
 					>
-						<EllipsisVertical className="size-3.5" aria-hidden="true" />
+						<EllipsisVertical className="size-5 sm:size-3.5" aria-hidden="true" />
 					</ItemCardPreviewButton>
 				}
 				onMoveItem={onMoveItem}

--- a/src/features/workspaces/components/workspace-item-card-preview-stage.tsx
+++ b/src/features/workspaces/components/workspace-item-card-preview-stage.tsx
@@ -1,45 +1,19 @@
 import WorkspaceItemPreviewSurface from "#/features/workspaces/components/WorkspaceItemPreviewSurface";
-import {
-	workspaceItemPreviewControlsLayerClass,
-	workspaceItemPreviewStageClass,
-} from "#/features/workspaces/components/workspace-item-card-chrome";
-import { WorkspaceItemCardPreviewControls } from "#/features/workspaces/components/workspace-item-card-preview-controls";
+import { workspaceItemPreviewStageClass } from "#/features/workspaces/components/workspace-item-card-chrome";
 import { getWorkspaceItemDisplay } from "#/features/workspaces/model/item-display";
 import type { WorkspaceItem } from "#/features/workspaces/model/types";
 import { cn } from "#/lib/utils";
 
 interface WorkspaceItemCardPreviewStageProps {
 	item: WorkspaceItem;
-	isSelected: boolean;
-	onSelectionChange: (item: WorkspaceItem, selected: boolean) => void;
-	onMoveItem: (item: WorkspaceItem) => void;
-	onRenameItem: (item: WorkspaceItem) => void;
-	onDeleteItem: (item: WorkspaceItem) => void;
 }
 
-export function WorkspaceItemCardPreviewStage({
-	item,
-	isSelected,
-	onSelectionChange,
-	onMoveItem,
-	onRenameItem,
-	onDeleteItem,
-}: WorkspaceItemCardPreviewStageProps) {
+export function WorkspaceItemCardPreviewStage({ item }: WorkspaceItemCardPreviewStageProps) {
 	const { surfaceClassName } = getWorkspaceItemDisplay(item);
 
 	return (
 		<div className={cn(workspaceItemPreviewStageClass, surfaceClassName)}>
 			<WorkspaceItemPreviewSurface item={item} />
-			<div className={workspaceItemPreviewControlsLayerClass}>
-				<WorkspaceItemCardPreviewControls
-					item={item}
-					isSelected={isSelected}
-					onSelectionChange={onSelectionChange}
-					onMoveItem={onMoveItem}
-					onRenameItem={onRenameItem}
-					onDeleteItem={onDeleteItem}
-				/>
-			</div>
 		</div>
 	);
 }

--- a/src/features/workspaces/components/workspace-view-policy.tsx
+++ b/src/features/workspaces/components/workspace-view-policy.tsx
@@ -1,0 +1,74 @@
+import { createContext, type ReactNode, use, useSyncExternalStore } from "react";
+
+const WORKSPACE_DESKTOP_MEDIA_QUERY = "(min-width: 640px)";
+
+export type WorkspaceViewportMode = "desktop" | "mobile";
+
+export interface WorkspaceViewCapabilities {
+	contextMenus: boolean;
+	fileCapture: boolean;
+}
+
+const desktopWorkspaceViewCapabilities: WorkspaceViewCapabilities = {
+	contextMenus: true,
+	fileCapture: true,
+};
+
+const mobileWorkspaceViewCapabilities: WorkspaceViewCapabilities = {
+	contextMenus: false,
+	fileCapture: false,
+};
+
+const WorkspaceViewCapabilitiesContext = createContext<WorkspaceViewCapabilities>(
+	desktopWorkspaceViewCapabilities,
+);
+
+function subscribeToWorkspaceViewportChange(onChange: () => void) {
+	const media = window.matchMedia(WORKSPACE_DESKTOP_MEDIA_QUERY);
+
+	media.addEventListener("change", onChange);
+
+	return () => media.removeEventListener("change", onChange);
+}
+
+function getWorkspaceViewportSnapshot(): WorkspaceViewportMode {
+	return window.matchMedia(WORKSPACE_DESKTOP_MEDIA_QUERY).matches ? "desktop" : "mobile";
+}
+
+function getWorkspaceViewportServerSnapshot(): WorkspaceViewportMode {
+	return "desktop";
+}
+
+export function useWorkspaceViewPolicy() {
+	const viewportMode = useSyncExternalStore(
+		subscribeToWorkspaceViewportChange,
+		getWorkspaceViewportSnapshot,
+		getWorkspaceViewportServerSnapshot,
+	);
+
+	return {
+		capabilities:
+			viewportMode === "desktop"
+				? desktopWorkspaceViewCapabilities
+				: mobileWorkspaceViewCapabilities,
+		viewportMode,
+	};
+}
+
+export function WorkspaceViewCapabilitiesProvider({
+	capabilities,
+	children,
+}: {
+	capabilities: WorkspaceViewCapabilities;
+	children: ReactNode;
+}) {
+	return (
+		<WorkspaceViewCapabilitiesContext value={capabilities}>
+			{children}
+		</WorkspaceViewCapabilitiesContext>
+	);
+}
+
+export function useWorkspaceViewCapabilities() {
+	return use(WorkspaceViewCapabilitiesContext);
+}


### PR DESCRIPTION
## Summary
- Add a dedicated mobile workspace shell with a simplified top bar and chat overlay.
- Introduce workspace view policy for mobile-only behavior like hiding capture tools and context menus.
- Rework mobile workspace item cards into compact icon rows while preserving desktop card previews.

## Why
Mobile users should browse a workspace or chat without cramped desktop chrome, and item rows should be easier to scan and tap. Desktop behavior remains intact, including thumbnails, context menus, and title rename affordances.

## Changes
- Mobile workspace layout uses a separate shell path from desktop.
- Mobile view policy disables capture and context-menu affordances where they do not fit.
- Empty workspace/folder states can trigger upload directly.
- Mobile item cards use icon-only previews, larger right-side row actions, and no title-click rename.
- Home header/search behavior is adjusted for mobile.

## Testing
- pnpm verify

## Review Notes
Start with WorkspaceLayout.tsx, WorkspaceMobileLayout.tsx, workspace-view-policy.tsx, and the item card chrome files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785452470&installation_id=142604731&pr_number=556&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F556&signature=fdb97704c42f68fbdc1a7c869a89b8e9366ae211523d8bc0f11bd3fee3899639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mobile-friendly workspace layout with a simplified header, back navigation, sharing, profile access, and chat handling.
  * Empty workspace and folder states now support click-to-upload actions.
  * Workspace browsing, item cards, and viewers now adapt more intelligently to available actions such as context menus and file capture.

* **Bug Fixes**
  * Improved responsive behavior across workspace toolbars, previews, and action menus on smaller screens.
  * Capture controls and related overlays now appear only when supported, reducing unavailable controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->