### PR TITLE
docs: fix clone path in CONTRIBUTING.md (Tracer E2E test drill)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Prerequisites:
 
 ```bash
 git clone https://github.com/ThinkEx-OSS/thinkex.git
-cd thinkex/web
+cd thinkex
 vp install --frozen-lockfile
 ```
 


### PR DESCRIPTION
> ⚠️ **This is a Tracer end-to-end test drill, not a response to a real incident.**

## What changed

Fixed the local setup instructions in `CONTRIBUTING.md` so the `cd` command matches the actual repository layout.

- The repo root **is** the application directory (`package.json`, `src/`, `wrangler.jsonc`, etc. all live at the root).
- The old instructions said `cd thinkex/web`, which would fail because no `web/` subdirectory exists.
- Changed it to `cd thinkex`.

This is a documentation-only, non-behavioral change.

## Verification

- `pnpm check` passes: all 574 files correctly formatted, no lint/type errors in 552 files.
- `git diff` confirms only `CONTRIBUTING.md` was modified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786415989&installation_id=142604731&pr_number=630&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F630&signature=9bfa987d02867dcea380520131cd8608c6df83b1f18044df6d9370fdebdb4aa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

