### PR TITLE
[codex] Polish workspace chat activity UI

### DIFF
--- a/src/features/workspaces/ai/ai-tool-presentation.ts
+++ b/src/features/workspaces/ai/ai-tool-presentation.ts
@@ -1,4 +1,5 @@
 export type AiToolVisibility = "hidden" | "visible";
+export type AiToolActivityIconKind = "code" | "edit" | "file" | "search" | "web";
 
 interface AiToolPresentation {
 	title?: string;
@@ -10,22 +11,22 @@ const defaultToolPresentation = {
 } as const satisfies AiToolPresentation;
 
 const aiToolPresentationByName: Readonly<Record<string, AiToolPresentation>> = {
-	compute: { title: "Computing", visibility: "visible" },
+	compute: { title: "Python", visibility: "visible" },
 	orchestrate: { title: "Working", visibility: "visible" },
-	research_deepen: { title: "Researching sources", visibility: "visible" },
-	research_discover: { title: "Researching sources", visibility: "visible" },
+	research_deepen: { title: "Research", visibility: "visible" },
+	research_discover: { title: "Research", visibility: "visible" },
 	sandbox_bash: { visibility: "hidden" },
-	web_links: { title: "Reading the web", visibility: "visible" },
-	web_markdown: { title: "Reading the web", visibility: "visible" },
-	web_search: { title: "Reading the web", visibility: "visible" },
-	workspace_create_items: { title: "Updating workspace", visibility: "visible" },
-	workspace_delete_items: { title: "Updating workspace", visibility: "visible" },
-	workspace_edit_item: { title: "Updating workspace", visibility: "visible" },
+	web_links: { title: "Web links", visibility: "visible" },
+	web_markdown: { title: "Web page", visibility: "visible" },
+	web_search: { title: "Web search", visibility: "visible" },
+	workspace_create_items: { title: "Workspace", visibility: "visible" },
+	workspace_delete_items: { title: "Workspace", visibility: "visible" },
+	workspace_edit_item: { title: "Workspace", visibility: "visible" },
 	workspace_link_items: { visibility: "hidden" },
-	workspace_list_items: { title: "Reading workspace", visibility: "visible" },
-	workspace_move_items: { title: "Updating workspace", visibility: "visible" },
-	workspace_read_items: { title: "Reading workspace", visibility: "visible" },
-	workspace_rename_item: { title: "Updating workspace", visibility: "visible" },
+	workspace_list_items: { title: "Workspace", visibility: "visible" },
+	workspace_move_items: { title: "Workspace", visibility: "visible" },
+	workspace_read_items: { title: "Workspace", visibility: "visible" },
+	workspace_rename_item: { title: "Workspace", visibility: "visible" },
 };
 
 export function getAiToolPresentation(toolName: string): AiToolPresentation {
@@ -44,6 +45,22 @@ export function getAiToolActivityTitle(input: { title?: string; toolName: string
 	}
 
 	return getAiToolPresentation(input.toolName).title ?? humanizeToolName(input.toolName);
+}
+
+export function getAiToolActivityIconKind(toolName: string): AiToolActivityIconKind {
+	if (toolName === "compute" || toolName === "orchestrate") {
+		return "code";
+	}
+
+	if (toolName.startsWith("web_") || toolName.startsWith("research_")) {
+		return toolName.includes("search") || toolName.includes("discover") ? "search" : "web";
+	}
+
+	if (toolName.startsWith("workspace_")) {
+		return toolName.includes("read") || toolName.includes("list") ? "file" : "edit";
+	}
+
+	return "web";
 }
 
 function humanizeToolName(value: string) {

--- a/src/features/workspaces/components/WorkspaceCardSkeleton.tsx
+++ b/src/features/workspaces/components/WorkspaceCardSkeleton.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from "#/components/ui/skeleton";
 
 export default function WorkspaceCardSkeleton() {
 	return (
-		<div className="relative flex overflow-hidden rounded-xl bg-muted/35 shadow-none ring-0 sm:block sm:bg-card sm:shadow-xs sm:ring-1 sm:ring-foreground/10 dark:bg-muted/20">
+		<div className="relative flex overflow-hidden rounded-xl bg-muted/35 shadow-none sm:block sm:bg-card sm:shadow-xs dark:bg-muted/20">
 			<Skeleton className="size-14 shrink-0 rounded-none bg-muted/45 sm:aspect-[5/2] sm:size-auto sm:w-full" />
 			<Skeleton className="absolute top-1/2 right-2 size-8 -translate-y-1/2 rounded-md bg-muted/55 sm:top-2 sm:translate-y-0" />
 			<div className="min-w-0 flex-1 space-y-2 px-3 py-2.5 pr-12 sm:px-4 sm:py-3 sm:pr-4">

--- a/src/features/workspaces/components/ai-chat/AiChatAssistantPending.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatAssistantPending.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { RefreshCw } from "lucide-react";
 
 import { Bubble, BubbleContent } from "#/components/ui/bubble";
@@ -33,6 +34,10 @@ function AiChatAssistantPendingBody({ pending }: { pending: AssistantPendingKind
 		);
 	}
 
+	if (pending === "working") {
+		return <AiChatWorkingLoader />;
+	}
+
 	return <AiChatThinkingLoader />;
 }
 
@@ -47,6 +52,16 @@ function AiChatThinkingLoader() {
 	);
 }
 
+function AiChatWorkingLoader() {
+	return (
+		<Marker role="status" aria-label="Still working" aria-live="polite" className="gap-0 py-1.5">
+			<MarkerIcon className="size-[18px]">
+				<ThinkExThinkingMark />
+			</MarkerIcon>
+		</Marker>
+	);
+}
+
 export function ThinkExThinkingMark({ className }: { className?: string }) {
 	return (
 		<svg
@@ -56,30 +71,30 @@ export function ThinkExThinkingMark({ className }: { className?: string }) {
 			}
 			aria-hidden="true"
 		>
-			<g className="thinkex-thinking-block" style={{ animationDelay: "0ms" }}>
+			<ThinkExThinkingBlock name="top-left">
 				<rect fill="currentColor" width="139.636" height="139.636" rx="18.5818" />
-			</g>
-			<g className="thinkex-thinking-block" style={{ animationDelay: "95ms" }}>
+			</ThinkExThinkingBlock>
+			<ThinkExThinkingBlock name="top-middle">
 				<rect fill="currentColor" x="186.182" width="139.636" height="116.364" rx="18.5818" />
-			</g>
-			<g className="thinkex-thinking-block" style={{ animationDelay: "215ms" }}>
+			</ThinkExThinkingBlock>
+			<ThinkExThinkingBlock name="top-right">
 				<rect fill="currentColor" x="372.364" width="139.636" height="139.636" rx="18.5818" />
-			</g>
-			<g className="thinkex-thinking-block" style={{ animationDelay: "355ms" }}>
+			</ThinkExThinkingBlock>
+			<ThinkExThinkingBlock name="right-middle">
 				<path
 					fill="#5C8BD6"
 					fillRule="evenodd"
 					d="M 387.9458 183.1820 H 493.4182 Q 512.0000 183.1820 512.0000 201.7638 V 356.7822 Q 512.0000 375.3640 493.4182 375.3640 H 387.9458 Q 369.3640 375.3640 369.3640 356.7822 V 201.7638 Q 369.3640 183.1820 387.9458 183.1820 Z M 398.8640 205.1820 Q 391.3640 205.1820 391.3640 212.6820 V 345.8640 Q 391.3640 353.3640 398.8640 353.3640 H 485.5000 Q 493.0000 353.3640 493.0000 345.8640 V 212.6820 Q 493.0000 205.1820 485.5000 205.1820 H 398.8640 Z"
 				/>
-			</g>
-			<g className="thinkex-thinking-block" style={{ animationDelay: "520ms" }}>
+			</ThinkExThinkingBlock>
+			<ThinkExThinkingBlock name="bottom-right">
 				<path
 					fill="#F7B53B"
 					fillRule="evenodd"
 					d="M 387.9458 415.9090 H 493.4182 Q 512.0000 415.9090 512.0000 434.4908 V 493.4182 Q 512.0000 512.0000 493.4182 512.0000 H 387.9458 Q 369.3640 512.0000 369.3640 493.4182 V 434.4908 Q 369.3640 415.9090 387.9458 415.9090 Z M 398.8640 437.9090 Q 391.3640 437.9090 391.3640 445.4090 V 485.4999 Q 391.3640 492.9999 398.8640 492.9999 H 485.5000 Q 493.0000 492.9999 493.0000 485.4999 V 445.4090 Q 493.0000 437.9090 485.5000 437.9090 H 398.8640 Z"
 				/>
-			</g>
-			<g className="thinkex-thinking-block" style={{ animationDelay: "700ms" }}>
+			</ThinkExThinkingBlock>
+			<ThinkExThinkingBlock name="center">
 				<rect
 					fill="currentColor"
 					x="186.182"
@@ -88,21 +103,41 @@ export function ThinkExThinkingMark({ className }: { className?: string }) {
 					height="349.091"
 					rx="18.5818"
 				/>
-			</g>
-			<g className="thinkex-thinking-block" style={{ animationDelay: "905ms" }}>
+			</ThinkExThinkingBlock>
+			<ThinkExThinkingBlock name="bottom-left">
 				<path
 					fill="#73BF7A"
 					fillRule="evenodd"
 					d="M 18.5818 322.8180 H 124.0542 Q 142.6360 322.8180 142.6360 341.3998 V 493.4182 Q 142.6360 512.0000 124.0542 512.0000 H 18.5818 Q 0.0000 512.0000 0.0000 493.4182 V 341.3998 Q 0.0000 322.8180 18.5818 322.8180 Z M 26.5000 344.8180 Q 19.0000 344.8180 19.0000 352.3180 V 485.5000 Q 19.0000 493.0000 26.5000 493.0000 H 113.1360 Q 120.6360 493.0000 120.6360 485.5000 V 352.3180 Q 120.6360 344.8180 113.1360 344.8180 H 26.5000 Z"
 				/>
-			</g>
-			<g className="thinkex-thinking-block" style={{ animationDelay: "1140ms" }}>
+			</ThinkExThinkingBlock>
+			<ThinkExThinkingBlock name="red-left">
 				<path
 					fill="#DA4944"
 					fillRule="evenodd"
 					d="M 18.5818 183.1820 H 124.0542 Q 142.6360 183.1820 142.6360 201.7638 V 263.6911 Q 142.6360 282.2729 124.0542 282.2729 H 18.5818 Q 0.0000 282.2729 0.0000 263.6911 V 201.7638 Q 0.0000 183.1820 18.5818 183.1820 Z M 26.5000 205.1820 Q 19.0000 205.1820 19.0000 212.6820 V 252.7729 Q 19.0000 260.2729 26.5000 260.2729 H 113.1360 Q 120.6360 260.2729 120.6360 252.7729 V 212.6820 Q 120.6360 205.1820 113.1360 205.1820 H 26.5000 Z"
 				/>
-			</g>
+			</ThinkExThinkingBlock>
 		</svg>
 	);
+}
+
+type ThinkExThinkingBlockName =
+	| "top-left"
+	| "top-middle"
+	| "top-right"
+	| "right-middle"
+	| "bottom-right"
+	| "center"
+	| "bottom-left"
+	| "red-left";
+
+function ThinkExThinkingBlock({
+	children,
+	name,
+}: {
+	children: ReactNode;
+	name: ThinkExThinkingBlockName;
+}) {
+	return <g className={`thinkex-thinking-block thinkex-thinking-block--${name}`}>{children}</g>;
 }

--- a/src/features/workspaces/components/ai-chat/AiChatMessageList.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatMessageList.tsx
@@ -1,6 +1,6 @@
 import type { ChatErrorClassification, ChatErrorContext } from "@cloudflare/think";
 import { AlertCircle, RotateCcw } from "lucide-react";
-import { motion, useReducedMotion } from "motion/react";
+import { LazyMotion, domAnimation, m, useReducedMotion } from "motion/react";
 import type { HTMLMotionProps } from "motion/react";
 import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
@@ -148,28 +148,30 @@ export default function AiChatMessageList({
 							aria-busy={isStreamActive}
 							className={aiChatMessageScrollerContentClassName}
 						>
-							{rows.map((row) => (
-								<AiChatMessageScrollerItem
-									key={row.key}
-									entryAnimation={
-										shouldReduceMotion
-											? null
-											: getAiChatRowEntryAnimation(row, sentMessageAnimationId)
-									}
-									enableLayoutMotion={!shouldReduceMotion}
-									messageId={getAiChatRowMessageId(row)}
-									scrollAnchor={isAiChatRowScrollAnchor(row)}
-								>
-									<AiChatListRowView
-										canRetry={Boolean(onRegenerateLastResponse)}
-										hasAssistantContent={hasAssistantContent}
-										lastAssistantMessageId={lastAssistantMessageId}
-										row={row}
-										status={status}
-										onRegenerateLastResponse={onRegenerateLastResponse}
-									/>
-								</AiChatMessageScrollerItem>
-							))}
+							<LazyMotion features={domAnimation}>
+								{rows.map((row) => (
+									<AiChatMessageScrollerItem
+										key={row.key}
+										entryAnimation={
+											shouldReduceMotion
+												? null
+												: getAiChatRowEntryAnimation(row, sentMessageAnimationId)
+										}
+										enableLayoutMotion={!shouldReduceMotion}
+										messageId={getAiChatRowMessageId(row)}
+										scrollAnchor={isAiChatRowScrollAnchor(row)}
+									>
+										<AiChatListRowView
+											canRetry={Boolean(onRegenerateLastResponse)}
+											hasAssistantContent={hasAssistantContent}
+											lastAssistantMessageId={lastAssistantMessageId}
+											row={row}
+											status={status}
+											onRegenerateLastResponse={onRegenerateLastResponse}
+										/>
+									</AiChatMessageScrollerItem>
+								))}
+							</LazyMotion>
 						</MessageScrollerContent>
 					</MessageScrollerViewport>
 					<MessageScrollerButton className={aiChatMessageScrollerButtonClassName} />
@@ -219,13 +221,13 @@ function AiChatMessageScrollerItem({
 
 	return (
 		<MessageScrollerItem messageId={messageId} scrollAnchor={scrollAnchor}>
-			<motion.div
+			<m.div
 				layout={enableLayoutMotion ? "position" : false}
 				className="min-w-0"
 				{...animationProps}
 			>
 				{children}
-			</motion.div>
+			</m.div>
 		</MessageScrollerItem>
 	);
 }

--- a/src/features/workspaces/components/ai-chat/AiChatMessageList.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatMessageList.tsx
@@ -1,5 +1,8 @@
 import type { ChatErrorClassification, ChatErrorContext } from "@cloudflare/think";
 import { AlertCircle, RotateCcw } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
+import type { HTMLMotionProps } from "motion/react";
+import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 import ThinkExLogo from "#/components/ThinkExLogo";
 import { Button } from "#/components/ui/button";
@@ -41,6 +44,23 @@ type SelectedText = {
 	text: string;
 };
 
+const sentMessageAnimation = {
+	animate: { opacity: 1, scale: 1, y: 0 },
+	initial: { opacity: 0, scale: 0.985, y: 18 },
+	transition: { duration: 0.22, ease: [0.22, 1, 0.36, 1] },
+} satisfies Pick<HTMLMotionProps<"div">, "animate" | "initial" | "transition">;
+
+const tailRowAnimation = {
+	animate: { opacity: 1, y: 0 },
+	initial: { opacity: 0, y: 6 },
+	transition: { duration: 0.18, ease: [0.22, 1, 0.36, 1] },
+} satisfies Pick<HTMLMotionProps<"div">, "animate" | "initial" | "transition">;
+
+const rowLayoutTransition = {
+	duration: 0.24,
+	ease: [0.22, 1, 0.36, 1],
+} satisfies HTMLMotionProps<"div">["transition"];
+
 export type AiChatAssistantErrorState =
 	| {
 			classification?: ChatErrorClassification | null;
@@ -74,6 +94,7 @@ interface AiChatMessageListProps {
 	messages: AiChatMessage[];
 	onRegenerateLastResponse?: () => void;
 	presentation: AiChatPresentation;
+	sentMessageAnimationId?: string | null;
 	workspaceId: string;
 }
 
@@ -82,6 +103,7 @@ export default function AiChatMessageList({
 	messages,
 	onRegenerateLastResponse,
 	presentation,
+	sentMessageAnimationId,
 	workspaceId,
 }: AiChatMessageListProps) {
 	const { lastAssistantMessageId, status } = presentation;
@@ -89,6 +111,7 @@ export default function AiChatMessageList({
 	const hasAssistantContent = hasLatestAssistantContent(rows);
 	const isStreamActive = isAiChatStreamActive(status);
 	const listRef = useRef<HTMLDivElement>(null);
+	const shouldReduceMotion = useReducedMotion();
 	const [selectedText, setSelectedText] = useState<SelectedText | null>(null);
 	const showEmptyState = rows.length === 0 && !assistantError;
 
@@ -126,8 +149,14 @@ export default function AiChatMessageList({
 							className={aiChatMessageScrollerContentClassName}
 						>
 							{rows.map((row) => (
-								<MessageScrollerItem
+								<AiChatMessageScrollerItem
 									key={row.key}
+									entryAnimation={
+										shouldReduceMotion
+											? null
+											: getAiChatRowEntryAnimation(row, sentMessageAnimationId)
+									}
+									enableLayoutMotion={!shouldReduceMotion}
 									messageId={getAiChatRowMessageId(row)}
 									scrollAnchor={isAiChatRowScrollAnchor(row)}
 								>
@@ -139,7 +168,7 @@ export default function AiChatMessageList({
 										status={status}
 										onRegenerateLastResponse={onRegenerateLastResponse}
 									/>
-								</MessageScrollerItem>
+								</AiChatMessageScrollerItem>
 							))}
 						</MessageScrollerContent>
 					</MessageScrollerViewport>
@@ -163,6 +192,41 @@ export default function AiChatMessageList({
 				/>
 			) : null}
 		</div>
+	);
+}
+
+function AiChatMessageScrollerItem({
+	children,
+	enableLayoutMotion,
+	entryAnimation,
+	messageId,
+	scrollAnchor,
+}: {
+	children: ReactNode;
+	enableLayoutMotion: boolean;
+	entryAnimation: "sent" | "tail" | null;
+	messageId: string;
+	scrollAnchor: boolean;
+}) {
+	const animationProps: Pick<
+		HTMLMotionProps<"div">,
+		"animate" | "initial" | "transition"
+	> = entryAnimation === "sent"
+		? sentMessageAnimation
+		: entryAnimation === "tail"
+			? tailRowAnimation
+			: { initial: false, transition: rowLayoutTransition };
+
+	return (
+		<MessageScrollerItem messageId={messageId} scrollAnchor={scrollAnchor}>
+			<motion.div
+				layout={enableLayoutMotion ? "position" : false}
+				className="min-w-0"
+				{...animationProps}
+			>
+				{children}
+			</motion.div>
+		</MessageScrollerItem>
 	);
 }
 
@@ -322,6 +386,21 @@ function getAiChatRowMessageId(row: AiChatListRow) {
 	}
 
 	return row.key;
+}
+
+function getAiChatRowEntryAnimation(
+	row: AiChatListRow,
+	sentMessageAnimationId?: string | null,
+): "sent" | "tail" | null {
+	if (getAiChatRowMessageId(row) === sentMessageAnimationId) {
+		return "sent";
+	}
+
+	if (row.type === "pending") {
+		return "tail";
+	}
+
+	return null;
 }
 
 function isAiChatRowScrollAnchor(row: AiChatListRow) {

--- a/src/features/workspaces/components/ai-chat/AiChatThreadView.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatThreadView.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from "react";
+import { generateId } from "ai";
+import { useEffect, useState } from "react";
 
 import type { PromptInputMessage } from "#/features/workspaces/components/ai-chat/ai-chat-prompt-input";
 import type { AIInspectorSnapshot } from "#/features/workspaces/ai/ai-inspector";
@@ -36,6 +37,7 @@ export default function AiChatThreadView({
 	threadId: string;
 }) {
 	const chat = useWorkspaceAiChat({ modelId, threadId });
+	const [sentMessageAnimationId, setSentMessageAnimationId] = useState<string | null>(null);
 	const {
 		connectionError,
 		error,
@@ -69,7 +71,7 @@ export default function AiChatThreadView({
 	});
 
 	const sendMessage = (message: PromptInputMessage) => {
-		const chatMessage = getChatMessageFromPrompt(message);
+		const chatMessage = getChatMessageFromPrompt(message, generateId());
 
 		if (!chatMessage) {
 			return false;
@@ -82,6 +84,7 @@ export default function AiChatThreadView({
 		});
 
 		if (didSend) {
+			setSentMessageAnimationId(chatMessage.id);
 			clearDraftArtifacts(context.workspaceId);
 		}
 
@@ -94,6 +97,7 @@ export default function AiChatThreadView({
 				assistantError={assistantError}
 				messages={messages}
 				presentation={presentation}
+				sentMessageAnimationId={sentMessageAnimationId}
 				workspaceId={context.workspaceId}
 				onRegenerateLastResponse={regenerate}
 			/>
@@ -118,7 +122,10 @@ export default function AiChatThreadView({
 	);
 }
 
-function getChatMessageFromPrompt(message: PromptInputMessage): AiChatSendMessage | null {
+function getChatMessageFromPrompt(
+	message: PromptInputMessage,
+	id: string,
+): AiChatSendMessage | null {
 	const trimmedText = message.text.trim();
 	const parts = [
 		...(trimmedText ? [{ type: "text" as const, text: trimmedText }] : []),
@@ -129,7 +136,7 @@ function getChatMessageFromPrompt(message: PromptInputMessage): AiChatSendMessag
 		return null;
 	}
 
-	return { role: "user", parts };
+	return { id, role: "user", parts };
 }
 
 function getAssistantErrorState(input: {

--- a/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
@@ -1,7 +1,19 @@
-import { ChevronDown } from "lucide-react";
+import {
+	AlertTriangle,
+	CheckCircle2,
+	ChevronDown,
+	Code2,
+	FileText,
+	Globe2,
+	LoaderCircle,
+	PencilLine,
+	Search,
+} from "lucide-react";
+import { LazyMotion, domAnimation, m, useReducedMotion } from "motion/react";
+import type { ReactNode } from "react";
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "#/components/ui/collapsible";
-import { Marker, MarkerContent } from "#/components/ui/marker";
+import { getAiToolActivityIconKind } from "#/features/workspaces/ai/ai-tool-presentation";
 import {
 	AiChatComputeDetails,
 	AiChatComputeImages,
@@ -11,7 +23,16 @@ import {
 	type AiChatToolChildActivity,
 	type AiChatToolActivity,
 } from "#/features/workspaces/components/ai-chat/ai-chat-display-state";
+import {
+	getToolSourceHostname,
+	getToolSourcePreviews,
+	type ToolSourcePreview,
+} from "#/features/workspaces/components/ai-chat/ai-chat-tool-source-previews";
 import type { AiChatToolPart } from "#/features/workspaces/components/ai-chat/types";
+import { cn } from "#/lib/utils";
+
+const INLINE_SOURCE_LIMIT = 3;
+const DETAIL_SOURCE_LIMIT = 8;
 
 export function AiChatToolActivityRow({
 	part,
@@ -20,6 +41,7 @@ export function AiChatToolActivityRow({
 	part: AiChatToolPart;
 	nestedChildren?: AiChatToolChildActivity[];
 }) {
+	const shouldReduceMotion = useReducedMotion();
 	const activity = getToolActivityForPart(part);
 
 	if (!activity) {
@@ -28,40 +50,71 @@ export function AiChatToolActivityRow({
 
 	const details = getActivityDetails(activity);
 	const inlineContent = getInlineActivityContent(activity);
-	const hasDetails = nestedChildren.length > 0 || details !== null;
+	const sourcePreviews = getToolSourcePreviews(activity);
+	const hasDetails = nestedChildren.length > 0 || details !== null || sourcePreviews.length > 0;
+	const content =
+		!hasDetails && !inlineContent && sourcePreviews.length === 0 ? (
+			<ActivitySummary activity={activity} sourcePreviews={sourcePreviews} />
+		) : (
+			<div className="max-w-full space-y-2">
+				{hasDetails ? (
+					<Collapsible className="w-fit max-w-full">
+						<div className="inline-flex min-w-0 max-w-full items-center gap-1.5">
+							<CollapsibleTrigger className="group/collapsible min-w-0 max-w-full text-left">
+								<ActivitySummary activity={activity} canExpand sourcePreviews={[]} />
+							</CollapsibleTrigger>
+							<InlineSourceFavicons sources={sourcePreviews.slice(0, INLINE_SOURCE_LIMIT)} />
+						</div>
+						<CollapsibleContent className="mt-2 space-y-3 pl-7">
+							{details}
+							{sourcePreviews.length > 0 ? <SourceDetailList sources={sourcePreviews} /> : null}
+							{nestedChildren.length > 0 ? (
+								<div className="space-y-1">
+									{nestedChildren.map((child) => (
+										<div
+											key={`${child.toolName}:${child.summary}`}
+											className="text-muted-foreground/80 text-sm"
+										>
+											{child.summary}
+										</div>
+									))}
+								</div>
+							) : null}
+						</CollapsibleContent>
+					</Collapsible>
+				) : (
+					<ActivitySummary activity={activity} sourcePreviews={sourcePreviews} />
+				)}
+				{inlineContent}
+			</div>
+		);
 
-	if (!hasDetails && !inlineContent) {
-		return <ActivitySummary activity={activity} />;
+	return <ToolActivityMotion disabled={shouldReduceMotion}>{content}</ToolActivityMotion>;
+}
+
+function ToolActivityMotion({
+	children,
+	disabled,
+}: {
+	children: ReactNode;
+	disabled: boolean | null;
+}) {
+	if (disabled) {
+		return children;
 	}
 
 	return (
-		<div className="max-w-full space-y-2">
-			{hasDetails ? (
-				<Collapsible className="w-fit max-w-full">
-					<CollapsibleTrigger className="w-fit max-w-full text-left">
-						<ActivitySummary activity={activity} canExpand />
-					</CollapsibleTrigger>
-					<CollapsibleContent className="mt-2 space-y-2 pl-7">
-						{details}
-						{nestedChildren.length > 0 ? (
-							<div className="space-y-1">
-								{nestedChildren.map((child) => (
-									<div
-										key={`${child.toolName}:${child.summary}`}
-										className="text-muted-foreground/80 text-sm"
-									>
-										{child.summary}
-									</div>
-								))}
-							</div>
-						) : null}
-					</CollapsibleContent>
-				</Collapsible>
-			) : (
-				<ActivitySummary activity={activity} />
-			)}
-			{inlineContent}
-		</div>
+		<LazyMotion features={domAnimation}>
+			<m.div
+				layout="position"
+				initial={{ opacity: 0, y: 2 }}
+				animate={{ opacity: 1, y: 0 }}
+				transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
+				className="max-w-full origin-top-left will-change-transform"
+			>
+				{children}
+			</m.div>
+		</LazyMotion>
 	);
 }
 
@@ -84,27 +137,209 @@ function getActivityDetails(activity: AiChatToolActivity) {
 function ActivitySummary({
 	activity,
 	canExpand = false,
+	sourcePreviews,
 }: {
 	activity: AiChatToolActivity;
 	canExpand?: boolean;
+	sourcePreviews: ToolSourcePreview[];
 }) {
 	const isRunning = activity.status === "running";
+	const title = activity.title;
+	const summary = activity.summary === title ? "" : activity.summary;
+	const fullLabel = summary ? `${title} · ${summary}` : title;
 
-	if (isRunning) {
+	return (
+		<div
+			role={isRunning ? "status" : undefined}
+			aria-live={isRunning ? "polite" : undefined}
+			title={fullLabel}
+			className={cn(
+				"group/tool-row inline-flex min-w-0 max-w-full items-center gap-1.5 py-0.5 text-sm text-muted-foreground",
+				activity.status === "failed" && "text-destructive",
+			)}
+		>
+			<span
+				className={cn(
+					"grid size-4 shrink-0 place-items-center self-center text-muted-foreground/80",
+					activity.status === "failed" && "text-destructive",
+				)}
+			>
+				<ToolActivityIcon toolName={activity.toolName} />
+			</span>
+			<span className="min-w-0 truncate">
+				<span className={cn("font-medium text-foreground/90", isRunning && "shimmer")}>
+					{title}
+				</span>
+				{summary ? (
+					<span className="text-muted-foreground/70">
+						{" · "}
+						{summary}
+					</span>
+				) : null}
+			</span>
+			<InlineSourceFavicons sources={sourcePreviews.slice(0, INLINE_SOURCE_LIMIT)} />
+			<ToolStatusIcon status={activity.status} />
+			{canExpand ? (
+				<ChevronDown
+					className="size-3.5 shrink-0 self-center text-muted-foreground/70 transition-transform group-data-[panel-open]/collapsible:rotate-180"
+					aria-hidden="true"
+				/>
+			) : null}
+		</div>
+	);
+}
+
+function InlineSourceFavicons({ sources }: { sources: ToolSourcePreview[] }) {
+	if (sources.length === 0) {
+		return null;
+	}
+
+	return (
+		<span className="inline-flex shrink-0 items-center -space-x-1 self-center pl-0.5">
+			{sources.map((source) => (
+				<SourceFaviconLink key={`${source.url ?? source.title}:${source.title}`} source={source} />
+			))}
+		</span>
+	);
+}
+
+function SourceFaviconLink({ source }: { source: ToolSourcePreview }) {
+	const hostname = source.url ? getToolSourceHostname(source.url) : null;
+	const content = (
+		<span className="grid size-4 place-items-center rounded-full bg-background ring-1 ring-border/70">
+			<Favicon hostname={hostname} title={source.title} className="size-3 rounded-[2px]" />
+		</span>
+	);
+
+	if (!source.url) {
+		return content;
+	}
+
+	return (
+		<a
+			href={source.url}
+			target="_blank"
+			rel="noreferrer"
+			className="outline-none transition-transform hover:z-10 hover:scale-110 focus-visible:z-10 focus-visible:scale-110"
+			title={hostname ?? source.title}
+		>
+			{content}
+		</a>
+	);
+}
+
+function SourceDetailList({ sources }: { sources: ToolSourcePreview[] }) {
+	const visibleSources = sources.slice(0, DETAIL_SOURCE_LIMIT);
+	const remainingSourceCount = sources.length - visibleSources.length;
+
+	return (
+		<div className="grid max-w-xl gap-1">
+			{visibleSources.map((source) => (
+				<SourceDetailItem key={`${source.url ?? source.title}:${source.title}`} source={source} />
+			))}
+			{remainingSourceCount > 0 ? (
+				<div className="px-1 text-muted-foreground text-xs">
+					+ {remainingSourceCount} more source{remainingSourceCount === 1 ? "" : "s"}
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+function SourceDetailItem({ source }: { source: ToolSourcePreview }) {
+	const hostname = source.url ? getToolSourceHostname(source.url) : null;
+	const title = source.url ? (
+		<a href={source.url} target="_blank" rel="noreferrer" className="hover:underline">
+			{source.title}
+		</a>
+	) : (
+		source.title
+	);
+
+	return (
+		<div className="grid grid-cols-[auto_minmax(0,1fr)] gap-2 py-1">
+			<Favicon hostname={hostname} title={source.title} className="size-3.5 rounded-sm" />
+			<div className="min-w-0">
+				<div className="truncate font-medium text-foreground/90 text-xs">{title}</div>
+				{hostname || source.kind ? (
+					<div className="truncate text-muted-foreground text-[11px]">
+						{[source.kind, hostname].filter(Boolean).join(" · ")}
+					</div>
+				) : null}
+				{source.description ? (
+					<p className="mt-1 line-clamp-2 text-muted-foreground/80 text-xs leading-4">
+						{source.description}
+					</p>
+				) : null}
+			</div>
+		</div>
+	);
+}
+
+function Favicon({
+	className,
+	hostname,
+	title,
+}: {
+	className?: string;
+	hostname: string | null;
+	title: string;
+}) {
+	if (!hostname) {
 		return (
-			<Marker role="status" aria-live="polite" className="w-fit max-w-full py-1 text-sm">
-				<MarkerContent className="shimmer ai-status-shimmer">{activity.summary}</MarkerContent>
-				{canExpand ? <ChevronDown className="size-3 shrink-0" aria-hidden="true" /> : null}
-			</Marker>
+			<span
+				className={cn(
+					"grid size-3.5 shrink-0 place-items-center rounded-sm bg-muted text-[9px] text-muted-foreground",
+					className,
+				)}
+			>
+				{title.charAt(0).toUpperCase()}
+			</span>
 		);
 	}
 
 	return (
-		<Marker className="w-fit max-w-full py-1 text-sm">
-			<MarkerContent className="truncate text-muted-foreground/80">
-				{activity.summary}
-			</MarkerContent>
-			{canExpand ? <ChevronDown className="size-3 shrink-0" aria-hidden="true" /> : null}
-		</Marker>
+		<img
+			src={`https://www.google.com/s2/favicons?domain=${encodeURIComponent(hostname)}&sz=32`}
+			alt=""
+			className={cn("size-3.5 shrink-0 rounded-sm", className)}
+			loading="lazy"
+		/>
+	);
+}
+
+function ToolActivityIcon({ toolName }: { toolName: string }) {
+	switch (getAiToolActivityIconKind(toolName)) {
+		case "code":
+			return <Code2 className="size-3.5" aria-hidden="true" />;
+		case "edit":
+			return <PencilLine className="size-3.5" aria-hidden="true" />;
+		case "file":
+			return <FileText className="size-3.5" aria-hidden="true" />;
+		case "search":
+			return <Search className="size-3.5" aria-hidden="true" />;
+		case "web":
+			return <Globe2 className="size-3.5" aria-hidden="true" />;
+		default:
+			return <Globe2 className="size-3.5" aria-hidden="true" />;
+	}
+}
+
+function ToolStatusIcon({ status }: { status: AiChatToolActivity["status"] }) {
+	const className = cn(
+		"size-3.5 shrink-0 text-muted-foreground/70",
+		status === "running" && "animate-spin",
+		status === "completed" && "text-success",
+		status === "failed" && "text-destructive",
+	);
+
+	if (status === "running") {
+		return <LoaderCircle className={className} aria-hidden="true" />;
+	}
+
+	return status === "failed" ? (
+		<AlertTriangle className={className} aria-hidden="true" />
+	) : (
+		<CheckCircle2 className={className} aria-hidden="true" />
 	);
 }

--- a/src/features/workspaces/components/ai-chat/ai-chat-display-state.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-display-state.ts
@@ -10,7 +10,10 @@ import {
 	getAiToolActivityTitle,
 	getAiToolPresentation,
 } from "#/features/workspaces/ai/ai-tool-presentation";
-import { getFinishedToolReceipt } from "#/features/workspaces/components/ai-chat/ai-chat-tool-receipts";
+import {
+	getFinishedToolReceipt,
+	getRunningToolReceipt,
+} from "#/features/workspaces/components/ai-chat/ai-chat-tool-receipts";
 
 export type AssistantPendingKind = "thinking" | "working" | "recovering";
 export interface AiChatToolChildActivity {
@@ -70,8 +73,8 @@ export function deriveAiChatPresentation(
 ): AiChatPresentation {
 	const lastMessage = messages.at(-1);
 	const lastAssistantMessageId = lastMessage?.role === "assistant" ? lastMessage.id : undefined;
-	const isBusy = isRecovering || isStreaming || isServerStreaming;
 	const awaitingFirstToken = status === "submitted" && !isToolContinuation;
+	const isBusy = isRecovering || isStreaming || isServerStreaming || status === "submitted";
 	const hasAssistantTail = lastMessage?.role === "assistant";
 	const assistantTailIsEmpty =
 		lastMessage?.role === "assistant" && getDisplayableParts(lastMessage).length === 0;
@@ -80,11 +83,13 @@ export function deriveAiChatPresentation(
 		? hasVisibleAssistantTail
 			? "working"
 			: "recovering"
-		: !isBusy
-			? null
-			: awaitingFirstToken || !hasVisibleAssistantTail
-				? "thinking"
-				: "working";
+		: awaitingFirstToken
+			? "thinking"
+			: !isBusy
+				? null
+				: !hasVisibleAssistantTail
+					? "thinking"
+					: "working";
 
 	return {
 		isBusy,
@@ -217,7 +222,7 @@ export function getToolActivityForPart(part: AiChatToolPart): AiChatToolActivity
 
 	const toolName = getToolPartName(part);
 	const title = getToolActivityTitle(part, toolName);
-	const receipt = getToolActivityReceipt(part, toolName, title);
+	const receipt = getToolActivityReceipt(part, toolName);
 
 	return {
 		children: [],
@@ -248,7 +253,6 @@ function getToolActivityTitle(part: AiChatToolPart, toolName: string) {
 function getToolActivityReceipt(
 	part: AiChatToolPart,
 	toolName: string,
-	title: string,
 ): { status: AiChatToolActivity["status"]; summary: string } {
 	switch (part.state) {
 		case "output-available":
@@ -269,7 +273,10 @@ function getToolActivityReceipt(
 		default:
 			return {
 				status: "running",
-				summary: title,
+				summary: getRunningToolReceipt({
+					toolInput: part.input,
+					toolName,
+				}).summary,
 			};
 	}
 }

--- a/src/features/workspaces/components/ai-chat/ai-chat-display-state.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-display-state.ts
@@ -12,7 +12,7 @@ import {
 } from "#/features/workspaces/ai/ai-tool-presentation";
 import { getFinishedToolReceipt } from "#/features/workspaces/components/ai-chat/ai-chat-tool-receipts";
 
-export type AssistantPendingKind = "thinking" | "recovering";
+export type AssistantPendingKind = "thinking" | "working" | "recovering";
 export interface AiChatToolChildActivity {
 	summary: string;
 	toolName: string;
@@ -75,14 +75,16 @@ export function deriveAiChatPresentation(
 	const hasAssistantTail = lastMessage?.role === "assistant";
 	const assistantTailIsEmpty =
 		lastMessage?.role === "assistant" && getDisplayableParts(lastMessage).length === 0;
+	const hasVisibleAssistantTail = hasAssistantTail && !assistantTailIsEmpty;
 	const tailPending = isRecovering
-		? hasAssistantTail && !assistantTailIsEmpty
-			? null
+		? hasVisibleAssistantTail
+			? "working"
 			: "recovering"
-		: !isToolContinuation &&
-			  (awaitingFirstToken || (isBusy && (!hasAssistantTail || assistantTailIsEmpty)))
-			? "thinking"
-			: null;
+		: !isBusy
+			? null
+			: awaitingFirstToken || !hasVisibleAssistantTail
+				? "thinking"
+				: "working";
 
 	return {
 		isBusy,

--- a/src/features/workspaces/components/ai-chat/ai-chat-tool-receipts.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-tool-receipts.ts
@@ -5,6 +5,48 @@ export interface AiChatToolReceipt {
 	summary: string;
 }
 
+const TOOL_RECEIPT_VALUE_MAX_LENGTH = 72;
+
+export function getRunningToolReceipt(input: {
+	toolInput: unknown;
+	toolName: string;
+}): Pick<AiChatToolReceipt, "summary"> {
+	const toolInput = asRecord(input.toolInput);
+
+	switch (input.toolName) {
+		case "workspace_create_items":
+			return running(`Creating ${formatCount(getArray(toolInput.items).length, "item")}`);
+		case "workspace_delete_items":
+			return running(`Deleting ${formatCount(getArray(toolInput.paths).length, "item")}`);
+		case "workspace_edit_item":
+			return running(`Editing ${quoteName(getBaseName(getString(toolInput.path)))}`);
+		case "workspace_list_items":
+			return running(`Listing ${formatPath(getString(toolInput.path) ?? "/")}`);
+		case "workspace_move_items":
+			return running(`Moving ${formatCount(getArray(toolInput.paths).length, "item")}`);
+		case "workspace_read_items":
+			return running(`Reading ${formatToolInputPaths(toolInput.paths)}`);
+		case "workspace_rename_item":
+			return running(`Renaming ${quoteName(getBaseName(getString(toolInput.path)))}`);
+		case "web_links":
+			return running(`Finding links on ${formatUrl(getString(toolInput.url))}`);
+		case "web_markdown":
+			return running(`Reading ${formatUrl(getString(toolInput.url))}`);
+		case "web_search":
+			return running(`Searching for ${quoteName(getString(toolInput.query))}`);
+		case "research_deepen":
+			return running(summarizeRunningResearchDeepen(toolInput));
+		case "research_discover":
+			return running(`Finding sources for ${quoteName(getString(toolInput.query))}`);
+		case "compute":
+			return running("Running Python");
+		case "orchestrate":
+			return running("Working through the task");
+		default:
+			return running("Working");
+	}
+}
+
 export function getFinishedToolReceipt(input: {
 	baseStatus: AiChatToolReceiptStatus;
 	output: unknown;
@@ -48,15 +90,15 @@ export function getFinishedToolReceipt(input: {
 		case "workspace_read_items":
 			return summarizeWorkspaceRead(input.output);
 		case "web_search":
-			return completed(summarizeWebSearch(input.output));
+			return completed(summarizeWebSearch(input.output, input.toolInput));
 		case "web_markdown":
-			return completed("Read 1 page");
+			return completed(`Read ${formatUrl(getString(asRecord(input.toolInput).url))}`);
 		case "web_links":
-			return completed(summarizeWebLinks(input.output));
+			return completed(summarizeWebLinks(input.output, input.toolInput));
 		case "research_discover":
-			return completed(summarizeResearchDiscover(input.output));
+			return completed(summarizeResearchDiscover(input.output, input.toolInput));
 		case "research_deepen":
-			return completed(summarizeResearchDeepen(input.output));
+			return completed(summarizeResearchDeepen(input.output, input.toolInput));
 		case "orchestrate":
 			return summarizeCodemode(input.output);
 		case "compute":
@@ -224,34 +266,51 @@ function summarizeWorkspaceRead(output: unknown): AiChatToolReceipt {
 	return completed(appendFailureCount(summary, failedCount));
 }
 
-function summarizeWebSearch(output: unknown) {
+function summarizeWebSearch(output: unknown, toolInput: unknown) {
 	const results = getArray(asRecord(output).results);
-	return `Found ${formatCount(results.length, "source")}`;
+	return appendSubject(`Found ${formatCount(results.length, "source")}`, asRecord(toolInput).query);
 }
 
-function summarizeWebLinks(output: unknown) {
+function summarizeWebLinks(output: unknown, toolInput: unknown) {
 	const items = getArray(asRecord(output).items);
-	return `Found ${formatCount(items.length, "link")}`;
+	return `Found ${formatCount(items.length, "link")} on ${formatUrl(getString(asRecord(toolInput).url))}`;
 }
 
-function summarizeResearchDiscover(output: unknown) {
+function summarizeResearchDiscover(output: unknown, toolInput: unknown) {
 	const record = asRecord(output);
 	const total = getArray(record.papers).length + getArray(record.github).length;
-	return `Found ${formatCount(total, "source")}`;
+	return appendSubject(`Found ${formatCount(total, "source")}`, asRecord(toolInput).query);
 }
 
-function summarizeResearchDeepen(output: unknown) {
+function summarizeResearchDeepen(output: unknown, toolInput: unknown) {
 	const record = asRecord(output);
+	const input = asRecord(toolInput);
+	const paper = getString(input.paper_id);
 
 	if (Array.isArray(record.passages)) {
-		return `Read ${formatCount(record.passages.length, "passage")}`;
+		return `Read ${formatCount(record.passages.length, "passage")} from ${quoteName(paper)}`;
 	}
 
 	if (Array.isArray(record.papers)) {
-		return `Found ${formatCount(record.papers.length, "paper")}`;
+		return `Found ${formatCount(record.papers.length, "paper")} related to ${quoteName(paper)}`;
 	}
 
 	return summarizeUnknownResult(output);
+}
+
+function summarizeRunningResearchDeepen(input: Record<string, unknown>) {
+	const paper = quoteName(getString(input.paper_id));
+	const mode = getString(input.mode);
+
+	if (mode === "passages") {
+		return `Reading passages from ${paper}`;
+	}
+
+	if (mode === "related") {
+		return `Finding related papers for ${paper}`;
+	}
+
+	return `Researching ${paper}`;
 }
 
 function summarizeCodemode(output: unknown): AiChatToolReceipt {
@@ -342,6 +401,10 @@ function completed(summary: string): AiChatToolReceipt {
 	};
 }
 
+function running(summary: string): Pick<AiChatToolReceipt, "summary"> {
+	return { summary };
+}
+
 function failed(summary: string): AiChatToolReceipt {
 	return {
 		status: "failed",
@@ -350,7 +413,7 @@ function failed(summary: string): AiChatToolReceipt {
 }
 
 function quoteName(value: string | undefined) {
-	return value ? `“${value}”` : "item";
+	return value ? `“${truncateReceiptValue(value)}”` : "item";
 }
 
 function joinNames(items: unknown[], fallbackNoun: string) {
@@ -375,6 +438,11 @@ function formatCount(count: number, noun: string) {
 	return `${safeCount} ${noun}${safeCount === 1 ? "" : "s"}`;
 }
 
+function appendSubject(summary: string, subject: unknown) {
+	const value = getString(subject);
+	return value ? `${summary} for ${quoteName(value)}` : summary;
+}
+
 function appendFailureCount(summary: string, failedCount: number) {
 	return failedCount > 0 ? `${summary}, ${formatCount(failedCount, "failure")}` : summary;
 }
@@ -390,6 +458,45 @@ function getBaseName(path: string | undefined) {
 
 function getPathFromToolInput(input: unknown) {
 	return getString(asRecord(input).path);
+}
+
+function formatPath(path: string) {
+	return path === "/" ? "workspace root" : quoteName(path);
+}
+
+function formatToolInputPaths(value: unknown) {
+	const paths = getArray(value)
+		.map((item) => getString(item))
+		.filter((item): item is string => Boolean(item));
+
+	if (paths.length === 1) {
+		return quoteName(getBaseName(paths[0]));
+	}
+
+	return formatCount(paths.length, "item");
+}
+
+function formatUrl(url: string | undefined) {
+	if (!url) {
+		return "page";
+	}
+
+	try {
+		return truncateReceiptValue(new URL(url).hostname.replace(/^www\./, ""));
+	} catch {
+		return truncateReceiptValue(url);
+	}
+}
+
+function truncateReceiptValue(value: string) {
+	const normalized = value.replace(/\s+/g, " ").trim();
+
+	if (normalized.length <= TOOL_RECEIPT_VALUE_MAX_LENGTH) {
+		return normalized;
+	}
+
+	const edgeLength = Math.floor((TOOL_RECEIPT_VALUE_MAX_LENGTH - 3) / 2);
+	return `${normalized.slice(0, edgeLength)}...${normalized.slice(-edgeLength)}`;
 }
 
 function asRecord(value: unknown): Record<string, unknown> {

--- a/src/features/workspaces/components/ai-chat/ai-chat-tool-source-previews.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-tool-source-previews.ts
@@ -1,0 +1,143 @@
+import type { AiChatToolActivity } from "#/features/workspaces/components/ai-chat/ai-chat-display-state";
+
+export interface ToolSourcePreview {
+	description?: string;
+	kind: string;
+	title: string;
+	url?: string;
+}
+
+export function getToolSourcePreviews(activity: AiChatToolActivity): ToolSourcePreview[] {
+	const output = asRecord(activity.detail.output);
+	const input = asRecord(activity.detail.input);
+
+	switch (activity.toolName) {
+		case "web_search":
+			return getArray(output.results).map((item) =>
+				sourcePreviewFromRecord(asRecord(item), {
+					descriptionKeys: ["snippet", "description"],
+					kind: "Web",
+					titleKeys: ["title"],
+					urlKeys: ["url"],
+				}),
+			);
+		case "web_links":
+			return getArray(output.items).map((item) =>
+				typeof item === "string"
+					? sourcePreviewFromUrl(item, "Link")
+					: sourcePreviewFromRecord(asRecord(item), {
+							kind: "Link",
+							titleKeys: ["title", "text", "label"],
+							urlKeys: ["url", "href"],
+						}),
+			);
+		case "web_markdown": {
+			const url = getString(input.url);
+			return url ? [sourcePreviewFromUrl(url, "Page")] : [];
+		}
+		case "research_discover":
+			return [
+				...getArray(output.papers).map((item) =>
+					sourcePreviewFromRecord(asRecord(item), {
+						descriptionKeys: ["abstract", "snippet"],
+						kind: "Paper",
+						titleKeys: ["title", "paper_id", "primary_id"],
+						urlKeys: ["url"],
+					}),
+				),
+				...getArray(output.github).map((item) =>
+					sourcePreviewFromRecord(asRecord(item), {
+						descriptionKeys: ["snippet"],
+						kind: "Repository",
+						titleKeys: ["repo", "title"],
+						urlKeys: ["url"],
+					}),
+				),
+			];
+		case "research_deepen":
+			return [
+				...getArray(output.papers).map((item) =>
+					sourcePreviewFromRecord(asRecord(item), {
+						descriptionKeys: ["abstract", "snippet"],
+						kind: "Paper",
+						titleKeys: ["title", "paper_id", "primary_id"],
+						urlKeys: ["url"],
+					}),
+				),
+				...(output.paper
+					? [
+							sourcePreviewFromRecord(asRecord(output.paper), {
+								descriptionKeys: ["abstract", "snippet"],
+								kind: "Paper",
+								titleKeys: ["title", "paper_id", "primary_id"],
+								urlKeys: ["url"],
+							}),
+						]
+					: []),
+			];
+		default:
+			return [];
+	}
+}
+
+export function getToolSourceHostname(url: string) {
+	try {
+		return new URL(url).hostname.replace(/^www\./, "");
+	} catch {
+		return null;
+	}
+}
+
+function sourcePreviewFromRecord(
+	record: Record<string, unknown>,
+	options: {
+		descriptionKeys?: string[];
+		kind: string;
+		titleKeys: string[];
+		urlKeys: string[];
+	},
+): ToolSourcePreview {
+	const url = getFirstString(record, options.urlKeys);
+	const title =
+		getFirstString(record, options.titleKeys) ??
+		(url ? getToolSourceHostname(url) : null) ??
+		options.kind;
+
+	return {
+		description: getFirstString(record, options.descriptionKeys ?? []),
+		kind: options.kind,
+		title,
+		url,
+	};
+}
+
+function sourcePreviewFromUrl(url: string, kind: string): ToolSourcePreview {
+	return {
+		kind,
+		title: getToolSourceHostname(url) ?? url,
+		url,
+	};
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+	return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+function getArray(value: unknown): unknown[] {
+	return Array.isArray(value) ? value : [];
+}
+
+function getString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function getFirstString(record: Record<string, unknown>, keys: string[]) {
+	for (const key of keys) {
+		const value = getString(record[key]);
+		if (value) {
+			return value;
+		}
+	}
+
+	return undefined;
+}

--- a/src/features/workspaces/components/ai-chat/types.ts
+++ b/src/features/workspaces/components/ai-chat/types.ts
@@ -8,6 +8,7 @@ export type AiChatToolPart = ToolUIPart | DynamicToolUIPart;
 export type AiChatModelId = WorkspaceAiChatModelId;
 
 export interface AiChatSendMessage {
+	id: string;
 	role: "user";
 	parts: AiChatMessagePart[];
 }

--- a/src/features/workspaces/model/workspace-ai-context-outline.ts
+++ b/src/features/workspaces/model/workspace-ai-context-outline.ts
@@ -1,0 +1,159 @@
+import { getWorkspaceItemTypeMeta } from "#/features/workspaces/defaults";
+import { buildWorkspaceKernelItemPathIndex } from "#/features/workspaces/kernel/workspace-kernel-paths";
+import type { WorkspaceItem } from "#/features/workspaces/model/types";
+
+import type {
+	WorkspaceAiContextOutline,
+	WorkspaceAiContextOutlineItem,
+	WorkspaceAiContextScope,
+} from "./workspace-ai-context-types";
+
+export const WORKSPACE_AI_CONTEXT_OUTLINE_ITEM_LIMIT = 50;
+
+type WorkspaceAiContextOutlineRow = {
+	item: WorkspaceItem;
+	outlineItem: WorkspaceAiContextOutlineItem;
+};
+
+export function buildWorkspaceAiContextOutline(
+	context: WorkspaceAiContextScope,
+): WorkspaceAiContextOutline {
+	const rows = getWorkspaceAiContextOutlineRows(context);
+	const totalItems = rows.length;
+
+	if (totalItems <= WORKSPACE_AI_CONTEXT_OUTLINE_ITEM_LIMIT) {
+		return {
+			status: "included",
+			totalItems,
+			items: rows.map((row) => row.outlineItem),
+		};
+	}
+
+	const items = summarizeWorkspaceAiContextOutlineRows({
+		rows,
+		limit: WORKSPACE_AI_CONTEXT_OUTLINE_ITEM_LIMIT,
+	}).map((row) => row.outlineItem);
+
+	return {
+		status: "summarized",
+		totalItems,
+		limit: WORKSPACE_AI_CONTEXT_OUTLINE_ITEM_LIMIT,
+		omittedItems: totalItems - items.length,
+		items,
+	};
+}
+
+function getWorkspaceAiContextOutlineRows(
+	context: WorkspaceAiContextScope,
+): WorkspaceAiContextOutlineRow[] {
+	const items = Array.from(context.itemsById.values());
+	const pathsByItemId = buildWorkspaceKernelItemPathIndex(items);
+	const childCountsByItemId = getWorkspaceAiContextOutlineChildCounts(items);
+	const descendantCountsByItemId = getWorkspaceAiContextOutlineDescendantCounts(items);
+
+	return Array.from(pathsByItemId, ([itemId, path]) => {
+		const item = context.itemsById.get(itemId);
+
+		if (!item) {
+			throw new Error("Workspace outline path index returned an unknown item.");
+		}
+
+		return {
+			item,
+			outlineItem: {
+				...(item.type === "folder"
+					? {
+							childCount: childCountsByItemId.get(item.id) ?? 0,
+							descendantCount: descendantCountsByItemId.get(item.id) ?? 0,
+						}
+					: {}),
+				path,
+				type: getWorkspaceItemTypeMeta(item.type),
+			},
+		};
+	});
+}
+
+function summarizeWorkspaceAiContextOutlineRows(input: {
+	rows: WorkspaceAiContextOutlineRow[];
+	limit: number;
+}) {
+	const rows: WorkspaceAiContextOutlineRow[] = [];
+	const selectedItemIds = new Set<string>();
+
+	const addRow = (row: WorkspaceAiContextOutlineRow) => {
+		if (rows.length >= input.limit || selectedItemIds.has(row.item.id)) {
+			return;
+		}
+
+		selectedItemIds.add(row.item.id);
+		rows.push(row);
+	};
+
+	for (const row of input.rows) {
+		if (row.item.type === "folder") {
+			addRow(row);
+		}
+	}
+
+	for (const row of input.rows) {
+		if (row.item.parentId === null && row.item.type !== "folder") {
+			addRow(row);
+		}
+	}
+
+	for (const row of input.rows) {
+		addRow(row);
+	}
+
+	return rows;
+}
+
+function getWorkspaceAiContextOutlineChildCounts(items: WorkspaceItem[]) {
+	const childCountsByItemId = new Map<string, number>();
+
+	for (const item of items) {
+		if (!item.parentId) {
+			continue;
+		}
+
+		childCountsByItemId.set(item.parentId, (childCountsByItemId.get(item.parentId) ?? 0) + 1);
+	}
+
+	return childCountsByItemId;
+}
+
+function getWorkspaceAiContextOutlineDescendantCounts(items: WorkspaceItem[]) {
+	const childrenByParentId = new Map<string | null, WorkspaceItem[]>();
+	const descendantCountsByItemId = new Map<string, number>();
+
+	for (const item of items) {
+		const children = childrenByParentId.get(item.parentId) ?? [];
+		children.push(item);
+		childrenByParentId.set(item.parentId, children);
+	}
+
+	const countDescendants = (itemId: string): number => {
+		const cachedCount = descendantCountsByItemId.get(itemId);
+
+		if (cachedCount !== undefined) {
+			return cachedCount;
+		}
+
+		const count = (childrenByParentId.get(itemId) ?? []).reduce(
+			(total, child) => total + 1 + countDescendants(child.id),
+			0,
+		);
+
+		descendantCountsByItemId.set(itemId, count);
+		return count;
+	};
+
+	for (const item of items) {
+		if (item.type === "folder") {
+			countDescendants(item.id);
+		}
+	}
+
+	return descendantCountsByItemId;
+}

--- a/src/features/workspaces/model/workspace-ai-context-prompt.ts
+++ b/src/features/workspaces/model/workspace-ai-context-prompt.ts
@@ -1,4 +1,5 @@
 import type {
+	WorkspaceAiContextOutline,
 	WorkspaceAiContextPaneReference,
 	WorkspaceAiContextPresentationReference,
 	WorkspaceAiContextSnapshotSelectedQuote,
@@ -14,6 +15,9 @@ import {
 	formatWorkspaceAiContextItemViewState,
 	formatWorkspaceAiContextItemViewStateSuffix,
 } from "./workspace-item-view-state";
+
+export const WORKSPACE_AI_CONTEXT_OUTLINE_PROMPT_CHAR_LIMIT = 6000;
+export const WORKSPACE_AI_CONTEXT_OUTLINE_PATH_CHAR_LIMIT = 180;
 
 export function formatWorkspaceAiContextForPrompt(value: unknown) {
 	if (!isWorkspaceAiContextSnapshot(value)) {
@@ -42,6 +46,12 @@ export function formatWorkspaceAiContextForPrompt(value: unknown) {
 		}
 	}
 
+	const outline = value.workspace.outline;
+
+	if (outline) {
+		lines.push(...formatWorkspaceAiContextOutline(outline));
+	}
+
 	if (openTabs.length > 0) {
 		lines.push("- Open workspace tabs:");
 		for (const tab of openTabs) {
@@ -60,6 +70,71 @@ export function formatWorkspaceAiContextForPrompt(value: unknown) {
 	}
 
 	return lines.join("\n");
+}
+
+function formatWorkspaceAiContextOutline(outline: WorkspaceAiContextOutline) {
+	const itemLines = limitWorkspaceAiContextOutlineLines(
+		outline.items.map(formatWorkspaceAiContextOutlineItem),
+	);
+	const omittedItems = outline.totalItems - itemLines.length;
+	const isComplete = outline.status === "included" && omittedItems === 0;
+	const lines = isComplete
+		? [
+				`- Workspace outline: ${outline.totalItems} ${outline.totalItems === 1 ? "item" : "items"} complete, paths/types and folder counts only. Item bodies are not included.`,
+			]
+		: [
+				`- Workspace outline: ${outline.totalItems} items total. Showing ${itemLines.length} structural paths, folder-first; this is not complete. Item bodies are not included.`,
+			];
+
+	lines.push(...itemLines);
+
+	if (!isComplete) {
+		lines.push(
+			`  - ${omittedItems} items omitted. Use workspace_list_items on a folder before assuming its contents.`,
+		);
+	}
+
+	return lines;
+}
+
+function formatWorkspaceAiContextOutlineItem(item: WorkspaceAiContextOutline["items"][number]) {
+	return `  - ${truncateWorkspaceAiContextOutlinePath(item.path)} (${formatWorkspaceAiContextOutlineItemMeta(item)})`;
+}
+
+function formatWorkspaceAiContextOutlineItemMeta(item: WorkspaceAiContextOutline["items"][number]) {
+	const counts =
+		item.childCount === undefined || item.descendantCount === undefined
+			? ""
+			: `, ${item.childCount} direct ${item.childCount === 1 ? "child" : "children"}, ${item.descendantCount} total ${item.descendantCount === 1 ? "descendant" : "descendants"}`;
+
+	return `${item.type}${counts}`;
+}
+
+function limitWorkspaceAiContextOutlineLines(lines: string[]) {
+	const selectedLines: string[] = [];
+	let size = 0;
+
+	for (const line of lines) {
+		const nextSize = size + line.length + 1;
+
+		if (selectedLines.length > 0 && nextSize > WORKSPACE_AI_CONTEXT_OUTLINE_PROMPT_CHAR_LIMIT) {
+			break;
+		}
+
+		selectedLines.push(line);
+		size = nextSize;
+	}
+
+	return selectedLines;
+}
+
+function truncateWorkspaceAiContextOutlinePath(path: string) {
+	if (path.length <= WORKSPACE_AI_CONTEXT_OUTLINE_PATH_CHAR_LIMIT) {
+		return path;
+	}
+
+	const edgeLength = Math.floor((WORKSPACE_AI_CONTEXT_OUTLINE_PATH_CHAR_LIMIT - 3) / 2);
+	return `${path.slice(0, edgeLength)}...${path.slice(-edgeLength)}`;
 }
 
 function formatWorkspaceAiContextTab(tab: WorkspaceAiContextTabReference) {

--- a/src/features/workspaces/model/workspace-ai-context-snapshot.ts
+++ b/src/features/workspaces/model/workspace-ai-context-snapshot.ts
@@ -9,6 +9,7 @@ import {
 	getWorkspaceAiContextItemReference,
 	getWorkspaceAiContextVisibleItemIds,
 } from "./workspace-ai-context-reference";
+import { buildWorkspaceAiContextOutline } from "./workspace-ai-context-outline";
 import type {
 	WorkspaceAiContextPaneReference,
 	WorkspaceAiContextPresentationReference,
@@ -39,6 +40,7 @@ export function buildWorkspaceAiContextSnapshot(
 	return {
 		workspace: {
 			name: context.workspaceName,
+			outline: buildWorkspaceAiContextOutline(context),
 		},
 		view: {
 			activeItem: activeItem

--- a/src/features/workspaces/model/workspace-ai-context-types.ts
+++ b/src/features/workspaces/model/workspace-ai-context-types.ts
@@ -23,6 +23,7 @@ export type WorkspaceAiContextScope = {
 export type WorkspaceAiContextSnapshot = {
 	workspace: {
 		name: string;
+		outline?: WorkspaceAiContextOutline;
 	};
 	view: {
 		activeItem?: WorkspaceAiContextItemReference;
@@ -33,6 +34,27 @@ export type WorkspaceAiContextSnapshot = {
 	openTabs: WorkspaceAiContextTabReference[];
 	selectedQuotes: WorkspaceAiContextSnapshotSelectedQuote[];
 	contentIncluded: false;
+};
+
+export type WorkspaceAiContextOutline =
+	| {
+			status: "included";
+			totalItems: number;
+			items: WorkspaceAiContextOutlineItem[];
+	  }
+	| {
+			status: "summarized";
+			totalItems: number;
+			limit: number;
+			omittedItems: number;
+			items: WorkspaceAiContextOutlineItem[];
+	  };
+
+export type WorkspaceAiContextOutlineItem = {
+	childCount?: number;
+	descendantCount?: number;
+	path: string;
+	type: string;
 };
 
 export type WorkspaceAiContextSnapshotSelectedQuote = {

--- a/src/features/workspaces/model/workspace-ai-context-validation.ts
+++ b/src/features/workspaces/model/workspace-ai-context-validation.ts
@@ -1,5 +1,6 @@
 import type {
 	WorkspaceAiContextItemReference,
+	WorkspaceAiContextOutline,
 	WorkspaceAiContextPaneReference,
 	WorkspaceAiContextPresentationReference,
 	WorkspaceAiContextSelectedItem,
@@ -16,6 +17,8 @@ export function isWorkspaceAiContextSnapshot(value: unknown): value is Workspace
 	return (
 		isRecord(value.workspace) &&
 		typeof value.workspace.name === "string" &&
+		(value.workspace.outline === undefined ||
+			isWorkspaceAiContextOutline(value.workspace.outline)) &&
 		Array.isArray(value.selectedItems) &&
 		Array.isArray(value.openTabs) &&
 		Array.isArray(value.selectedQuotes) &&
@@ -23,6 +26,64 @@ export function isWorkspaceAiContextSnapshot(value: unknown): value is Workspace
 		isRecord(value.view) &&
 		isWorkspaceAiContextPresentationReference(value.view.presentation)
 	);
+}
+
+function isWorkspaceAiContextOutline(value: unknown): value is WorkspaceAiContextOutline {
+	if (!isRecord(value)) {
+		return false;
+	}
+
+	if (
+		typeof value.totalItems !== "number" ||
+		!Number.isInteger(value.totalItems) ||
+		value.totalItems < 0
+	) {
+		return false;
+	}
+
+	if (value.status === "summarized") {
+		return (
+			typeof value.limit === "number" &&
+			Number.isInteger(value.limit) &&
+			value.limit > 0 &&
+			value.totalItems > value.limit &&
+			Array.isArray(value.items) &&
+			value.items.length <= value.limit &&
+			typeof value.omittedItems === "number" &&
+			Number.isInteger(value.omittedItems) &&
+			value.omittedItems === value.totalItems - value.items.length &&
+			value.omittedItems > 0 &&
+			value.items.every(isWorkspaceAiContextOutlineItem)
+		);
+	}
+
+	return (
+		value.status === "included" &&
+		Array.isArray(value.items) &&
+		value.items.length === value.totalItems &&
+		value.items.every(isWorkspaceAiContextOutlineItem)
+	);
+}
+
+function isWorkspaceAiContextOutlineItem(value: unknown) {
+	if (!isRecord(value)) {
+		return false;
+	}
+
+	const hasChildCount = value.childCount !== undefined;
+	const hasDescendantCount = value.descendantCount !== undefined;
+
+	return (
+		typeof value.path === "string" &&
+		typeof value.type === "string" &&
+		hasChildCount === hasDescendantCount &&
+		(value.childCount === undefined || isNonNegativeInteger(value.childCount)) &&
+		(value.descendantCount === undefined || isNonNegativeInteger(value.descendantCount))
+	);
+}
+
+function isNonNegativeInteger(value: unknown) {
+	return typeof value === "number" && Number.isInteger(value) && value >= 0;
 }
 
 export function isWorkspaceAiContextSelectedItem(

--- a/src/styles.css
+++ b/src/styles.css
@@ -358,13 +358,46 @@
 	}
 
 	.thinkex-thinking-mark {
+		--thinkex-thinking-cycle: 2.2s;
 		overflow: visible;
 	}
 
 	.thinkex-thinking-block {
-		animation: thinkex-thinking-block 2.3s ease-in-out infinite both;
+		animation: thinkex-thinking-block-loop var(--thinkex-thinking-cycle) ease-in-out infinite both;
 		opacity: 0;
 		will-change: opacity;
+	}
+
+	.thinkex-thinking-block--red-left {
+		animation-delay: 840ms;
+	}
+
+	.thinkex-thinking-block--top-left {
+		animation-delay: 0ms;
+	}
+
+	.thinkex-thinking-block--top-middle {
+		animation-delay: 120ms;
+	}
+
+	.thinkex-thinking-block--top-right {
+		animation-delay: 240ms;
+	}
+
+	.thinkex-thinking-block--right-middle {
+		animation-delay: 360ms;
+	}
+
+	.thinkex-thinking-block--bottom-right {
+		animation-delay: 480ms;
+	}
+
+	.thinkex-thinking-block--center {
+		animation-delay: 600ms;
+	}
+
+	.thinkex-thinking-block--bottom-left {
+		animation-delay: 720ms;
 	}
 
 	@media (prefers-reduced-motion: reduce) {
@@ -390,27 +423,21 @@
 		}
 	}
 
-	@keyframes thinkex-thinking-block {
+	/* One traveling segment with a brief full-logo beat, then a quiet gap before the next loop. */
+	@keyframes thinkex-thinking-block-loop {
 		0% {
 			opacity: 0;
 		}
 
-		12% {
-			opacity: 0;
-		}
-
-		24% {
+		7% {
 			opacity: 1;
 		}
 
-		68% {
+		54% {
 			opacity: 1;
 		}
 
-		82% {
-			opacity: 0;
-		}
-
+		64%,
 		100% {
 			opacity: 0;
 		}


### PR DESCRIPTION
## Summary
- Add a structural workspace outline to AI context so the assistant sees folder/file shape without item bodies.
- Smooth chat pending/message animations and remove the workspace skeleton ring.
- Replace card-like tool activity with compact inline rows, concise status copy, source favicons, and expandable details.

## Why
The workspace chat activity UI was too heavy for lay users: tool calls looked like cards, source details competed with the answer, and the pending indicator did not persist smoothly while work continued.

## Changes
- Adds a bounded workspace outline model, validation, and prompt formatting.
- Keeps the ThinkEx thinking/working indicator visible at the transcript tail while streaming continues.
- Uses explicit sent-message ids for user-message entry animation.
- Maps visible tools to simple labels/icons and input-aware running/completed summaries.
- Extracts web/research source previews so favicons stay inline and detailed source metadata lives behind expansion.

## Testing
- `pnpm run check`

Note: the command passes, with the existing local Node engine warning because this shell uses Node `v25.8.0` while the repo declares `>=24.11.0 <25`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786045436&installation_id=142604731&pr_number=601&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F601&signature=afe48046655ed186bf95bb50ec2afe5da768674267e5211399ad3ab0c49e7a7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI chat now shows richer activity updates, including a new “working” state and clearer in-progress summaries.
  * Workspace AI context now includes a structured outline, helping provide more complete workspace-aware responses.
  * Tool activity rows can now show source previews, favicons, and expanded details for web/research results.

* **Bug Fixes**
  * Improved chat message animation timing and reduced-motion behavior.
  * Refined tool labels and presentation text for clearer, more consistent wording.
  * Updated workspace card styling for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->