### PR TITLE
chore(config): remove unused @/* path alias from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,7 @@
 		"jsx": "react-jsx",
 		"module": "ESNext",
 		"paths": {
-			"#/*": ["./src/*"],
-			"@/*": ["./src/*"]
+			"#/*": ["./src/*"]
 		},
 		"lib": ["ES2022", "DOM", "DOM.Iterable"],
 		"types": ["./worker-configuration.d.ts", "node", "vite/client"],


### PR DESCRIPTION
This is a **Tracer end-to-end test drill** and not a response to a real incident.

### What changed
Removed the unused `"@/*": ["./src/*"]` path alias from `tsconfig.json`. The entire codebase already imports via `"#/*"`, so `"@/*"` is dead configuration.

### Why
- Simplifies `paths` to a single, actively used alias (`#/*`).
- Eliminates a misleading, unused entry that could cause confusion or tooling drift.
- Zero behavioral change.

### Verification
- Confirmed no source file imports via `"@/` (grep across `src`).
- `npx vitest run --config vitest.config.ts` → 10 test files, 31 tests passed.
- `npx tsc --noEmit --pretty` → clean compile with no errors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786585738&installation_id=142604731&pr_number=640&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F640&signature=384cc5fe8049424d9481a351a95fcac8499081fd738c0ac9440e934631cee723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

