### PR TITLE
refactor(ai): centralize gateway routing policy

### DIFF
--- a/src/features/workspaces/ai/ai-gateway-routing.ts
+++ b/src/features/workspaces/ai/ai-gateway-routing.ts
@@ -1,0 +1,61 @@
+import type { WorkspaceAiChatModelId } from "#/features/workspaces/ai/models";
+
+type GatewayRoutingOptions = {
+	models: readonly string[];
+	order: readonly string[];
+	sort: "ttft";
+};
+
+// Keep the policy server-side and independent from picker copy. Each order
+// puts ThinkEx's configured BYOK providers first. It is intentionally a
+// preference rather than an allowlist so cross-provider model fallbacks remain
+// reachable if no preferred provider can serve a request.
+const workspaceAiGatewayRouting: Record<WorkspaceAiChatModelId, GatewayRoutingOptions> = {
+	auto: {
+		order: ["openai", "azure"],
+		models: ["google/gemini-3-flash", "anthropic/claude-haiku-4.5"],
+		sort: "ttft",
+	},
+	"claude-sonnet": {
+		order: ["bedrock", "vertex"],
+		models: ["openai/gpt-5.4", "google/gemini-3.1-pro-preview"],
+		sort: "ttft",
+	},
+	"claude-haiku": {
+		order: ["bedrock", "vertex"],
+		models: ["openai/gpt-5.4-mini", "google/gemini-3-flash"],
+		sort: "ttft",
+	},
+	chatgpt: {
+		order: ["openai", "azure"],
+		models: ["anthropic/claude-sonnet-4.6", "google/gemini-3.1-pro-preview"],
+		sort: "ttft",
+	},
+	"chatgpt-mini": {
+		order: ["openai", "azure"],
+		models: ["google/gemini-3-flash", "anthropic/claude-haiku-4.5"],
+		sort: "ttft",
+	},
+	"gemini-pro": {
+		order: ["vertex"],
+		models: ["openai/gpt-5.4", "anthropic/claude-sonnet-4.6"],
+		sort: "ttft",
+	},
+	gemini: {
+		order: ["vertex"],
+		models: ["openai/gpt-5.4-mini", "anthropic/claude-haiku-4.5"],
+		sort: "ttft",
+	},
+};
+
+export function getWorkspaceAiGatewayRoutingOptions(modelId: WorkspaceAiChatModelId) {
+	return workspaceAiGatewayRouting[modelId];
+}
+
+export function getAIThreadTitleGatewayRoutingOptions() {
+	return {
+		order: ["vertex"],
+		models: ["openai/gpt-4.1-nano"],
+		sort: "ttft" as const,
+	};
+}

--- a/src/features/workspaces/ai/ai-gateway-routing.ts
+++ b/src/features/workspaces/ai/ai-gateway-routing.ts
@@ -1,10 +1,12 @@
 import type { WorkspaceAiChatModelId } from "#/features/workspaces/ai/models";
 
 type GatewayRoutingOptions = {
-	models: readonly string[];
-	order: readonly string[];
+	models: string[];
+	order: string[];
 	sort: "ttft";
 };
+
+const GOOGLE_GATEWAY_PROVIDER_ORDER = ["google", "vertex"];
 
 // Keep the policy server-side and independent from picker copy. Each order
 // puts ThinkEx's configured BYOK providers first. It is intentionally a
@@ -37,12 +39,12 @@ const workspaceAiGatewayRouting: Record<WorkspaceAiChatModelId, GatewayRoutingOp
 		sort: "ttft",
 	},
 	"gemini-pro": {
-		order: ["vertex"],
+		order: GOOGLE_GATEWAY_PROVIDER_ORDER,
 		models: ["openai/gpt-5.4", "anthropic/claude-sonnet-4.6"],
 		sort: "ttft",
 	},
 	gemini: {
-		order: ["vertex"],
+		order: GOOGLE_GATEWAY_PROVIDER_ORDER,
 		models: ["openai/gpt-5.4-mini", "anthropic/claude-haiku-4.5"],
 		sort: "ttft",
 	},
@@ -54,7 +56,7 @@ export function getWorkspaceAiGatewayRoutingOptions(modelId: WorkspaceAiChatMode
 
 export function getAIThreadTitleGatewayRoutingOptions() {
 	return {
-		order: ["vertex"],
+		order: GOOGLE_GATEWAY_PROVIDER_ORDER,
 		models: ["openai/gpt-4.1-nano"],
 		sort: "ttft" as const,
 	};

--- a/src/features/workspaces/ai/ai-thread-runtime.ts
+++ b/src/features/workspaces/ai/ai-thread-runtime.ts
@@ -10,6 +10,10 @@ import type {
 	AIThreadPromptScope,
 } from "#/features/workspaces/ai/ai-thread-metadata";
 import {
+	getAIThreadTitleGatewayRoutingOptions,
+	getWorkspaceAiGatewayRoutingOptions,
+} from "#/features/workspaces/ai/ai-gateway-routing";
+import {
 	DEFAULT_WORKSPACE_AI_CHAT_MODEL_ID,
 	getWorkspaceAiChatModel,
 	type resolveWorkspaceAiChatModelId,
@@ -25,7 +29,6 @@ import { formatWorkspaceAiContextForPrompt } from "#/features/workspaces/model/w
 const thinkPromptSectionDivider = "══════════════════════════════════════════════";
 
 const AI_THREAD_TITLE_GATEWAY_MODEL = "google/gemini-2.5-flash-lite";
-const AI_THREAD_TITLE_FALLBACK_MODELS = ["openai/gpt-4.1-nano"] as const;
 
 type WorkspaceAiProviderOptions = NonNullable<
 	Parameters<typeof generateText>[0]["providerOptions"]
@@ -392,33 +395,6 @@ export function getWorkspaceAiGatewayProviderOptions(input?: {
 	} as unknown as WorkspaceAiProviderOptions;
 }
 
-function getWorkspaceAiGatewayRoutingOptions(
-	modelId: ReturnType<typeof resolveWorkspaceAiChatModelId>,
-) {
-	switch (modelId) {
-		case "claude-sonnet":
-			return {
-				order: ["bedrock", "vertex"],
-				models: ["google/gemini-3-flash", "openai/gpt-5.4-mini"],
-				sort: "ttft",
-			};
-		case "gemini":
-			return {
-				order: ["google", "vertex"],
-				models: ["openai/gpt-5.4-mini"],
-				sort: "ttft",
-			};
-		case "chatgpt":
-			return {
-				order: ["openai", "azure"],
-				models: ["google/gemini-3-flash", "openai/gpt-5.4-mini"],
-				sort: "ttft",
-			};
-		default:
-			return {};
-	}
-}
-
 function getWorkspaceAiReasoningOptions(modelId: ReturnType<typeof resolveWorkspaceAiChatModelId>) {
 	switch (modelId) {
 		case "claude-sonnet":
@@ -478,9 +454,7 @@ export async function generateAIThreadTitle(input: { env: Cloudflare.Env; messag
 		providerOptions: {
 			gateway: {
 				...getWorkspaceAiGatewayTransportOptions(),
-				order: ["google", "vertex"],
-				models: [...AI_THREAD_TITLE_FALLBACK_MODELS],
-				sort: "ttft",
+				...getAIThreadTitleGatewayRoutingOptions(),
 				tags: [
 					"app:thinkex",
 					"feature:workspace-chat",

--- a/src/features/workspaces/ai/ai-thread.ts
+++ b/src/features/workspaces/ai/ai-thread.ts
@@ -396,6 +396,10 @@ export function createAIThreadClass(getUserAIStore: () => typeof UserAIStore) {
 						this.env,
 						this.sessionAffinity,
 					),
+					providerOptions: getWorkspaceAiGatewayProviderOptions({
+						modelId: DEFAULT_WORKSPACE_AI_CHAT_MODEL_ID,
+						tags: ["task:compaction"],
+					}),
 					prompt,
 				});
 			} catch (error) {

--- a/src/features/workspaces/ai/models.ts
+++ b/src/features/workspaces/ai/models.ts
@@ -30,7 +30,7 @@ export const WORKSPACE_AI_CHAT_MODELS = [
 		provider: "auto",
 		tagline: "Fast and capable by default",
 		description:
-			"ThinkEx uses a fast, capable default model and keeps fallback options available when needed.",
+			"ThinkEx picks the model for you. It stays quick for simple things and strong when the task is harder.",
 		bestFor: "Everyday work",
 		intelligence: 3,
 		speed: 3,

--- a/src/features/workspaces/ai/models.ts
+++ b/src/features/workspaces/ai/models.ts
@@ -30,7 +30,7 @@ export const WORKSPACE_AI_CHAT_MODELS = [
 		provider: "auto",
 		tagline: "Fast and capable by default",
 		description:
-			"ThinkEx picks the model for you. It stays quick for simple things and strong when the task is harder.",
+			"ThinkEx uses a fast, capable default model and keeps fallback options available when needed.",
 		bestFor: "Everyday work",
 		intelligence: 3,
 		speed: 3,

--- a/src/features/workspaces/ai/models.ts
+++ b/src/features/workspaces/ai/models.ts
@@ -24,15 +24,14 @@ export const WORKSPACE_AI_CHAT_MODELS = [
 	{
 		id: "auto",
 		name: "Auto",
-		// ThinkEx's own "let us pick for you" option. For now "Auto" is Kimi K2.6
-		// under the hood until we build or adopt a real router; the slug can
-		// change without affecting the user-facing choice.
-		gatewayModel: "moonshotai/kimi-k2.6",
+		// Keep this a stable product choice while the server owns its availability
+		// policy and fallback chain.
+		gatewayModel: "openai/gpt-5.4-mini",
 		provider: "auto",
-		tagline: "Picks a good fit for you",
+		tagline: "Fast and capable by default",
 		description:
-			"ThinkEx picks the model for you. It stays quick for simple things and uses a stronger model when the task is harder.",
-		bestFor: "Most tasks",
+			"ThinkEx picks the model for you. It stays quick for simple things and strong when the task is harder.",
+		bestFor: "Everyday work",
 		intelligence: 3,
 		speed: 3,
 		cost: 1,


### PR DESCRIPTION
## Summary
- Centralize Gateway provider preferences and fallback chains for every chat model.
- Route Auto through GPT-5.4 mini and apply the same availability policy to compaction.
- Prefer configured BYOK providers while retaining cross-provider fallback availability.

## Why
The prior policy was partial, split across runtime branches, and left Auto and compaction without a complete fallback strategy.

## Testing
- pnpm check
- pnpm test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786404340&installation_id=142604731&pr_number=628&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F628&signature=ead6187f9e8dec4eff9007577ee32df6792c6b929546783f51310150d542388e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

