### PR TITLE
Tracer end-to-end drill: normalize remaining relative imports in __root.tsx

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -10,10 +10,10 @@ import type { AuthSession } from "#/lib/auth.functions";
 import { AppHotkeysProvider } from "#/lib/hotkeys";
 import { seo } from "#/lib/seo";
 import { getAuthSessionQueryOptions } from "#/lib/session-query";
-import { ThemeProvider } from "../components/theme-provider";
-import PostHogProvider from "../integrations/posthog/provider";
-import TanStackQueryDevtools from "../integrations/tanstack-query/devtools";
-import appCss from "../styles.css?url";
+import { ThemeProvider } from "#/components/theme-provider";
+import PostHogProvider from "#/integrations/posthog/provider";
+import TanStackQueryDevtools from "#/integrations/tanstack-query/devtools";
+import appCss from "#/styles.css?url";
 
 interface MyRouterContext {
 	queryClient: QueryClient;


### PR DESCRIPTION
## Summary

This is a **Tracer end-to-end test drill** and not a response to a real incident.

### What changed

The `src/routes/__root.tsx` file used inconsistent import paths for four modules, importing them via relative paths (`../`) instead of the project-standard aliased paths (`#/`). This change normalizes those four imports to match the rest of the codebase.

### Why

1. **Consistency** — The entire repository (through `tsconfig.json` paths and `package.json` imports) standardizes on `#/*` for internal source modules. `__root.tsx` was the only file still using `../` for these imports.
2. **Refactor resilience** — If `__root.tsx` is moved to a different directory in the future, these aliased imports will remain valid without further edits.

### Files modified

- `src/routes/__root.tsx` — 4 import paths updated:
  - `../components/theme-provider` → `#/components/theme-provider`
  - `../integrations/posthog/provider` → `#/integrations/posthog/provider`
  - `../integrations/tanstack-query/devtools` → `#/integrations/tanstack-query/devtools`
  - `../styles.css?url` → `#/styles.css?url`

### Verification

- ✅ `pnpm check` passed with zero formatting, lint, or type errors.

### Context

This PR was generated as part of an automated test run to exercise the investigation pipeline: inspect repository → propose a safe improvement → run checks → open a draft PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786478150&installation_id=142604731&pr_number=635&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F635&signature=5400a3fa00ae0d2ee6ebde21c4fc69dd0e230977f911675fd5ae49d37de4949a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

