### PR TITLE
fix(workspaces): await lifecycle agent lookups

### DIFF
--- a/src/features/workspaces/ai/user-ai-agents.ts
+++ b/src/features/workspaces/ai/user-ai-agents.ts
@@ -360,10 +360,10 @@ export class UserAIStore extends Agent<Cloudflare.Env, UserAIStoreState> {
 			return;
 		}
 
-		const anonymousStore = getAgentByName(
+		const anonymousStore: LinkedUserAIStore = await getAgentByName(
 			this.env[userAIAgentName],
 			input.anonymousUserId,
-		) as unknown as LinkedUserAIStore;
+		);
 		const snapshots = await anonymousStore.exportForAccountLinking();
 
 		for (const snapshot of snapshots) {

--- a/src/features/workspaces/durable-object-lifecycle.ts
+++ b/src/features/workspaces/durable-object-lifecycle.ts
@@ -38,7 +38,7 @@ async function purgeUserAIStore(userId: string) {
 	const { env } = await import("cloudflare:workers");
 
 	try {
-		const store = getUserAIStoreLifecycleAgent(env, userId);
+		const store = await getUserAIStoreLifecycleAgent(env, userId);
 		return await store.purgeForDeletion();
 	} catch (error) {
 		recordPurgeAgentFailure("user", userId, error);
@@ -55,7 +55,7 @@ export async function transferLinkedAccountResources(input: {
 	}
 
 	const { env } = await import("cloudflare:workers");
-	const store = getUserAIStoreLifecycleAgent(env, input.newUserId);
+	const store = await getUserAIStoreLifecycleAgent(env, input.newUserId);
 
 	await store.mergeLinkedAnonymousUser({ anonymousUserId: input.anonymousUserId });
 }
@@ -70,7 +70,7 @@ async function purgeWorkspaceResourcesResult(workspaceId: string): Promise<Resou
 	const { env } = await import("cloudflare:workers");
 
 	try {
-		const kernel = getWorkspaceKernelLifecycleAgent(env, workspaceId);
+		const kernel = await getWorkspaceKernelLifecycleAgent(env, workspaceId);
 		return await kernel.purgeForDeletion();
 	} catch (error) {
 		recordPurgeAgentFailure("workspace", workspaceId, error);
@@ -127,13 +127,16 @@ function recordPurgeOutcome(
 	});
 }
 
-function getUserAIStoreLifecycleAgent(env: Cloudflare.Env, userId: string) {
-	return getAgentByName(env[userAIAgentName], userId) as unknown as UserAIStoreLifecycleAgent;
+async function getUserAIStoreLifecycleAgent(
+	env: Cloudflare.Env,
+	userId: string,
+): Promise<UserAIStoreLifecycleAgent> {
+	return await getAgentByName(env[userAIAgentName], userId);
 }
 
-function getWorkspaceKernelLifecycleAgent(env: Cloudflare.Env, workspaceId: string) {
-	return getAgentByName(
-		env[workspaceKernelAgentName],
-		workspaceId,
-	) as unknown as WorkspaceKernelLifecycleAgent;
+async function getWorkspaceKernelLifecycleAgent(
+	env: Cloudflare.Env,
+	workspaceId: string,
+): Promise<WorkspaceKernelLifecycleAgent> {
+	return await getAgentByName(env[workspaceKernelAgentName], workspaceId);
 }


### PR DESCRIPTION
## Summary

- Await `getAgentByName()` before invoking user and workspace lifecycle methods.
- Fix the nested anonymous-user lookup used during account linking.
- Remove the `as unknown as` casts that hid Promise/stub type mismatches.

## Why

`getAgentByName()` returns a Promise and has done so since the repository's original Agents 0.17.x integration. The lifecycle helpers cast that Promise to narrow agent interfaces, so deletion attempted to call `purgeForDeletion()` on the Promise itself.

Those calls threw before Durable Object or R2 cleanup began. The purge wrappers recorded the failure and returned a failed result, allowing the database deletion to complete while backing storage could remain orphaned.

The workspace regression was introduced when commit `f4d1022b` replaced the previously awaited `getWorkspaceKernel()` path with the unawaited lifecycle helper. It was not caused by the later Agents 0.18.0 upgrade.

## Changes

- Make both lifecycle lookup helpers async with explicit Promise return types.
- Await those helpers in workspace deletion, account deletion, and account-link transfer paths.
- Await the anonymous `UserAIStore` lookup inside `mergeLinkedAnonymousUser()`.
- Keep the existing best-effort purge and operational-event behavior unchanged.

## Testing

- `pnpm vp check`
- `pnpm test -- --run` — 29 files, 102 tests passed
- `git diff --check`

## Review Notes

The important review boundary is the removal of all three unsafe lifecycle casts. With explicit awaited assignments, TypeScript will reject the same missing-await pattern in these paths.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787616815&installation_model_id=425282&pr_number=676&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F676&signature=317f54eb30e3a332b30db35e32f0bfa7c0ef4492b3685d8f61ac3edbb2bd8388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account linking and workspace lifecycle operations by ensuring background agent actions complete reliably.
  * Increased reliability when purging user data and transferring resources during account or workspace cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->