### PR TITLE
docs(contributing): fix setup path in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Prerequisites:
 
 ```bash
 git clone https://github.com/ThinkEx-OSS/thinkex.git
-cd thinkex/web
+cd thinkex
 vp install --frozen-lockfile
 ```
 


### PR DESCRIPTION
**Tracer end-to-end test drill — not a response to a real incident.**

This PR fixes a small documentation inconsistency in `CONTRIBUTING.md`.

### What changed
- Corrected the setup command path from `cd thinkex/web` to `cd thinkex`.

The repository root is `thinkex` (the file listing shows `package.json`, `src/`, `wrangler.jsonc`, etc. at the root), not a nested `thinkex/web` directory. This makes the documented setup instructions match the actual repository structure.

### Verification
- `git diff` confirms the single-line markdown change.
- No code or behavioral changes were made, so no runtime checks are needed beyond confirming the markdown renders correctly.

### Notes
- This is part of a Tracer simulation exercise to exercise the report → fix → draft-PR pipeline.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786411028&installation_id=142604731&pr_number=629&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F629&signature=f4050ea3a35f6b14e3e2401fd3c77edd1b04577eef5662b0a01e4d34b471b12d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local development setup instructions to use the correct project directory before installing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->