### PR TITLE
feat(workspace): version history timeline backed by kernel events

### DIFF
--- a/src/features/workspaces/components/WorkspaceContextBar.tsx
+++ b/src/features/workspaces/components/WorkspaceContextBar.tsx
@@ -28,6 +28,7 @@ import WorkspaceMobileBreadcrumbOverflow from "#/features/workspaces/components/
 import { WorkspaceSearchDialog } from "#/features/workspaces/components/WorkspaceSearchDialog";
 import WorkspaceSettingsDialog from "#/features/workspaces/components/WorkspaceSettingsDialog";
 import { WorkspaceShareDialog } from "#/features/workspaces/components/WorkspaceShareDialog";
+import { WorkspaceVersionHistoryDialog } from "#/features/workspaces/components/WorkspaceVersionHistoryDialog";
 import { WorkspaceToolbarGroup } from "#/features/workspaces/components/WorkspaceToolbar";
 import {
 	renderWorkspaceMenuActions,
@@ -74,6 +75,7 @@ export default function WorkspaceContextBar({
 	const [searchOpen, setSearchOpen] = useState(false);
 	const [shareOpen, setShareOpen] = useState(false);
 	const [settingsOpen, setSettingsOpen] = useState(false);
+	const [historyOpen, setHistoryOpen] = useState(false);
 	const breadcrumbs = getWorkspaceBreadcrumbItems(activeItem, itemsById);
 	const mobileOverflowBreadcrumbs = breadcrumbs.slice(0, -1);
 	const createParentId = getWorkspaceBrowseParentId(activeItem);
@@ -117,6 +119,7 @@ export default function WorkspaceContextBar({
 							) : (
 								<WorkspaceRootActionsMenu
 									capabilities={capabilities}
+									onOpenHistory={() => setHistoryOpen(true)}
 									onOpenSettings={() => setSettingsOpen(true)}
 									onOpenShare={() => setShareOpen(true)}
 									trigger={
@@ -215,17 +218,24 @@ export default function WorkspaceContextBar({
 				workspaceId={workspace.id}
 				workspaceName={workspace.name}
 			/>
+			<WorkspaceVersionHistoryDialog
+				open={historyOpen}
+				onOpenChange={setHistoryOpen}
+				workspaceId={workspace.id}
+			/>
 		</>
 	);
 }
 
 function WorkspaceRootActionsMenu({
 	capabilities,
+	onOpenHistory,
 	onOpenSettings,
 	onOpenShare,
 	trigger,
 }: {
 	capabilities: ReturnType<typeof useWorkspaceMutationAccess>["capabilities"];
+	onOpenHistory: () => void;
 	onOpenSettings: () => void;
 	onOpenShare: () => void;
 	trigger: ReactElement;
@@ -237,6 +247,7 @@ function WorkspaceRootActionsMenu({
 				{renderWorkspaceMenuActions(
 					getWorkspaceRootMenuActions({
 						canOpenSettings: capabilities.canMutateContent,
+						onOpenHistory,
 						onOpenSettings,
 						onOpenShare,
 					}),
@@ -249,6 +260,7 @@ function WorkspaceRootActionsMenu({
 
 function getWorkspaceRootMenuActions(input: {
 	canOpenSettings: boolean;
+	onOpenHistory: () => void;
 	onOpenSettings: () => void;
 	onOpenShare: () => void;
 }): WorkspaceMenuAction[] {
@@ -265,8 +277,7 @@ function getWorkspaceRootMenuActions(input: {
 			id: "version-history",
 			label: "Version history",
 			leading: <Clock3 className="size-4" />,
-			trailing: "Soon",
-			disabled: true,
+			onSelect: input.onOpenHistory,
 		},
 		{
 			kind: "item",

--- a/src/features/workspaces/components/WorkspaceVersionHistoryDialog.tsx
+++ b/src/features/workspaces/components/WorkspaceVersionHistoryDialog.tsx
@@ -1,0 +1,207 @@
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import {
+	CircleDot,
+	FolderInput,
+	Loader2,
+	Palette,
+	PenLine,
+	Pencil,
+	Plus,
+	Trash2,
+} from "lucide-react";
+import type { ComponentType } from "react";
+
+import { Button } from "#/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "#/components/ui/dialog";
+import { getWorkspaceMembersQueryOptions } from "#/features/workspaces/components/workspace-share-queries";
+import { formatWorkspaceRecency } from "#/features/workspaces/model/display";
+import {
+	mapWorkspaceHistoryEvents,
+	type WorkspaceHistoryEntry,
+	type WorkspaceHistoryEntryKind,
+} from "#/features/workspaces/model/workspace-history";
+import { getWorkspaceHistoryPageFn } from "#/features/workspaces/server/functions";
+
+const historyKindIcons: Record<WorkspaceHistoryEntryKind, ComponentType<{ className?: string }>> = {
+	created: Plus,
+	renamed: PenLine,
+	moved: FolderInput,
+	color: Palette,
+	edited: Pencil,
+	deleted: Trash2,
+	change: CircleDot,
+};
+
+interface WorkspaceVersionHistoryDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	workspaceId: string;
+}
+
+export function WorkspaceVersionHistoryDialog({
+	open,
+	onOpenChange,
+	workspaceId,
+}: WorkspaceVersionHistoryDialogProps) {
+	const historyQuery = useWorkspaceHistoryQuery(workspaceId, open);
+	const membersQuery = useQuery({
+		...getWorkspaceMembersQueryOptions(workspaceId),
+		enabled: open,
+	});
+	const actorNamesById = new Map(
+		(membersQuery.data ?? []).map((member) => [member.userId, member.name]),
+	);
+	const entries = mapWorkspaceHistoryEvents(
+		(historyQuery.data?.pages ?? []).flatMap((page) => page.events),
+	);
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="flex max-h-[min(36rem,85vh)] flex-col gap-4 sm:max-w-lg">
+				<DialogHeader>
+					<DialogTitle>Version history</DialogTitle>
+					<DialogDescription>
+						Every change in this workspace, newest first. History is inspection-only for now —
+						restoring earlier versions isn't supported yet.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="min-h-0 flex-1 overflow-y-auto rounded-md border">
+					<WorkspaceVersionHistoryList
+						entries={entries}
+						getActorName={(actorUserId) => resolveActorName(actorUserId, actorNamesById)}
+						historyQuery={historyQuery}
+					/>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function useWorkspaceHistoryQuery(workspaceId: string, open: boolean) {
+	return useInfiniteQuery({
+		queryKey: ["workspace-history", workspaceId],
+		queryFn: ({ pageParam }) =>
+			getWorkspaceHistoryPageFn({
+				data: {
+					workspaceId,
+					beforeRevision: pageParam,
+				},
+			}),
+		initialPageParam: undefined as number | undefined,
+		getNextPageParam: (lastPage) => lastPage.nextBeforeRevision ?? undefined,
+		enabled: open,
+	});
+}
+
+function resolveActorName(actorUserId: string | null, actorNamesById: Map<string, string>) {
+	if (actorUserId === null) {
+		return "Someone";
+	}
+
+	return actorNamesById.get(actorUserId) ?? "Former member";
+}
+
+function WorkspaceVersionHistoryList({
+	entries,
+	getActorName,
+	historyQuery,
+}: {
+	entries: WorkspaceHistoryEntry[];
+	getActorName: (actorUserId: string | null) => string;
+	historyQuery: ReturnType<typeof useWorkspaceHistoryQuery>;
+}) {
+	if (historyQuery.isPending) {
+		return (
+			<div className="flex items-center justify-center gap-2 p-6 text-sm text-muted-foreground">
+				<Loader2 className="size-4 animate-spin" aria-hidden={true} />
+				Loading history…
+			</div>
+		);
+	}
+
+	if (historyQuery.isError) {
+		return (
+			<div className="flex flex-col items-center gap-3 p-6 text-center text-sm text-muted-foreground">
+				Could not load version history.
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					onClick={() => void historyQuery.refetch()}
+				>
+					Try again
+				</Button>
+			</div>
+		);
+	}
+
+	if (entries.length === 0) {
+		return (
+			<div className="p-6 text-center text-sm text-muted-foreground">
+				No changes yet. Edits to this workspace will show up here.
+			</div>
+		);
+	}
+
+	return (
+		<ul className="divide-y">
+			{entries.map((entry) => (
+				<WorkspaceVersionHistoryRow
+					key={entry.id}
+					actorName={getActorName(entry.actorUserId)}
+					entry={entry}
+				/>
+			))}
+			{historyQuery.hasNextPage ? (
+				<li className="flex justify-center p-2">
+					<Button
+						type="button"
+						variant="ghost"
+						size="sm"
+						disabled={historyQuery.isFetchingNextPage}
+						onClick={() => void historyQuery.fetchNextPage()}
+					>
+						{historyQuery.isFetchingNextPage ? (
+							<Loader2 className="size-4 animate-spin" aria-hidden={true} />
+						) : null}
+						{historyQuery.isFetchingNextPage ? "Loading…" : "Load more"}
+					</Button>
+				</li>
+			) : null}
+		</ul>
+	);
+}
+
+function WorkspaceVersionHistoryRow({
+	actorName,
+	entry,
+}: {
+	actorName: string;
+	entry: WorkspaceHistoryEntry;
+}) {
+	const KindIcon = historyKindIcons[entry.kind];
+
+	return (
+		<li className="flex items-start gap-3 px-4 py-3 text-sm">
+			<KindIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" aria-hidden={true} />
+			<div className="min-w-0 flex-1">
+				<p className="break-words">
+					<span className="font-medium">{actorName}</span> {entry.summary}
+				</p>
+			</div>
+			<time
+				dateTime={entry.createdAt}
+				className="shrink-0 whitespace-nowrap text-xs text-muted-foreground"
+			>
+				{formatWorkspaceRecency(entry.createdAt)}
+			</time>
+		</li>
+	);
+}

--- a/src/features/workspaces/components/WorkspaceVersionHistoryDialog.tsx
+++ b/src/features/workspaces/components/WorkspaceVersionHistoryDialog.tsx
@@ -9,7 +9,7 @@ import {
 	Plus,
 	Trash2,
 } from "lucide-react";
-import type { ComponentType } from "react";
+import { type ComponentType, useMemo } from "react";
 
 import { Button } from "#/components/ui/button";
 import {
@@ -54,11 +54,15 @@ export function WorkspaceVersionHistoryDialog({
 		...getWorkspaceMembersQueryOptions(workspaceId),
 		enabled: open,
 	});
-	const actorNamesById = new Map(
-		(membersQuery.data ?? []).map((member) => [member.userId, member.name]),
+	const members = membersQuery.data;
+	const actorNamesById = useMemo(
+		() => (members ? new Map(members.map((member) => [member.userId, member.name])) : null),
+		[members],
 	);
-	const entries = mapWorkspaceHistoryEvents(
-		(historyQuery.data?.pages ?? []).flatMap((page) => page.events),
+	const historyPages = historyQuery.data?.pages;
+	const entries = useMemo(
+		() => mapWorkspaceHistoryEvents((historyPages ?? []).flatMap((page) => page.events)),
+		[historyPages],
 	);
 
 	return (
@@ -100,8 +104,14 @@ function useWorkspaceHistoryQuery(workspaceId: string, open: boolean) {
 	});
 }
 
-function resolveActorName(actorUserId: string | null, actorNamesById: Map<string, string>) {
+function resolveActorName(actorUserId: string | null, actorNamesById: Map<string, string> | null) {
 	if (actorUserId === null) {
+		return "Someone";
+	}
+
+	// Until the member list has loaded, stay neutral instead of wrongly
+	// labeling current members as former ones.
+	if (!actorNamesById) {
 		return "Someone";
 	}
 

--- a/src/features/workspaces/kernel/workspace-kernel-access.ts
+++ b/src/features/workspaces/kernel/workspace-kernel-access.ts
@@ -20,6 +20,7 @@ import type {
 	CreateWorkspaceKernelFileFromUploadArgs,
 	CreateWorkspaceKernelRelationArgs,
 	DeleteWorkspaceKernelItemsResult,
+	ListWorkspaceKernelHistoryArgs,
 	ListWorkspaceKernelItemRelationsArgs,
 	MoveWorkspaceKernelItemsResult,
 	ReadWorkspaceKernelFilePreviewResult,
@@ -30,6 +31,7 @@ import type {
 	WorkspaceKernelNameConflictPolicy,
 } from "#/features/workspaces/kernel/workspace-kernel-types";
 import type { WorkspaceFileAssetKind } from "#/features/workspaces/model/workspace-file";
+import type { WorkspaceHistoryPage } from "#/features/workspaces/model/workspace-history";
 import type { WorkspaceCommandResult } from "#/features/workspaces/realtime/messages";
 import {
 	assertCanMutateWorkspace,
@@ -123,6 +125,7 @@ export interface WorkspaceKernelClient {
 		actorUserId?: string | null;
 		clientMutationId?: string | null;
 	}): Promise<WorkspaceCommandResult<WorkspaceItemSummary>>;
+	listEventsPage(input: ListWorkspaceKernelHistoryArgs): Promise<WorkspaceHistoryPage>;
 	purgeForDeletion(): Promise<void>;
 }
 
@@ -177,6 +180,27 @@ export async function getWorkspaceKernelPage(input: {
 			items: page.items,
 			revision: page.revision,
 		};
+	} finally {
+		await dbContext.dispose();
+	}
+}
+
+export async function getWorkspaceKernelHistoryPage(input: {
+	workspaceId: string;
+	userId: string;
+	beforeRevision?: number;
+	limit?: number;
+}): Promise<WorkspaceHistoryPage> {
+	const dbContext = await createDbContext();
+
+	try {
+		await assertCanReadWorkspace(dbContext.db, input);
+		const kernel = await getWorkspaceKernel(input.workspaceId);
+
+		return await kernel.listEventsPage({
+			beforeRevision: input.beforeRevision,
+			limit: input.limit,
+		});
 	} finally {
 		await dbContext.dispose();
 	}

--- a/src/features/workspaces/kernel/workspace-kernel-events.test.ts
+++ b/src/features/workspaces/kernel/workspace-kernel-events.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import { WorkspaceKernelEventBus } from "#/features/workspaces/kernel/workspace-kernel-events";
+import type { KernelEventRow } from "#/features/workspaces/kernel/workspace-kernel-rows";
+import type { WorkspaceKernelSql } from "#/features/workspaces/kernel/workspace-kernel-schema";
+
+function eventRow(revision: number, overrides: Partial<KernelEventRow> = {}): KernelEventRow {
+	return {
+		id: `event-${revision}`,
+		revision,
+		type: "workspace.item.created",
+		actor_user_id: "user-1",
+		client_mutation_id: null,
+		payload_json: JSON.stringify({
+			item: { id: "item-1", name: "Notes", type: "document" },
+		}),
+		created_at: 1_780_000_000_000 + revision,
+		...overrides,
+	};
+}
+
+function createEventBus(rows: KernelEventRow[]) {
+	const queries: Array<{ sql: string; values: unknown[] }> = [];
+	const sql: WorkspaceKernelSql = (strings, ...values) => {
+		queries.push({ sql: strings.join("?"), values });
+		return rows as never[];
+	};
+	const bus = new WorkspaceKernelEventBus({
+		sql,
+		workspaceId: () => "workspace-1",
+		getNextRevision: () => {
+			throw new Error("History reads must not advance the revision.");
+		},
+		broadcast: () => {
+			throw new Error("History reads must not broadcast.");
+		},
+	});
+
+	return { bus, queries };
+}
+
+describe("WorkspaceKernelEventBus.listEventsPage", () => {
+	it("reads newest first with a lookahead row and no cursor filter by default", () => {
+		const { bus, queries } = createEventBus([eventRow(3), eventRow(2), eventRow(1)]);
+		const page = bus.listEventsPage({});
+
+		expect(queries).toHaveLength(1);
+		expect(queries[0].sql).toContain("ORDER BY revision DESC");
+		expect(queries[0].sql).not.toContain("WHERE");
+		expect(queries[0].values).toEqual([51]);
+		expect(page.events.map((event) => event.revision)).toEqual([3, 2, 1]);
+		expect(page.nextBeforeRevision).toBeNull();
+	});
+
+	it("filters below the cursor when one is provided", () => {
+		const { bus, queries } = createEventBus([eventRow(2), eventRow(1)]);
+		bus.listEventsPage({ beforeRevision: 3, limit: 10 });
+
+		expect(queries[0].sql).toContain("WHERE revision <");
+		expect(queries[0].values).toEqual([3, 11]);
+	});
+
+	it("clamps the limit between 1 and 100", () => {
+		const { bus: overBus, queries: overQueries } = createEventBus([]);
+		overBus.listEventsPage({ limit: 5000 });
+		expect(overQueries[0].values).toEqual([101]);
+
+		const { bus: underBus, queries: underQueries } = createEventBus([]);
+		underBus.listEventsPage({ limit: 0 });
+		expect(underQueries[0].values).toEqual([2]);
+	});
+
+	it("clamps a negative cursor to zero", () => {
+		const { bus, queries } = createEventBus([]);
+		bus.listEventsPage({ beforeRevision: -5 });
+
+		expect(queries[0].values[0]).toBe(0);
+	});
+
+	it("advertises the next cursor only when the lookahead row exists", () => {
+		const { bus } = createEventBus([eventRow(5), eventRow(4), eventRow(3)]);
+		const page = bus.listEventsPage({ limit: 2 });
+
+		expect(page.events.map((event) => event.revision)).toEqual([5, 4]);
+		expect(page.nextBeforeRevision).toBe(4);
+
+		const { bus: lastBus } = createEventBus([eventRow(2), eventRow(1)]);
+		const lastPage = lastBus.listEventsPage({ limit: 2 });
+
+		expect(lastPage.events.map((event) => event.revision)).toEqual([2, 1]);
+		expect(lastPage.nextBeforeRevision).toBeNull();
+	});
+
+	it("maps rows through the shared event mapper", () => {
+		const { bus } = createEventBus([eventRow(7)]);
+		const [event] = bus.listEventsPage({}).events;
+
+		expect(event).toMatchObject({
+			id: "event-7",
+			revision: 7,
+			workspaceId: "workspace-1",
+			type: "workspace.item.created",
+			actorUserId: "user-1",
+			payload: { item: { id: "item-1", name: "Notes", type: "document" } },
+		});
+		expect(event.createdAt).toBe(new Date(1_780_000_000_007).toISOString());
+	});
+
+	it("degrades malformed payload rows instead of failing the page", () => {
+		const { bus } = createEventBus([eventRow(9), eventRow(8, { payload_json: "{not json" })]);
+		const page = bus.listEventsPage({});
+
+		expect(page.events).toHaveLength(2);
+		expect(page.events[1]).toMatchObject({
+			id: "event-8",
+			revision: 8,
+			payload: null,
+		});
+	});
+});

--- a/src/features/workspaces/kernel/workspace-kernel-events.ts
+++ b/src/features/workspaces/kernel/workspace-kernel-events.ts
@@ -1,7 +1,18 @@
 import type { KernelEventRow } from "#/features/workspaces/kernel/workspace-kernel-rows";
 import { mapKernelEventRow } from "#/features/workspaces/kernel/workspace-kernel-rows";
 import type { WorkspaceKernelSql } from "#/features/workspaces/kernel/workspace-kernel-schema";
-import type { ListWorkspaceKernelEventsArgs } from "#/features/workspaces/kernel/workspace-kernel-types";
+import type {
+	ListWorkspaceKernelEventsArgs,
+	ListWorkspaceKernelHistoryArgs,
+} from "#/features/workspaces/kernel/workspace-kernel-types";
+import type {
+	WorkspaceHistoryEvent,
+	WorkspaceHistoryPage,
+} from "#/features/workspaces/model/workspace-history";
+import {
+	workspaceHistoryDefaultPageSize,
+	workspaceHistoryMaxPageSize,
+} from "#/features/workspaces/model/workspace-history";
 import type {
 	WorkspaceRealtimeEvent,
 	WorkspaceRealtimeServerMessage,
@@ -38,6 +49,58 @@ export class WorkspaceKernelEventBus {
 		`;
 
 		return rows.map((row) => mapKernelEventRow(row, this.workspaceId()));
+	}
+
+	listEventsPage({
+		beforeRevision,
+		limit = workspaceHistoryDefaultPageSize,
+	}: ListWorkspaceKernelHistoryArgs): WorkspaceHistoryPage {
+		const pageSize = Math.max(1, Math.min(limit, workspaceHistoryMaxPageSize));
+		// Fetch one extra row so the cursor is only advertised when a next page exists.
+		const lookahead = pageSize + 1;
+		const rows =
+			beforeRevision === undefined
+				? this.sql<KernelEventRow>`
+						SELECT *
+						FROM kernel_events
+						ORDER BY revision DESC
+						LIMIT ${lookahead}
+					`
+				: this.sql<KernelEventRow>`
+						SELECT *
+						FROM kernel_events
+						WHERE revision < ${Math.max(0, beforeRevision)}
+						ORDER BY revision DESC
+						LIMIT ${lookahead}
+					`;
+		const events = rows.slice(0, pageSize).map((row) => this.mapHistoryRow(row));
+
+		return {
+			events,
+			nextBeforeRevision: rows.length > pageSize ? events[events.length - 1].revision : null,
+		};
+	}
+
+	private mapHistoryRow(row: KernelEventRow): WorkspaceHistoryEvent {
+		try {
+			const event = mapKernelEventRow(row, this.workspaceId());
+
+			// The payload came from JSON.parse, so it is JSON by construction.
+			return { ...event, payload: event.payload as unknown as WorkspaceHistoryEvent["payload"] };
+		} catch {
+			// Malformed payloads must never break the history view; realtime sync
+			// keeps its strict parsing.
+			return {
+				id: row.id,
+				revision: row.revision,
+				workspaceId: this.workspaceId(),
+				type: row.type,
+				actorUserId: row.actor_user_id,
+				clientMutationId: row.client_mutation_id,
+				createdAt: new Date(row.created_at).toISOString(),
+				payload: null,
+			};
+		}
 	}
 
 	commit(input: Omit<WorkspaceRealtimeEvent, "id" | "revision" | "workspaceId" | "createdAt">) {

--- a/src/features/workspaces/kernel/workspace-kernel-events.ts
+++ b/src/features/workspaces/kernel/workspace-kernel-events.ts
@@ -87,9 +87,16 @@ export class WorkspaceKernelEventBus {
 
 			// The payload came from JSON.parse, so it is JSON by construction.
 			return { ...event, payload: event.payload as unknown as WorkspaceHistoryEvent["payload"] };
-		} catch {
+		} catch (error) {
 			// Malformed payloads must never break the history view; realtime sync
 			// keeps its strict parsing.
+			console.warn("[WorkspaceKernel] Unable to map history event payload", {
+				eventId: row.id,
+				revision: row.revision,
+				type: row.type,
+				error,
+			});
+
 			return {
 				id: row.id,
 				revision: row.revision,

--- a/src/features/workspaces/kernel/workspace-kernel-types.ts
+++ b/src/features/workspaces/kernel/workspace-kernel-types.ts
@@ -190,3 +190,8 @@ export interface ListWorkspaceKernelEventsArgs {
 	afterRevision: number;
 	limit?: number;
 }
+
+export interface ListWorkspaceKernelHistoryArgs {
+	beforeRevision?: number;
+	limit?: number;
+}

--- a/src/features/workspaces/kernel/workspace-kernel.ts
+++ b/src/features/workspaces/kernel/workspace-kernel.ts
@@ -24,6 +24,7 @@ import type {
 	DeleteWorkspaceKernelItemsArgs,
 	DeleteWorkspaceKernelItemsResult,
 	ListWorkspaceKernelEventsArgs,
+	ListWorkspaceKernelHistoryArgs,
 	ListWorkspaceKernelItemRelationsArgs,
 	ListWorkspaceKernelItemsArgs,
 	MoveWorkspaceKernelItemsArgs,
@@ -37,6 +38,7 @@ import type {
 	WorkspaceKernelPage,
 	WriteWorkspaceKernelItemArgs,
 } from "#/features/workspaces/kernel/workspace-kernel-types";
+import type { WorkspaceHistoryPage } from "#/features/workspaces/model/workspace-history";
 import type {
 	WorkspaceCommandResult,
 	WorkspaceConnectionState,
@@ -200,6 +202,10 @@ export class WorkspaceKernel extends Agent<Cloudflare.Env> {
 		limit = 100,
 	}: ListWorkspaceKernelEventsArgs): Promise<WorkspaceRealtimeEvent[]> {
 		return this.events.getEventsSince({ afterRevision, limit });
+	}
+
+	async listEventsPage(input: ListWorkspaceKernelHistoryArgs = {}): Promise<WorkspaceHistoryPage> {
+		return this.events.listEventsPage(input);
 	}
 
 	async purgeForDeletion(): Promise<void> {

--- a/src/features/workspaces/model/workspace-history.test.ts
+++ b/src/features/workspaces/model/workspace-history.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+
+import type { JsonValue } from "#/features/workspaces/contracts";
+import {
+	mapWorkspaceHistoryEvents,
+	type WorkspaceHistoryEvent,
+} from "#/features/workspaces/model/workspace-history";
+
+let nextRevision = 1000;
+
+function historyEvent(input: {
+	type: string;
+	payload?: JsonValue;
+	actorUserId?: string | null;
+	createdAt?: string;
+	revision?: number;
+}): WorkspaceHistoryEvent {
+	const revision = input.revision ?? nextRevision--;
+
+	return {
+		id: `event-${revision}`,
+		revision,
+		workspaceId: "workspace-1",
+		type: input.type,
+		actorUserId: input.actorUserId === undefined ? "user-1" : input.actorUserId,
+		clientMutationId: null,
+		createdAt: input.createdAt ?? "2026-07-04T12:00:00.000Z",
+		payload: input.payload ?? null,
+	};
+}
+
+function payloadItem(overrides: Partial<{ id: string; name: string; type: string }> = {}) {
+	return {
+		id: "item-1",
+		name: "Notes",
+		type: "document",
+		...overrides,
+	};
+}
+
+describe("mapWorkspaceHistoryEvents", () => {
+	it("maps every known event type to readable copy", () => {
+		const entries = mapWorkspaceHistoryEvents([
+			historyEvent({
+				type: "workspace.item.created",
+				payload: { item: payloadItem({ type: "folder", name: "Research" }) },
+			}),
+			historyEvent({
+				type: "workspace.item.renamed",
+				payload: { item: payloadItem({ name: "Final notes" }) },
+			}),
+			historyEvent({
+				type: "workspace.item.moved",
+				payload: { item: payloadItem({ name: "Final notes" }) },
+			}),
+			historyEvent({
+				type: "workspace.item.color.updated",
+				payload: { item: payloadItem({ type: "folder", name: "Research" }) },
+			}),
+			historyEvent({
+				type: "workspace.item.content.updated",
+				payload: { item: payloadItem() },
+			}),
+			historyEvent({
+				type: "workspace.item.deleted",
+				payload: { itemIds: ["item-1"], deletedItemIds: ["item-1", "item-2"] },
+			}),
+		]);
+
+		expect(entries.map((entry) => [entry.kind, entry.summary])).toEqual([
+			["created", "created folder “Research”"],
+			["renamed", "renamed document to “Final notes”"],
+			["moved", "moved “Final notes”"],
+			["color", "changed the color of “Research”"],
+			["edited", "edited “Notes”"],
+			["deleted", "deleted an item"],
+		]);
+	});
+
+	it("renders bulk moves as one grouped row", () => {
+		const entries = mapWorkspaceHistoryEvents([
+			historyEvent({
+				type: "workspace.items.moved",
+				payload: {
+					items: [
+						payloadItem({ id: "item-1", name: "A" }),
+						payloadItem({ id: "item-2", name: "B" }),
+						payloadItem({ id: "item-3", name: "C" }),
+					],
+				},
+			}),
+		]);
+
+		expect(entries).toHaveLength(1);
+		expect(entries[0].summary).toBe("moved 3 items");
+	});
+
+	it("renders a single-item bulk move like a plain move", () => {
+		const entries = mapWorkspaceHistoryEvents([
+			historyEvent({
+				type: "workspace.items.moved",
+				payload: { items: [payloadItem({ name: "A" })] },
+			}),
+		]);
+
+		expect(entries[0].summary).toBe("moved “A”");
+	});
+
+	it("counts deleted items from the root item ids", () => {
+		const entries = mapWorkspaceHistoryEvents([
+			historyEvent({
+				type: "workspace.item.deleted",
+				payload: { itemIds: ["item-1", "item-2"], deletedItemIds: ["item-1", "item-2", "item-3"] },
+			}),
+		]);
+
+		expect(entries[0].summary).toBe("deleted 2 items");
+	});
+
+	it("coalesces consecutive edits to the same item by the same actor", () => {
+		const entries = mapWorkspaceHistoryEvents([
+			historyEvent({
+				type: "workspace.item.content.updated",
+				payload: { item: payloadItem() },
+				createdAt: "2026-07-04T12:04:00.000Z",
+				revision: 12,
+			}),
+			historyEvent({
+				type: "workspace.item.content.updated",
+				payload: { item: payloadItem() },
+				createdAt: "2026-07-04T12:02:00.000Z",
+				revision: 11,
+			}),
+			historyEvent({
+				type: "workspace.item.content.updated",
+				payload: { item: payloadItem() },
+				createdAt: "2026-07-04T12:00:00.000Z",
+				revision: 10,
+			}),
+		]);
+
+		expect(entries).toHaveLength(1);
+		expect(entries[0].summary).toBe("edited “Notes” (3 changes)");
+		expect(entries[0].eventCount).toBe(3);
+		expect(entries[0].revision).toBe(12);
+		expect(entries[0].createdAt).toBe("2026-07-04T12:04:00.000Z");
+	});
+
+	it("groups unattributed collaborative edits together", () => {
+		const entries = mapWorkspaceHistoryEvents([
+			historyEvent({
+				type: "workspace.item.content.updated",
+				payload: { item: payloadItem() },
+				actorUserId: null,
+				createdAt: "2026-07-04T12:01:00.000Z",
+			}),
+			historyEvent({
+				type: "workspace.item.content.updated",
+				payload: { item: payloadItem() },
+				actorUserId: null,
+				createdAt: "2026-07-04T12:00:00.000Z",
+			}),
+		]);
+
+		expect(entries).toHaveLength(1);
+		expect(entries[0].actorUserId).toBeNull();
+	});
+
+	it("splits edit bursts across actors, items, gaps, and other events", () => {
+		const editAt = (createdAt: string, actorUserId: string | null = "user-1") =>
+			historyEvent({
+				type: "workspace.item.content.updated",
+				payload: { item: payloadItem() },
+				createdAt,
+				actorUserId,
+			});
+
+		const differentActor = mapWorkspaceHistoryEvents([
+			editAt("2026-07-04T12:01:00.000Z"),
+			editAt("2026-07-04T12:00:00.000Z", "user-2"),
+		]);
+		expect(differentActor).toHaveLength(2);
+
+		const differentItem = mapWorkspaceHistoryEvents([
+			editAt("2026-07-04T12:01:00.000Z"),
+			historyEvent({
+				type: "workspace.item.content.updated",
+				payload: { item: payloadItem({ id: "item-2", name: "Other" }) },
+				createdAt: "2026-07-04T12:00:00.000Z",
+			}),
+		]);
+		expect(differentItem).toHaveLength(2);
+
+		const longGap = mapWorkspaceHistoryEvents([
+			editAt("2026-07-04T12:10:00.000Z"),
+			editAt("2026-07-04T12:00:00.000Z"),
+		]);
+		expect(longGap).toHaveLength(2);
+
+		const interleaved = mapWorkspaceHistoryEvents([
+			editAt("2026-07-04T12:02:00.000Z"),
+			historyEvent({
+				type: "workspace.item.renamed",
+				payload: { item: payloadItem() },
+				createdAt: "2026-07-04T12:01:00.000Z",
+			}),
+			editAt("2026-07-04T12:00:00.000Z"),
+		]);
+		expect(interleaved).toHaveLength(3);
+	});
+
+	it("renders unknown event types as a generic change row", () => {
+		const entries = mapWorkspaceHistoryEvents([
+			historyEvent({ type: "workspace.item.starred", payload: { anything: true } }),
+		]);
+
+		expect(entries[0].kind).toBe("change");
+		expect(entries[0].summary).toBe("made a change");
+	});
+
+	it("never throws on malformed payloads", () => {
+		const entries = mapWorkspaceHistoryEvents([
+			historyEvent({ type: "workspace.item.created", payload: null }),
+			historyEvent({ type: "workspace.item.renamed", payload: { item: "not-an-object" } }),
+			historyEvent({ type: "workspace.items.moved", payload: { items: "nope" } }),
+			historyEvent({ type: "workspace.item.deleted", payload: {} }),
+			historyEvent({ type: "workspace.item.content.updated", payload: 42 }),
+		]);
+
+		expect(entries.map((entry) => entry.summary)).toEqual([
+			"created an item",
+			"renamed an item",
+			"moved items",
+			"deleted items",
+			"edited an item",
+		]);
+	});
+});

--- a/src/features/workspaces/model/workspace-history.ts
+++ b/src/features/workspaces/model/workspace-history.ts
@@ -1,0 +1,236 @@
+import type { JsonValue } from "#/features/workspaces/contracts";
+
+export const workspaceHistoryDefaultPageSize = 50;
+export const workspaceHistoryMaxPageSize = 100;
+export const workspaceHistoryBurstWindowMs = 5 * 60_000;
+
+export interface WorkspaceHistoryEvent {
+	id: string;
+	revision: number;
+	workspaceId: string;
+	type: string;
+	actorUserId: string | null;
+	clientMutationId: string | null;
+	createdAt: string;
+	// JsonValue rather than unknown so the type survives server-function
+	// serialization; consumers still treat it as untrusted.
+	payload: JsonValue;
+}
+
+export interface WorkspaceHistoryPage {
+	events: WorkspaceHistoryEvent[];
+	nextBeforeRevision: number | null;
+}
+
+export type WorkspaceHistoryEntryKind =
+	| "created"
+	| "renamed"
+	| "moved"
+	| "color"
+	| "edited"
+	| "deleted"
+	| "change";
+
+export interface WorkspaceHistoryEntry {
+	id: string;
+	revision: number;
+	createdAt: string;
+	actorUserId: string | null;
+	kind: WorkspaceHistoryEntryKind;
+	summary: string;
+	eventCount: number;
+}
+
+interface WorkspaceHistoryPayloadItem {
+	id: string;
+	name: string;
+	type?: string | null;
+}
+
+/**
+ * Maps newest-first kernel event records into readable timeline entries,
+ * coalescing bursts of consecutive content edits to the same item by the
+ * same actor. Unknown event types and malformed payloads degrade to a
+ * generic "made a change" entry instead of failing the timeline.
+ */
+export function mapWorkspaceHistoryEvents(
+	events: readonly WorkspaceHistoryEvent[],
+	options: { burstWindowMs?: number } = {},
+): WorkspaceHistoryEntry[] {
+	const burstWindowMs = options.burstWindowMs ?? workspaceHistoryBurstWindowMs;
+	const groups: WorkspaceHistoryEvent[][] = [];
+
+	for (const event of events) {
+		const group = groups[groups.length - 1];
+
+		if (group && extendsEditBurst(group[group.length - 1], event, burstWindowMs)) {
+			group.push(event);
+			continue;
+		}
+
+		groups.push([event]);
+	}
+
+	return groups.map(mapWorkspaceHistoryEventGroup);
+}
+
+function extendsEditBurst(
+	previous: WorkspaceHistoryEvent,
+	event: WorkspaceHistoryEvent,
+	burstWindowMs: number,
+) {
+	if (
+		previous.type !== "workspace.item.content.updated" ||
+		event.type !== "workspace.item.content.updated" ||
+		event.actorUserId !== previous.actorUserId
+	) {
+		return false;
+	}
+
+	const previousItem = getPayloadItem(previous.payload);
+	const item = getPayloadItem(event.payload);
+
+	if (!previousItem || !item || previousItem.id !== item.id) {
+		return false;
+	}
+
+	const gapMs = Date.parse(previous.createdAt) - Date.parse(event.createdAt);
+
+	return Number.isFinite(gapMs) && gapMs <= burstWindowMs;
+}
+
+function mapWorkspaceHistoryEventGroup(group: WorkspaceHistoryEvent[]): WorkspaceHistoryEntry {
+	const newest = group[0];
+	const { kind, summary } = describeWorkspaceHistoryEvent(newest);
+
+	return {
+		id: newest.id,
+		revision: newest.revision,
+		createdAt: newest.createdAt,
+		actorUserId: newest.actorUserId,
+		kind,
+		summary: group.length > 1 ? `${summary} (${group.length} changes)` : summary,
+		eventCount: group.length,
+	};
+}
+
+function describeWorkspaceHistoryEvent(event: WorkspaceHistoryEvent): {
+	kind: WorkspaceHistoryEntryKind;
+	summary: string;
+} {
+	switch (event.type) {
+		case "workspace.item.created": {
+			const item = getPayloadItem(event.payload);
+			return {
+				kind: "created",
+				summary: item ? `created ${getItemTypeWord(item)} “${item.name}”` : "created an item",
+			};
+		}
+		case "workspace.item.renamed": {
+			const item = getPayloadItem(event.payload);
+			return {
+				kind: "renamed",
+				summary: item ? `renamed ${getItemTypeWord(item)} to “${item.name}”` : "renamed an item",
+			};
+		}
+		case "workspace.item.moved": {
+			const item = getPayloadItem(event.payload);
+			return {
+				kind: "moved",
+				summary: item ? `moved “${item.name}”` : "moved an item",
+			};
+		}
+		case "workspace.items.moved": {
+			const items = getPayloadItems(event.payload);
+
+			if (items.length === 1) {
+				return { kind: "moved", summary: `moved “${items[0].name}”` };
+			}
+
+			return {
+				kind: "moved",
+				summary: items.length > 0 ? `moved ${items.length} items` : "moved items",
+			};
+		}
+		case "workspace.item.color.updated": {
+			const item = getPayloadItem(event.payload);
+			return {
+				kind: "color",
+				summary: item ? `changed the color of “${item.name}”` : "changed an item's color",
+			};
+		}
+		case "workspace.item.content.updated": {
+			const item = getPayloadItem(event.payload);
+			return {
+				kind: "edited",
+				summary: item ? `edited “${item.name}”` : "edited an item",
+			};
+		}
+		case "workspace.item.deleted": {
+			const itemIds = getPayloadItemIds(event.payload);
+
+			if (itemIds.length === 1) {
+				return { kind: "deleted", summary: "deleted an item" };
+			}
+
+			return {
+				kind: "deleted",
+				summary: itemIds.length > 0 ? `deleted ${itemIds.length} items` : "deleted items",
+			};
+		}
+		default:
+			return { kind: "change", summary: "made a change" };
+	}
+}
+
+function getItemTypeWord(item: WorkspaceHistoryPayloadItem) {
+	switch (item.type) {
+		case "folder":
+			return "folder";
+		case "document":
+			return "document";
+		case "file":
+			return "file";
+		case "flashcard":
+			return "flashcards";
+		case "quiz":
+			return "quiz";
+		default:
+			return "item";
+	}
+}
+
+function getPayloadItem(payload: unknown): WorkspaceHistoryPayloadItem | null {
+	const item = (payload as { item?: unknown } | null)?.item;
+
+	return isItemLike(item) ? item : null;
+}
+
+function getPayloadItems(payload: unknown): WorkspaceHistoryPayloadItem[] {
+	const items = (payload as { items?: unknown } | null)?.items;
+
+	if (!Array.isArray(items)) {
+		return [];
+	}
+
+	return items.filter(isItemLike);
+}
+
+function getPayloadItemIds(payload: unknown) {
+	const itemIds = (payload as { itemIds?: unknown } | null)?.itemIds;
+
+	if (!Array.isArray(itemIds)) {
+		return [];
+	}
+
+	return itemIds.filter((itemId): itemId is string => typeof itemId === "string");
+}
+
+function isItemLike(value: unknown): value is WorkspaceHistoryPayloadItem {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		typeof (value as { id?: unknown }).id === "string" &&
+		typeof (value as { name?: unknown }).name === "string"
+	);
+}

--- a/src/features/workspaces/server/functions.ts
+++ b/src/features/workspaces/server/functions.ts
@@ -24,14 +24,22 @@ import {
 	recordWorkspaceOpenedForCurrentUser,
 	updateWorkspaceForCurrentUser,
 } from "#/features/workspaces/server/mutations";
+import { workspaceHistoryMaxPageSize } from "#/features/workspaces/model/workspace-history";
 import { getCurrentUserId } from "#/features/workspaces/server/permissions";
 import {
+	getWorkspaceHistoryPageForCurrentUser,
 	getWorkspacePageForCurrentUser,
 	listWorkspacesForCurrentUser,
 } from "#/features/workspaces/server/queries";
 
 const workspaceIdInputSchema = z.object({
 	workspaceId: z.string().min(1),
+});
+
+const workspaceHistoryPageInputSchema = z.object({
+	workspaceId: z.string().min(1),
+	beforeRevision: z.number().int().positive().optional(),
+	limit: z.number().int().min(1).max(workspaceHistoryMaxPageSize).optional(),
 });
 
 export const listWorkspacesFn = createServerFn({ method: "GET" }).handler(async () =>
@@ -41,6 +49,10 @@ export const listWorkspacesFn = createServerFn({ method: "GET" }).handler(async 
 export const getWorkspacePageFn = createServerFn({ method: "GET" })
 	.validator(workspaceIdInputSchema)
 	.handler(async ({ data }) => getWorkspacePageForCurrentUser(data.workspaceId));
+
+export const getWorkspaceHistoryPageFn = createServerFn({ method: "GET" })
+	.validator(workspaceHistoryPageInputSchema)
+	.handler(async ({ data }) => getWorkspaceHistoryPageForCurrentUser(data));
 
 export const createWorkspaceFn = createServerFn({ method: "POST" })
 	.validator(createWorkspaceInputSchema)

--- a/src/features/workspaces/server/queries.ts
+++ b/src/features/workspaces/server/queries.ts
@@ -3,7 +3,11 @@ import { and, asc, desc, eq, isNull, sql } from "drizzle-orm";
 import { workspaceMembers, workspaces } from "#/db/schema";
 import { createDbContext } from "#/db/server";
 import type { WorkspacePage, WorkspaceSummary } from "#/features/workspaces/contracts";
-import { getWorkspaceKernelPage } from "#/features/workspaces/kernel/workspace-kernel-access";
+import {
+	getWorkspaceKernelHistoryPage,
+	getWorkspaceKernelPage,
+} from "#/features/workspaces/kernel/workspace-kernel-access";
+import type { WorkspaceHistoryPage } from "#/features/workspaces/model/workspace-history";
 import { mapWorkspaceDetailRow, mapWorkspaceRow } from "#/features/workspaces/server/mappers";
 import { getCurrentUserId } from "#/features/workspaces/server/permissions";
 
@@ -88,4 +92,19 @@ export async function getWorkspacePageForCurrentUser(
 	} finally {
 		await dbContext.dispose();
 	}
+}
+
+export async function getWorkspaceHistoryPageForCurrentUser(input: {
+	workspaceId: string;
+	beforeRevision?: number;
+	limit?: number;
+}): Promise<WorkspaceHistoryPage> {
+	const userId = await getCurrentUserId();
+
+	return getWorkspaceKernelHistoryPage({
+		workspaceId: input.workspaceId,
+		userId,
+		beforeRevision: input.beforeRevision,
+		limit: input.limit,
+	});
 }


### PR DESCRIPTION
## Root cause

The workspace root menu's `Version history` action was a disabled stub (`trailing: "Soon"` in `WorkspaceContextBar.tsx`), and `kernel_events` rows — which already record every mutation with a monotonic revision, actor, and payload — were only ever consumed for realtime cache sync via `getEventsSince()`. Nothing read the log backwards for humans.

## Approach and the inspection-only scoping decision

**This v1 is inspection-only: no restore, no snapshots, no diffs.** Event payloads are written *after* the mutation (`commitItemEvent` reads the row post-update), so they carry only post-change summaries — no previous name on renames, and `content.updated` has no content snapshot at all. Past state cannot be reconstructed from the log, so restore is out of scope by design, and the dialog says so in its description ("History is inspection-only for now — restoring earlier versions isn't supported yet"). Copy consequence: renames read "renamed to X", never "renamed from Y to X".

The implementation is one additive read path:

- **Kernel**: `WorkspaceKernelEventBus.listEventsPage({ beforeRevision?, limit })` pages `kernel_events` by `ORDER BY revision DESC` with `WHERE revision < cursor`, limit clamped to 1–100 (default 50), fetching one lookahead row so `nextBeforeRevision` is only advertised when a next page actually exists. Exposed on `WorkspaceKernel` next to `getEventsSince`, which is untouched. The event log is strictly read-only for this feature.
- **Server**: `getWorkspaceHistoryPageFn` (GET) → `getWorkspaceHistoryPageForCurrentUser` → `getWorkspaceKernelHistoryPage`, gated by the **same `assertCanReadWorkspace` check** that `getWorkspacePageFn` uses. Input validated with zod (`beforeRevision` positive int, `limit` 1–100).
- **View model**: pure `mapWorkspaceHistoryEvents` in `model/workspace-history.ts` turns raw events into readable entries and coalesces consecutive `content.updated` bursts for the same item by the same actor within 5 minutes into one "edited “X” (N changes)" entry. Grouping happens client-side; the API returns raw events.
- **UI**: `WorkspaceVersionHistoryDialog` opened from the (now enabled) menu action, TanStack infinite query keyed on the revision cursor, actor names resolved from the existing members query, relative timestamps via `formatWorkspaceRecency`, loading/empty/error states, and a Load more button. No route changes; nothing fetches until the dialog opens, so baseline workspace load is unchanged (`getPage()` untouched).

Graceful degradation is layered: a malformed `payload_json` row falls back to a generic record inside `listEventsPage` (the shared `mapKernelEventRow` stays strict for realtime), and the view model routes unknown event types or unexpected payload shapes to a generic "made a change" row — so future event types can never break the dialog.

## Decisions and rejected alternatives

- **No `itemId` filter parameter yet.** The issue floats per-item history later; I rejected shipping a dead parameter that doesn't filter (a trap for callers). Adding an optional `itemId` to the schema later is backward-compatible.
- **Dialog over side panel** — matches how Share and Settings already hang off this menu, and needs no layout or route work.
- **Lookahead-row pagination over `hasMore` count queries** — one query per page, and no trailing empty page when the total is an exact multiple of the page size.
- **Burst grouping in the view model, not SQL** — keeps the API raw and the policy (5-minute window) a pure, fixture-tested function.
- **Delete rows count root `itemIds`, not `deletedItemIds`** — "deleted 2 items" matches what the user selected; descendants are an implementation detail of recursive delete.
- **No AI badge.** AI tool mutations run with the requesting user's id (`createThreadWorkspaceAccessContext` passes `thread.userId`), so AI edits are indistinguishable from manual edits in the log today — faking a badge would be wrong. This answers the issue's open question; distinguishing them needs an actor-kind column or a `clientMutationId` convention (follow-up).

## Fact corrections vs the task prompt

- `mapKernelEventRow` does **not** already degrade gracefully — its payload parse is a bare `JSON.parse` that throws on malformed rows. It is reused as directed, but wrapped per-row in `listEventsPage` so one bad row can't kill a history page.
- Collaborative document edits commit `content.updated` with **`actorUserId: null`** (`DocumentSession.checkpointToKernel`), so most document-edit history is unattributed. The UI renders these as "Someone"; null actors still group into bursts. (AI edits, by contrast, carry the requesting user's id.)

## Follow-ups noticed (not in this PR)

- **Restore** (the issue's stated end goal): needs either content snapshots in event payloads / a snapshot table, or — cheapest first step — a `restoreDeletedItems` kernel command leveraging the existing `deleted_at` soft delete, which requires no schema change. Any snapshot/retention schema should be designed before that implementation, per the issue.
- **AI attribution**: record an actor kind (user / ai / system) on `kernel_events` so AI changes can be visually distinguished.
- **Retention/compaction** for high-frequency document edits (issue open question) — unbounded event growth in the DO's SQLite will eventually need a policy.
- Pre-existing: `parseWorkspaceEventPayload` in `workspace-kernel-rows.ts` can throw on a corrupt row in the realtime `getEventsSince` path too; left untouched here since changing realtime semantics is out of scope.

## How verified

- `pnpm check` clean (format, lint, types); `pnpm test` clean — 30 tests, 7 files, including the 17 new ones.
- New unit tests cover: every known event type's copy, single-item vs bulk move rendering, delete counts, burst grouping (and its splits across actors, items, >5-min gaps, and interleaved events), null-actor grouping, unknown event types, malformed payloads (both JSON-invalid rows at the kernel layer and shape-invalid payloads at the view-model layer), cursor math, limit clamping (0 → 1, 5000 → 100), negative-cursor clamping, and that history reads never touch the revision counter or broadcast (fakes throw if called).
- `pnpm build` passes end-to-end (including prerender), run with `CLOUDFLARE_VITE_FORCE_LOCAL=true` and Docker per the recent CI setup.
- Manual UI verification (create/rename/move/recolor/edit/delete, then paginate history) requires a seeded local environment with auth secrets; not run here — happy to record a screencap if a maintainer wants one before merge.

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785873314&installation_id=142604731&pr_number=593&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F593&signature=940db2cf1ffb9aedf0eceefb95d71272e5ae1eded53d11ebceb94fc74f344643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workspace **Version history** view from the workspace actions menu, including a dialog with scrollable history, “load more” pagination, and loading/error retry.
  * History entries now display improved details, including actor name (with sensible fallbacks) and relative time, with cleaner grouping of closely related edits.
* **Bug Fixes**
  * History loading is resilient to malformed or unexpected event data, preventing the timeline from breaking.
* **Tests**
  * Added coverage for history pagination and event-to-history mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->