### PR TITLE
fix(security): restore direct R2 uploads

### DIFF
--- a/src/lib/http/content-security-policy.test.ts
+++ b/src/lib/http/content-security-policy.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { buildContentSecurityPolicy } from "#/lib/http/content-security-policy";
+
+const r2AccountId = "676650ed1ca37ffdeba997fb2a7fa24a";
+
+describe("content security policy", () => {
+	it("allows the configured R2 account without weakening connect-src", () => {
+		const policy = buildContentSecurityPolicy({
+			applicationOrigin: "https://thinkex.app",
+			isProduction: true,
+			posthogHostOrigin: "https://h.thinkex.app",
+			posthogReportUrl: "https://h.thinkex.app/report/?token=test",
+			r2AccountId,
+		});
+
+		expect(policy).toContain(
+			`connect-src 'self' https://cloudflareinsights.com wss://thinkex.app https://h.thinkex.app https://${r2AccountId}.r2.cloudflarestorage.com`,
+		);
+		expect(policy).not.toContain(" wss: ");
+		expect(policy).not.toContain("*.r2.cloudflarestorage.com");
+		expect(policy).not.toContain("connect-src https:");
+		expect(policy).not.toContain("'unsafe-eval'");
+		expect(policy).toContain("report-uri https://h.thinkex.app/report/?token=test");
+	});
+
+	it("does not put malformed account identifiers into a response header", () => {
+		const policy = buildContentSecurityPolicy({
+			applicationOrigin: "javascript:alert(1)",
+			isProduction: true,
+			r2AccountId: "invalid\nconnect-src https:",
+		});
+
+		expect(policy).not.toContain("r2.cloudflarestorage.com");
+		expect(policy).not.toContain("invalid");
+		expect(policy).not.toContain("javascript:");
+	});
+});

--- a/src/lib/http/content-security-policy.ts
+++ b/src/lib/http/content-security-policy.ts
@@ -1,0 +1,94 @@
+interface ContentSecurityPolicyOptions {
+	applicationOrigin?: string;
+	isProduction: boolean;
+	posthogHostOrigin?: string;
+	posthogReportUrl?: string;
+	r2AccountId?: string;
+}
+
+const cloudflareInsightsScriptOrigin = "https://static.cloudflareinsights.com";
+const cloudflareInsightsConnectOrigin = "https://cloudflareinsights.com";
+const cloudflareAccountIdPattern = /^[a-f\d]{32}$/i;
+
+export function buildContentSecurityPolicy(options: ContentSecurityPolicyOptions) {
+	const scriptSrc = [
+		"'self'",
+		"'unsafe-inline'",
+		"'wasm-unsafe-eval'",
+		cloudflareInsightsScriptOrigin,
+	];
+	const connectSrc = ["'self'", cloudflareInsightsConnectOrigin];
+	const websocketOrigin = getWebSocketOrigin(options.applicationOrigin);
+
+	if (websocketOrigin) {
+		connectSrc.push(websocketOrigin);
+	}
+
+	if (options.posthogHostOrigin) {
+		scriptSrc.push(options.posthogHostOrigin);
+		connectSrc.push(options.posthogHostOrigin);
+	}
+
+	const r2Origin = getR2Origin(options.r2AccountId);
+
+	if (r2Origin) {
+		connectSrc.push(r2Origin);
+	}
+
+	if (!options.isProduction) {
+		scriptSrc.push("'unsafe-eval'");
+		connectSrc.push("ws:", "http://localhost:*", "http://127.0.0.1:*");
+	}
+
+	const directives = [
+		"default-src 'self'",
+		"base-uri 'self'",
+		"object-src 'none'",
+		"frame-ancestors 'none'",
+		"frame-src 'none'",
+		"form-action 'self'",
+		"manifest-src 'self'",
+		"img-src 'self' data: blob: https:",
+		"font-src 'self' data:",
+		"style-src 'self' 'unsafe-inline'",
+		`script-src ${scriptSrc.join(" ")}`,
+		`connect-src ${connectSrc.join(" ")}`,
+		"media-src 'self' data: blob:",
+		"worker-src 'self' blob:",
+	];
+
+	if (options.posthogReportUrl) {
+		directives.push(`report-uri ${options.posthogReportUrl}`);
+	}
+
+	return directives.join("; ");
+}
+
+function getR2Origin(accountId: string | undefined) {
+	const normalizedAccountId = accountId?.trim();
+
+	if (!normalizedAccountId || !cloudflareAccountIdPattern.test(normalizedAccountId)) {
+		return undefined;
+	}
+
+	return `https://${normalizedAccountId}.r2.cloudflarestorage.com`;
+}
+
+function getWebSocketOrigin(applicationOrigin: string | undefined) {
+	if (!applicationOrigin) {
+		return undefined;
+	}
+
+	try {
+		const url = new URL(applicationOrigin);
+
+		if (url.protocol !== "https:" && url.protocol !== "http:") {
+			return undefined;
+		}
+
+		url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+		return url.origin;
+	} catch {
+		return undefined;
+	}
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,7 +1,12 @@
 import geistLatinWoff2 from "@fontsource-variable/geist/files/geist-latin-wght-normal.woff2?url";
 import { TanStackDevtools } from "@tanstack/react-devtools";
 import { useQuery, type QueryClient } from "@tanstack/react-query";
-import { createRootRouteWithContext, HeadContent, Scripts } from "@tanstack/react-router";
+import {
+	createRootRouteWithContext,
+	HeadContent,
+	ScriptOnce,
+	Scripts,
+} from "@tanstack/react-router";
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
 import { Toaster } from "#/components/ui/sonner";
 import { TooltipProvider } from "#/components/ui/tooltip";
@@ -14,6 +19,9 @@ import { ThemeProvider } from "../components/theme-provider";
 import PostHogProvider from "../integrations/posthog/provider";
 import TanStackQueryDevtools from "../integrations/tanstack-query/devtools";
 import appCss from "../styles.css?url";
+
+const configureZodForStrictCsp =
+	"globalThis.__zod_globalConfig??={};globalThis.__zod_globalConfig.jitless=true";
 
 interface MyRouterContext {
 	queryClient: QueryClient;
@@ -79,6 +87,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
 	return (
 		<html lang="en" suppressHydrationWarning>
 			<head>
+				<ScriptOnce>{configureZodForStrictCsp}</ScriptOnce>
 				<HeadContent />
 			</head>
 			<body>

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import { routeWorkspaceKernelRequest } from "#/features/workspaces/kernel/worksp
 import { recordOperationalFailure } from "#/integrations/observability/operational-events";
 import { posthogHost, posthogHostOrigin, posthogProjectToken } from "#/integrations/posthog/config";
 import { getTelemetryRequestDetails } from "#/integrations/posthog/server-context";
+import { buildContentSecurityPolicy } from "#/lib/http/content-security-policy";
 
 export { CodemodeRuntime } from "@cloudflare/codemode";
 export { Sandbox } from "@cloudflare/sandbox";
@@ -18,8 +19,6 @@ export { WorkspaceFileProcessor } from "#/features/workspaces/files/workspace-fi
 export { WorkspaceKernel } from "#/features/workspaces/kernel/workspace-kernel";
 
 const isProduction = import.meta.env.PROD;
-const cloudflareInsightsScriptOrigin = "https://static.cloudflareinsights.com";
-const cloudflareInsightsConnectOrigin = "https://cloudflareinsights.com";
 
 function buildContentSecurityPolicyReportUrl() {
 	if (!posthogHost || !posthogProjectToken) {
@@ -37,62 +36,26 @@ function buildContentSecurityPolicyReportUrl() {
 	}
 }
 
-function buildContentSecurityPolicy() {
-	const scriptSrc = [
-		"'self'",
-		"'unsafe-inline'",
-		"'wasm-unsafe-eval'",
-		cloudflareInsightsScriptOrigin,
-	];
-	const connectSrc = ["'self'", "wss:", cloudflareInsightsConnectOrigin];
-
-	if (posthogHostOrigin) {
-		scriptSrc.push(posthogHostOrigin);
-		connectSrc.push(posthogHostOrigin);
-	}
-
-	if (!isProduction) {
-		scriptSrc.push("'unsafe-eval'");
-		connectSrc.push("ws:", "http://localhost:*", "http://127.0.0.1:*");
-	}
-
-	const cspDirectives = [
-		"default-src 'self'",
-		"base-uri 'self'",
-		"object-src 'none'",
-		"frame-ancestors 'none'",
-		"frame-src 'none'",
-		"form-action 'self'",
-		"manifest-src 'self'",
-		"img-src 'self' data: blob: https:",
-		"font-src 'self' data:",
-		"style-src 'self' 'unsafe-inline'",
-		`script-src ${scriptSrc.join(" ")}`,
-		`connect-src ${connectSrc.join(" ")}`,
-		"media-src 'self' data: blob:",
-		"worker-src 'self' blob:",
-	];
-
-	const reportUrl = buildContentSecurityPolicyReportUrl();
-
-	if (reportUrl) {
-		cspDirectives.push(`report-uri ${reportUrl}`);
-	}
-
-	return cspDirectives.join("; ");
-}
-
 function isHtmlResponse(response: Response) {
 	return response.headers.get("content-type")?.includes("text/html") ?? false;
 }
 
-function withSecurityHeaders(response: Response) {
+function withSecurityHeaders(response: Response, env: Cloudflare.Env, request: Request) {
 	if (!isHtmlResponse(response)) {
 		return response;
 	}
 
 	const headers = new Headers(response.headers);
-	headers.set("Content-Security-Policy", buildContentSecurityPolicy());
+	headers.set(
+		"Content-Security-Policy",
+		buildContentSecurityPolicy({
+			applicationOrigin: new URL(request.url).origin,
+			isProduction,
+			posthogHostOrigin,
+			posthogReportUrl: buildContentSecurityPolicyReportUrl(),
+			r2AccountId: env.R2_ACCOUNT_ID,
+		}),
+	);
 	headers.set("X-Content-Type-Options", "nosniff");
 	headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
 	headers.set("X-Frame-Options", "DENY");
@@ -126,7 +89,11 @@ export default {
 
 			const workspaceKernelResponse = await routeWorkspaceKernelRequest(request, env);
 
-			return withSecurityHeaders(workspaceKernelResponse ?? (await handler.fetch(request)));
+			return withSecurityHeaders(
+				workspaceKernelResponse ?? (await handler.fetch(request)),
+				env,
+				request,
+			);
 		} catch (error) {
 			recordOperationalFailure({
 				error,


### PR DESCRIPTION
## Summary
- restore production browser uploads to R2
- centralize and test CSP construction
- reduce CSP noise and unnecessary connection scope

## Why
Direct browser uploads use presigned R2 URLs, but production connect-src did not allow the account-specific R2 origin. Browsers blocked the PUT before completion, so uploads failed before Durable Object processing or extraction began.

## Changes
- allow only the configured account-specific R2 origin
- scope production WebSockets to the current application origin instead of all secure WebSocket destinations
- configure Zod for jitless operation so its eval capability probe does not generate false CSP violations
- retain required PDF WASM and existing framework allowances
- add focused regression coverage for strict production policy generation and malformed configuration

## Testing
- pnpm test: 54 tests passed
- pnpm check
- pnpm knip
- pnpm test:workers
- production application bundle completed successfully

## Review Notes
Start with src/lib/http/content-security-policy.ts and its test. The server change supplies request and environment-specific origins; the root route initializes Zod before application bundles execute.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786721937&installation_id=142604731&pr_number=644&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F644&signature=3e241f0f25491f1fc5bacc60b8cffcdb2337808d50bef7eaa7c1998a41ea4501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added stricter Content Security Policy handling for application, analytics, and storage connections.
  - Sanitized configured origins and identifiers to prevent unsafe or malformed values from entering security headers.
  - Added optional security policy reporting support.

- **Compatibility**
  - Configured Zod for strict Content Security Policy environments.
  - Preserved development-only allowances while applying tighter production policies.

- **Tests**
  - Added coverage for valid configuration, unsafe input rejection, and prevention of overly broad security rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->