### PR TITLE
fix(conversion): extend Gotenberg request timeout

### DIFF
--- a/src/features/workspaces/conversion/office-pdf-converter.ts
+++ b/src/features/workspaces/conversion/office-pdf-converter.ts
@@ -13,6 +13,7 @@ export class OfficePdfConverter extends Container {
 	sleepAfter = "5m";
 	enableInternet = false;
 	envVars = {
+		API_TIMEOUT: "120s",
 		LIBREOFFICE_AUTO_START: "true",
 		LIBREOFFICE_MAX_QUEUE_SIZE: "1",
 		LIBREOFFICE_START_TIMEOUT: "60s",


### PR DESCRIPTION
## Summary
- Set Gotenberg `API_TIMEOUT` to 120 seconds for Office-to-PDF conversion.

## Why
Production conversion attempts on cold containers failed because Gotenberg's default 30-second request timeout was shorter than the configured 60-second LibreOffice startup allowance. The provider returned `The request exceeded the time limit.`

## Changes
- Add `API_TIMEOUT: "120s"` to `OfficePdfConverter.envVars`.
- Keep the existing 60-second LibreOffice startup timeout and two-instance production pool unchanged.

## Testing
- `pnpm check` passed: 650 files formatted correctly and no lint, type, or warning errors across 626 files.
- `git diff --check` passed.

## Review Notes
This is a one-line runtime configuration change. It has not been deployed outside the normal `main` release workflow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787745194&installation_model_id=425282&pr_number=683&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F683&signature=8408568e8db43eb280064f35ca3eb081873860d51ced1aa018abb8c715a15d7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for office-to-PDF conversions by allowing longer processing time before timing out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->