### PR TITLE
feat: improve collaboration startup and add interactive browser handoff

### DIFF
--- a/docs/concepts/ai-chat.mdx
+++ b/docs/concepts/ai-chat.mdx
@@ -18,7 +18,10 @@ The AI tool surface is intentionally named and bounded:
     Search, read, create, and update workspace content through workspace access checks and `WorkspaceKernel` commands.
   </Accordion>
   <Accordion title="Web tools">
-    Search the public web, read rendered pages as Markdown, and extract links through policy-checked public HTTP(S) URLs.
+    Search the public web, read rendered pages as Markdown, and extract links through policy-checked public HTTP(S) URLs. For interactive sites, the AI can open a task-scoped Browser Run session that appears in the chat.
+  </Accordion>
+  <Accordion title="Interactive browser">
+    Watch the active browser from the chat, expand its Live View, or take control when the AI asks for login, MFA, CAPTCHA, private input, or confirmation of a consequential action. Select **Done** or **Failed** to hand the same session back to the AI. The unrecorded session remains available briefly after the response so you can inspect it, then expires after inactivity; select **Stop** to discard it immediately.
   </Accordion>
   <Accordion title="Research tools">
     Discover and deepen research sources when the workspace task needs external literature or source discovery.

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
 		"tw-animate-css": "^1.3.6",
 		"unified": "^11.0.5",
 		"unist-util-visit": "^5.1.0",
+		"y-indexeddb": "9.0.12",
 		"y-partyserver": "^2.2.0",
 		"y-protocols": "^1.0.7",
 		"yjs": "^13.6.31",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,6 +317,9 @@ importers:
       unist-util-visit:
         specifier: ^5.1.0
         version: 5.1.0
+      y-indexeddb:
+        specifier: 9.0.12
+        version: 9.0.12(yjs@13.6.31)
       y-partyserver:
         specifier: ^2.2.0
         version: 2.2.0(@cloudflare/workers-types@5.20260727.1)(partyserver@0.5.8(@cloudflare/workers-types@5.20260727.1))(yjs@13.6.31)
@@ -8833,6 +8836,12 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  y-indexeddb@9.0.12:
+    resolution: {integrity: sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      yjs: ^13.0.0
+
   y-partyserver@2.2.0:
     resolution: {integrity: sha512-AIsTEZ3jPicBe3VHO5c/VdSGSaFr0J9cAGj6+sgRL/RnXLTNSkP3oQXyXf1y8hQNeXv/j9zYDT5NnRv2k1eMGA==}
     peerDependencies:
@@ -17328,6 +17337,11 @@ snapshots:
 
   xtend@4.0.2:
     optional: true
+
+  y-indexeddb@9.0.12(yjs@13.6.31):
+    dependencies:
+      lib0: 0.2.117
+      yjs: 13.6.31
 
   y-partyserver@2.2.0(@cloudflare/workers-types@5.20260727.1)(partyserver@0.5.8(@cloudflare/workers-types@5.20260727.1))(yjs@13.6.31):
     dependencies:

--- a/src/features/workspaces/ai/ai-codemode-types.ts
+++ b/src/features/workspaces/ai/ai-codemode-types.ts
@@ -1,0 +1,32 @@
+import { generateTypes } from "@cloudflare/codemode/ai";
+import type { ToolSet } from "ai";
+
+import { requireAIThreadToolRuntime } from "#/features/workspaces/ai/ai-thread-tool";
+
+/**
+ * The TypeScript block the model writes Code Mode against.
+ *
+ * The tool a provider sees is deliberately lossy: `getModelToolDefinition`
+ * drops `outputSchema` so it never has to survive a provider's JSON Schema
+ * dialect, and `modelInputSchema` flattens unions that some providers reject.
+ * Code Mode is not a provider — it hands the model TypeScript, which
+ * represents both faithfully — so generate types from the runtime's real
+ * schemas. Without this, every method reads as `Promise<unknown>` and every
+ * flattened union loses the fields it makes conditional.
+ *
+ * This mirrors what `AIThreadToolSetConnector` publishes as the connector's
+ * JSON Schema, so the types and the contract agree.
+ */
+export function generateAIThreadCodemodeTypes(toolSet: ToolSet, namespace: string) {
+	const typedToolSet = Object.fromEntries(
+		Object.entries(toolSet).map(([toolName, aiTool]) => {
+			const runtime = requireAIThreadToolRuntime(toolName, aiTool);
+			return [
+				toolName,
+				{ ...aiTool, inputSchema: runtime.inputSchema, outputSchema: runtime.outputSchema },
+			];
+		}),
+	);
+
+	return generateTypes(typedToolSet, namespace);
+}

--- a/src/features/workspaces/ai/ai-codemode-types.worker.test.ts
+++ b/src/features/workspaces/ai/ai-codemode-types.worker.test.ts
@@ -1,10 +1,12 @@
 import { generateTypes } from "@cloudflare/codemode/ai";
+import type { ToolSet } from "ai";
 import { describe, expect, it } from "vitest";
 
 import {
 	AI_TOOL_REGISTRY,
 	requireAiToolDefinition,
 } from "#/features/workspaces/ai/ai-tool-registry";
+import { createAIThreadBrowserHandoffTool } from "#/features/workspaces/ai/ai-thread-browser";
 import { createAIThreadCodeRunTools } from "#/features/workspaces/ai/code-run-tools";
 import { createAIThreadResearchTools } from "#/features/workspaces/ai/research-tools";
 import { createAIThreadTimeTools } from "#/features/workspaces/ai/time-tools";
@@ -13,7 +15,8 @@ import { createAIThreadWebTools } from "#/features/workspaces/ai/web-tools";
 describe("AI Code Mode type generation", () => {
 	it("publishes concrete output types for every non-workspace nested tool", () => {
 		const env = {} as Cloudflare.Env;
-		const tools = {
+		const tools: ToolSet = {
+			browser_handoff: createAIThreadBrowserHandoffTool(),
 			...createAIThreadCodeRunTools({ env, sandboxId: "test-thread" }),
 			...createAIThreadResearchTools(env),
 			...createAIThreadTimeTools(),
@@ -35,7 +38,8 @@ describe("AI Code Mode type generation", () => {
 
 	it("keeps every runtime tool factory synchronized with the registry", () => {
 		const env = {} as Cloudflare.Env;
-		const tools = {
+		const tools: ToolSet = {
+			browser_handoff: createAIThreadBrowserHandoffTool(),
 			...createAIThreadCodeRunTools({ env, sandboxId: "registry-test" }),
 			...createAIThreadResearchTools(env),
 			...createAIThreadTimeTools(),

--- a/src/features/workspaces/ai/ai-codemode-types.worker.test.ts
+++ b/src/features/workspaces/ai/ai-codemode-types.worker.test.ts
@@ -1,4 +1,3 @@
-import { generateTypes } from "@cloudflare/codemode/ai";
 import type { ToolSet } from "ai";
 import { describe, expect, it } from "vitest";
 
@@ -6,6 +5,7 @@ import {
 	AI_TOOL_REGISTRY,
 	requireAiToolDefinition,
 } from "#/features/workspaces/ai/ai-tool-registry";
+import { generateAIThreadCodemodeTypes } from "#/features/workspaces/ai/ai-codemode-types";
 import { createAIThreadBrowserHandoffTool } from "#/features/workspaces/ai/ai-thread-browser";
 import { createAIThreadCodeRunTools } from "#/features/workspaces/ai/code-run-tools";
 import { createAIThreadResearchTools } from "#/features/workspaces/ai/research-tools";
@@ -22,7 +22,10 @@ describe("AI Code Mode type generation", () => {
 			...createAIThreadTimeTools(),
 			...createAIThreadWebTools(env),
 		};
-		const declarations = generateTypes(tools, "tools");
+		// Exercise the generator the connector actually calls: the raw ToolSet has
+		// no output schemas, so asserting against `generateTypes` directly would
+		// pass on a type block the model never sees.
+		const declarations = generateAIThreadCodemodeTypes(tools, "tools");
 
 		expect(declarations).not.toMatch(/type \w+Output = unknown/);
 		for (const toolName of Object.keys(tools)) {
@@ -46,8 +49,12 @@ describe("AI Code Mode type generation", () => {
 			...createAIThreadWebTools(env),
 		};
 		const runtimeNames = ["sandbox_bash", ...Object.keys(tools)].sort();
-		const registeredRuntimeNames = Object.keys(AI_TOOL_REGISTRY)
-			.filter((name) => name !== "orchestrate" && !name.startsWith("workspace_"))
+		const registeredRuntimeNames = Object.entries(AI_TOOL_REGISTRY)
+			.filter(
+				([name, definition]) =>
+					name !== "orchestrate" && !name.startsWith("workspace_") && !definition.presentationOnly,
+			)
+			.map(([name]) => name)
 			.sort();
 
 		for (const name of runtimeNames) {

--- a/src/features/workspaces/ai/ai-thread-browser-activity.ts
+++ b/src/features/workspaces/ai/ai-thread-browser-activity.ts
@@ -1,0 +1,166 @@
+export type AIThreadBrowserActivityStatus = "completed" | "failed" | "running";
+
+interface AIThreadBrowserActivityCall {
+	args: unknown;
+	method: string;
+	result?: unknown;
+}
+
+interface AIThreadBrowserDestination {
+	site: string;
+	title?: string;
+	url: string;
+}
+
+/**
+ * Turns low-level CDP traffic into one user-facing destination summary.
+ *
+ * Only explicit navigations count. Protocol setup such as `attachToTarget`
+ * carries no useful destination, and successful traffic without a destination
+ * is omitted instead of rendering a generic "Browsed web" row.
+ */
+export function summarizeAIThreadBrowserActivity(
+	calls: readonly AIThreadBrowserActivityCall[],
+	status: AIThreadBrowserActivityStatus,
+): string | undefined {
+	const destinations = getBrowserDestinations(calls);
+	const sites = unique(destinations.map((destination) => destination.site));
+
+	if (status === "failed") {
+		if (sites.length === 1) {
+			return `Browser failed on ${sites[0]}`;
+		}
+		return sites.length > 1 ? `Browser failed across ${sites.length} sites` : "Browser failed";
+	}
+
+	if (sites.length === 0) {
+		return undefined;
+	}
+
+	const verb = status === "running" ? "Browsing" : "Browsed";
+	if (sites.length === 1) {
+		const pageCount = unique(destinations.map((destination) => destination.url)).length;
+		const pageTitles = unique(
+			destinations
+				.map((destination) => destination.title)
+				.filter((title): title is string => Boolean(title)),
+		);
+		if (pageCount === 1 && pageTitles.length === 1 && pageTitles[0] !== sites[0]) {
+			return `${verb} ${sites[0]} — ${pageTitles[0]}`;
+		}
+		return pageCount > 1 ? `${verb} ${pageCount} pages on ${sites[0]}` : `${verb} ${sites[0]}`;
+	}
+	if (sites.length === 2) {
+		return `${verb} ${sites[0]} and ${sites[1]}`;
+	}
+	return `${verb} ${sites.length} sites`;
+}
+
+function getBrowserDestinations(calls: readonly AIThreadBrowserActivityCall[]) {
+	const destinations = calls.flatMap((call) => {
+		if (call.method !== "send") {
+			return [];
+		}
+
+		const args = asRecord(call.args);
+		const method = getString(args.method);
+		if (method !== "Target.createTarget" && method !== "Page.navigate") {
+			return [];
+		}
+
+		const url = getString(asRecord(args.params).url);
+		const destination = url ? getBrowserDestination(url) : undefined;
+		return destination ? [destination] : [];
+	});
+
+	if (unique(destinations.map((destination) => destination.url)).length === 1) {
+		const title = getLastEvaluatedPageTitle(calls);
+		if (title) {
+			for (const destination of destinations) {
+				destination.title ??= title;
+			}
+		}
+	}
+
+	return destinations;
+}
+
+function getLastEvaluatedPageTitle(calls: readonly AIThreadBrowserActivityCall[]) {
+	for (let index = calls.length - 1; index >= 0; index -= 1) {
+		const call = calls[index];
+		const args = asRecord(call?.args);
+		if (call?.method !== "send" || getString(args.method) !== "Runtime.evaluate") {
+			continue;
+		}
+
+		const params = asRecord(args.params);
+		const expression = getString(params.expression);
+		if (!expression?.includes("document.title")) {
+			continue;
+		}
+
+		const value = asRecord(asRecord(call.result).result).value;
+		const title =
+			typeof value === "string"
+				? formatPageTitle(value)
+				: formatPageTitle(getString(asRecord(value).title));
+		if (title) {
+			return title;
+		}
+	}
+	return undefined;
+}
+
+function getBrowserDestination(value: string): AIThreadBrowserDestination | undefined {
+	try {
+		const url = new URL(value);
+		if (url.protocol !== "http:" && url.protocol !== "https:") {
+			return undefined;
+		}
+
+		url.hash = "";
+		const hostname = url.hostname.toLowerCase().replace(/^www\./, "");
+		return {
+			site: formatBrowserSite(hostname),
+			url: url.toString(),
+		};
+	} catch {
+		return undefined;
+	}
+}
+
+function formatPageTitle(value: string | undefined) {
+	const title = value?.replace(/\s+/g, " ").trim();
+	if (!title) {
+		return undefined;
+	}
+	return title.length > 80 ? `${title.slice(0, 79).trimEnd()}…` : title;
+}
+
+function formatBrowserSite(hostname: string) {
+	if (hostname === "instructure.com" || hostname.endsWith(".instructure.com")) {
+		const tenant = hostname.slice(0, -".instructure.com".length).split(".").filter(Boolean).at(-1);
+		return tenant && tenant !== "canvas" ? `${formatSiteWord(tenant)} Canvas` : "Canvas";
+	}
+	return hostname;
+}
+
+function formatSiteWord(value: string) {
+	return value.length <= 5
+		? value.toUpperCase()
+		: `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
+}
+
+function unique<T>(values: readonly T[]) {
+	return [...new Set(values)];
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: {};
+}
+
+function getString(value: unknown) {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/src/features/workspaces/ai/ai-thread-browser.ts
+++ b/src/features/workspaces/ai/ai-thread-browser.ts
@@ -36,21 +36,35 @@ const MODEL_HIDDEN_BROWSER_TOOLS = new Set([
  * connector reuse this list so browser behavior cannot drift depending on
  * whether the model has inspected the connector yet.
  */
-export const AI_THREAD_BROWSER_GUIDANCE = [
-	"Use web search and page-reading tools for simple research. Use CDP only for rendered interaction, JavaScript applications, screenshots, or authenticated work.",
+/**
+ * What the model must know *before* it decides to reach for a browser at all:
+ * when browsing is the right tool, and the rules it cannot violate once it is.
+ * This is the only browser text carried in the always-on orchestrate
+ * description, so it stays short — every turn pays for it, including the ones
+ * that never open a page.
+ */
+export const AI_THREAD_BROWSER_POLICY = [
+	"Use web search and page-reading tools for simple research. Use `cdp.*` only for rendered interaction, JavaScript applications, screenshots, or authenticated work.",
 	"Navigate only public HTTP(S) pages. Never navigate to localhost, private or link-local IP addresses, or internal-only hostnames.",
+	"For login, MFA, CAPTCHA, private input, payments, external publishing or sending, destructive deletion, and account or security changes, open the exact page and call tools.browser_handoff({ instructions }) before the consequential step. Calling it is mandatory — a chat message saying you paused does not pause the run.",
+	"Never ask the user to put credentials or private form values in chat. They enter them only in Browser Live View.",
+	"ThinkEx owns browser session lifecycle and Live View. Never request, return, or mention a Live View URL, browser session ID, target handle, JWT, or WebSocket URL.",
+] as const;
+
+/**
+ * How to actually drive CDP. Only reaches the model through the connector's
+ * own instructions, which it reads on discovery — the point at which it is
+ * already writing browser code and these details start to matter.
+ */
+const AI_THREAD_BROWSER_MECHANICS = [
 	"Issue CDP calls sequentially. Never run them with Promise.all.",
 	"Browser- and Target-scoped commands need no sessionId; page-scoped commands require the stable handle from cdp.attachToTarget({ targetId }).",
+	"There is no cdp.newTab. Open a tab with Target.createTarget, then attach before any page-scoped command.",
 	"The CDP namespace is request/response only: use cdp.send, cdp.attachToTarget, cdp.spec, and the debug-log helpers. It has no cdp.on, cdp.off, or event-subscription API.",
 	"Never wait for CDP events. When page readiness matters, poll document.readyState with sequential Runtime.evaluate calls.",
 	"Do not use saved snippets or codemode.run for browser work. Issue CDP calls directly in the current execution so the target and session are live when a handoff pauses.",
 	"If the shared browser session is disconnected or a CDP command fails because the session is gone, call cdp.resetSession() once and retry the failed operation. Do not repeatedly reset a healthy session.",
 	"Start with one tab, close tabs you no longer need, and keep at most five tabs open.",
-	"For login, MFA, CAPTCHA, private input, payments, external publishing or sending, destructive deletion, and account or security changes, open the exact page and call tools.browser_handoff({ instructions }) before the consequential step.",
-	"When the user must interact in Live View before you can continue, calling tools.browser_handoff is mandatory. Call it immediately after opening the exact page; a chat message saying you paused or handed off does not pause the run.",
-	"Never ask the user to put credentials or private form values in chat. They enter them only in Browser Live View.",
-	"ThinkEx owns browser session lifecycle and Live View. Never request, return, or mention a Live View URL, browser session ID, target handle, JWT, or WebSocket URL.",
-	"There is no cdp.newTab. Open a tab with Target.createTarget, then attach before any page-scoped command.",
 ] as const;
 
 const AI_THREAD_BROWSER_SESSION_OPTIONS = {
@@ -109,7 +123,10 @@ export function createAIThreadBrowserConnector(ctx: DurableObjectState, browser:
 
 class AIThreadBrowserConnector extends BrowserConnector {
 	protected override instructions() {
-		return AI_THREAD_BROWSER_GUIDANCE.join("\n");
+		// Discovery is the moment of use, so repeat the policy here alongside the
+		// mechanics: it costs nothing on turns that never open a browser, and the
+		// rules matter most immediately before the model writes CDP calls.
+		return [...AI_THREAD_BROWSER_POLICY, ...AI_THREAD_BROWSER_MECHANICS].join("\n");
 	}
 
 	protected override tools() {

--- a/src/features/workspaces/ai/ai-thread-browser.ts
+++ b/src/features/workspaces/ai/ai-thread-browser.ts
@@ -1,0 +1,212 @@
+import type { PendingAction } from "@cloudflare/codemode";
+import {
+	BrowserConnector,
+	DurableBrowserSessionStore,
+	type BrowserBinding,
+	type BrowserConnectorSessionOptions,
+} from "agents/browser";
+import { z } from "zod";
+
+import { defineAIThreadTool } from "#/features/workspaces/ai/ai-thread-tool";
+
+export const AI_THREAD_BROWSER_HANDOFF_TOOL_NAME = "browser_handoff";
+/** The namespace `AIThreadToolSetConnector` publishes first-party tools under. */
+const AI_THREAD_TOOL_CONNECTOR_NAME = "tools";
+const AI_THREAD_BROWSER_KEEP_ALIVE_MS = 10 * 60 * 1000;
+const AI_THREAD_BROWSER_SESSION_KEY = "task";
+/**
+ * `agents` files the shared session under `cdp:reuse:<key>`. Presence reads
+ * that record directly instead of calling `sessionInfo()`, which would spend a
+ * Browser Run round trip on every poll — at the cost of depending on a prefix
+ * the library keeps private, so keep the key half derived from the options
+ * that produce it.
+ */
+const AI_THREAD_BROWSER_STORE_KEY = `cdp:reuse:${AI_THREAD_BROWSER_SESSION_KEY}`;
+const MODEL_HIDDEN_BROWSER_TOOLS = new Set([
+	"closeSession",
+	"getLiveViewUrl",
+	"sessionInfo",
+	"startSession",
+]);
+
+/**
+ * The single model-facing browser contract.
+ *
+ * Both the top-level orchestration tool and the lazily discovered CDP
+ * connector reuse this list so browser behavior cannot drift depending on
+ * whether the model has inspected the connector yet.
+ */
+export const AI_THREAD_BROWSER_GUIDANCE = [
+	"Use web search and page-reading tools for simple research. Use CDP only for rendered interaction, JavaScript applications, screenshots, or authenticated work.",
+	"Navigate only public HTTP(S) pages. Never navigate to localhost, private or link-local IP addresses, or internal-only hostnames.",
+	"Issue CDP calls sequentially. Never run them with Promise.all.",
+	"Browser- and Target-scoped commands need no sessionId; page-scoped commands require the stable handle from cdp.attachToTarget({ targetId }).",
+	"The CDP namespace is request/response only: use cdp.send, cdp.attachToTarget, cdp.spec, and the debug-log helpers. It has no cdp.on, cdp.off, or event-subscription API.",
+	"Never wait for CDP events. When page readiness matters, poll document.readyState with sequential Runtime.evaluate calls.",
+	"Do not use saved snippets or codemode.run for browser work. Issue CDP calls directly in the current execution so the target and session are live when a handoff pauses.",
+	"If the shared browser session is disconnected or a CDP command fails because the session is gone, call cdp.resetSession() once and retry the failed operation. Do not repeatedly reset a healthy session.",
+	"Start with one tab, close tabs you no longer need, and keep at most five tabs open.",
+	"For login, MFA, CAPTCHA, private input, payments, external publishing or sending, destructive deletion, and account or security changes, open the exact page and call tools.browser_handoff({ instructions }) before the consequential step.",
+	"When the user must interact in Live View before you can continue, calling tools.browser_handoff is mandatory. Call it immediately after opening the exact page; a chat message saying you paused or handed off does not pause the run.",
+	"Never ask the user to put credentials or private form values in chat. They enter them only in Browser Live View.",
+	"ThinkEx owns browser session lifecycle and Live View. Never request, return, or mention a Live View URL, browser session ID, target handle, JWT, or WebSocket URL.",
+	"There is no cdp.newTab. Open a tab with Target.createTarget, then attach before any page-scoped command.",
+] as const;
+
+const AI_THREAD_BROWSER_SESSION_OPTIONS = {
+	mode: "reuse",
+	key: AI_THREAD_BROWSER_SESSION_KEY,
+	keepAliveMs: AI_THREAD_BROWSER_KEEP_ALIVE_MS,
+	recording: false,
+} as const satisfies BrowserConnectorSessionOptions;
+
+export interface AIThreadBrowserLiveViewTarget {
+	id: string;
+	liveViewUrl: string;
+	title?: string;
+	url?: string;
+}
+
+export interface AIThreadBrowserLiveView {
+	expiresInMs: number;
+	targets: AIThreadBrowserLiveViewTarget[];
+}
+
+export interface AIThreadBrowserPresence {
+	startedAt: number;
+}
+
+export interface AIThreadBrowserHandoff {
+	executionId: string;
+	instructions: string;
+}
+
+export interface AIThreadBrowserState {
+	handoff: AIThreadBrowserHandoff | null;
+	presence: AIThreadBrowserPresence | null;
+}
+
+const browserHandoffInputSchema = z.object({
+	instructions: z
+		.string()
+		.trim()
+		.min(1)
+		.max(500)
+		.describe("What the user must complete in the open browser before the agent resumes."),
+});
+
+const browserHandoffOutputSchema = z.object({
+	resumed: z.literal(true),
+});
+
+export function createAIThreadBrowserConnector(ctx: DurableObjectState, browser: BrowserBinding) {
+	return new AIThreadBrowserConnector(ctx, {
+		browser,
+		store: new DurableBrowserSessionStore(ctx.storage),
+		session: AI_THREAD_BROWSER_SESSION_OPTIONS,
+	});
+}
+
+class AIThreadBrowserConnector extends BrowserConnector {
+	protected override instructions() {
+		return AI_THREAD_BROWSER_GUIDANCE.join("\n");
+	}
+
+	protected override tools() {
+		return Object.fromEntries(
+			Object.entries(super.tools()).filter(([name]) => !MODEL_HIDDEN_BROWSER_TOOLS.has(name)),
+		);
+	}
+}
+
+export function createAIThreadBrowserHandoffTool() {
+	return defineAIThreadTool({
+		description:
+			"Pause browser automation so the user can take control in Live View. Call only after opening the exact page that needs login, MFA, CAPTCHA, private input, or confirmation of a consequential final action.",
+		inputSchema: browserHandoffInputSchema,
+		outputSchema: browserHandoffOutputSchema,
+		needsApproval: true,
+		strict: true,
+		execute: async () => ({ resumed: true }),
+	});
+}
+
+/**
+ * Narrow the runtime's pending actions to the one the chat can resolve.
+ *
+ * Deliberately server-side: `PendingAction.args` is untruncated, so handing the
+ * raw list to the client would ship every approval-gated tool's arguments to
+ * the browser on a 1.5s poll just to read one instruction string.
+ */
+export function getAIThreadBrowserHandoff(
+	pending: readonly PendingAction[],
+): AIThreadBrowserHandoff | null {
+	const action = pending.find(
+		(candidate) =>
+			candidate.connector === AI_THREAD_TOOL_CONNECTOR_NAME &&
+			candidate.method === AI_THREAD_BROWSER_HANDOFF_TOOL_NAME,
+	);
+
+	if (!action) {
+		return null;
+	}
+
+	return {
+		executionId: action.executionId,
+		instructions: getBrowserHandoffInstructions(action.args),
+	};
+}
+
+function getBrowserHandoffInstructions(args: unknown) {
+	const fallback = "Complete the requested step in the browser.";
+	if (!args || typeof args !== "object" || !("instructions" in args)) {
+		return fallback;
+	}
+
+	const instructions = args.instructions;
+	return typeof instructions === "string" && instructions.trim() ? instructions.trim() : fallback;
+}
+
+export async function getAIThreadBrowserPresence(
+	storage: DurableObjectStorage,
+): Promise<AIThreadBrowserPresence | null> {
+	const store = new DurableBrowserSessionStore(storage);
+	const session = await store.get(AI_THREAD_BROWSER_STORE_KEY);
+	if (!session) {
+		return null;
+	}
+
+	if (Date.now() - session.updatedAt >= AI_THREAD_BROWSER_KEEP_ALIVE_MS) {
+		await store.delete(AI_THREAD_BROWSER_STORE_KEY);
+		return null;
+	}
+
+	return { startedAt: session.createdAt };
+}
+
+export async function getAIThreadBrowserLiveView(
+	connector: BrowserConnector,
+): Promise<AIThreadBrowserLiveView | null> {
+	const liveView = await connector.liveView({ mode: "tab" });
+	if (!liveView) {
+		return null;
+	}
+
+	return {
+		expiresInMs: liveView.expiresInMs,
+		targets: liveView.targets.filter(isBrowserPageTarget).map((target) => ({
+			id: target.targetId,
+			liveViewUrl: target.url,
+			...(target.title ? { title: target.title } : {}),
+			...(isDisplayableBrowserUrl(target.pageUrl) ? { url: target.pageUrl } : {}),
+		})),
+	};
+}
+
+function isBrowserPageTarget(target: { type?: string }) {
+	return target.type === undefined || target.type === "page";
+}
+
+function isDisplayableBrowserUrl(url: string | undefined): url is string {
+	return Boolean(url && !url.startsWith("about:") && !url.startsWith("chrome:"));
+}

--- a/src/features/workspaces/ai/ai-thread-orchestration-contract.ts
+++ b/src/features/workspaces/ai/ai-thread-orchestration-contract.ts
@@ -7,6 +7,7 @@ import {
 	getAIToolOutputOutcome,
 	type AIToolOutcome,
 } from "#/features/workspaces/ai/ai-tool-outcome";
+import { summarizeAIThreadBrowserActivity } from "#/features/workspaces/ai/ai-thread-browser-activity";
 
 const orchestrationCallStateSchema = z.enum([
 	"executing",
@@ -122,7 +123,7 @@ export function normalizeAIThreadOrchestrationOutput(output: unknown): AIThreadO
 		return invalidOrchestrationOutput(output);
 	}
 
-	const calls = parsed.data.calls.map(normalizeCall);
+	const calls = normalizeCalls(parsed.data.calls);
 	const childOutcome = aggregateAIToolOutcomes(calls.map((call) => call.outcome));
 
 	if (parsed.data.status === "completed") {
@@ -216,6 +217,78 @@ function normalizeCall(call: z.output<typeof rawOrchestrationCallSchema>) {
 		outcome,
 		summary: summarizeOrchestrationCall(outcome),
 	};
+}
+
+function normalizeCalls(rawCalls: z.output<typeof rawOrchestrationCallSchema>[]) {
+	const calls: ReturnType<typeof normalizeCall>[] = [];
+	const browserCalls: z.output<typeof rawOrchestrationCallSchema>[] = [];
+	let browserCallIndex = 0;
+
+	for (const call of rawCalls) {
+		if (call.connector === "cdp") {
+			if (browserCalls.length === 0) {
+				browserCallIndex = calls.length;
+			}
+			browserCalls.push(call);
+			continue;
+		}
+
+		calls.push(normalizeCall(call));
+	}
+
+	if (browserCalls.length > 0) {
+		const browserCall = normalizeBrowserCalls(browserCalls);
+		if (browserCall) {
+			calls.splice(browserCallIndex, 0, browserCall);
+		}
+	}
+
+	return calls;
+}
+
+function normalizeBrowserCalls(calls: z.output<typeof rawOrchestrationCallSchema>[]) {
+	const state = getBrowserCallState(calls);
+	// An in-flight CDP call has no result yet, and getOrchestrationCallOutcome
+	// reads any state other than applied/pending as a failure — folding one in
+	// would report `codemode_tool_error` for work that has not failed and drag
+	// the whole turn's outcome down with it. Only settled calls decide the
+	// outcome; `executing` decides the status on its own, because
+	// getOrchestrationCallStatus recognizes `pending` as the sole running state
+	// and this group never reports `pending` (CDP calls need no approval).
+	const outcome = aggregateAIToolOutcomes(
+		calls
+			.filter((call) => call.state !== "executing")
+			.map((call) => getOrchestrationCallOutcome("browser_execute", call.state, call.result)),
+	);
+	const status =
+		state === "executing" ? ("running" as const) : getOrchestrationCallStatus(state, outcome);
+	const summary = summarizeAIThreadBrowserActivity(calls, status);
+	if (!summary) {
+		return undefined;
+	}
+
+	return {
+		id: `${calls[0]?.seq ?? 0}:cdp:browser_execute`,
+		toolName: "browser_execute",
+		state,
+		status,
+		requiresApproval: false,
+		outcome,
+		summary,
+	};
+}
+
+function getBrowserCallState(
+	calls: z.output<typeof rawOrchestrationCallSchema>[],
+): z.output<typeof orchestrationCallStateSchema> {
+	if (calls.some((call) => call.state === "error" || call.state === "reverted")) {
+		return "error";
+	}
+	if (calls.some((call) => call.state === "executing" || call.state === "pending")) {
+		return "executing";
+	}
+
+	return "applied";
 }
 
 function getOrchestrationCallStatus(

--- a/src/features/workspaces/ai/ai-thread-orchestration-contract.ts
+++ b/src/features/workspaces/ai/ai-thread-orchestration-contract.ts
@@ -219,47 +219,55 @@ function normalizeCall(call: z.output<typeof rawOrchestrationCallSchema>) {
 	};
 }
 
+/**
+ * Collapse each *contiguous* run of CDP traffic into one browser receipt.
+ *
+ * Grouping every CDP call in the execution instead would reorder the
+ * transcript: a tool call made between two browser stretches would render
+ * after browsing that actually happened later, and two unrelated visits would
+ * merge into a single row.
+ */
 function normalizeCalls(rawCalls: z.output<typeof rawOrchestrationCallSchema>[]) {
 	const calls: ReturnType<typeof normalizeCall>[] = [];
-	const browserCalls: z.output<typeof rawOrchestrationCallSchema>[] = [];
-	let browserCallIndex = 0;
+	let browserRun: z.output<typeof rawOrchestrationCallSchema>[] = [];
+
+	const flushBrowserRun = () => {
+		if (browserRun.length === 0) {
+			return;
+		}
+
+		const browserCall = normalizeBrowserCalls(browserRun);
+		if (browserCall) {
+			calls.push(browserCall);
+		}
+		browserRun = [];
+	};
 
 	for (const call of rawCalls) {
 		if (call.connector === "cdp") {
-			if (browserCalls.length === 0) {
-				browserCallIndex = calls.length;
-			}
-			browserCalls.push(call);
+			browserRun.push(call);
 			continue;
 		}
 
+		flushBrowserRun();
 		calls.push(normalizeCall(call));
 	}
-
-	if (browserCalls.length > 0) {
-		const browserCall = normalizeBrowserCalls(browserCalls);
-		if (browserCall) {
-			calls.splice(browserCallIndex, 0, browserCall);
-		}
-	}
+	flushBrowserRun();
 
 	return calls;
 }
 
 function normalizeBrowserCalls(calls: z.output<typeof rawOrchestrationCallSchema>[]) {
 	const state = getBrowserCallState(calls);
-	// An in-flight CDP call has no result yet, and getOrchestrationCallOutcome
-	// reads any state other than applied/pending as a failure — folding one in
-	// would report `codemode_tool_error` for work that has not failed and drag
-	// the whole turn's outcome down with it. Only settled calls decide the
-	// outcome; `executing` decides the status on its own, because
-	// getOrchestrationCallStatus recognizes `pending` as the sole running state
-	// and this group never reports `pending` (CDP calls need no approval).
-	const outcome = aggregateAIToolOutcomes(
-		calls
-			.filter((call) => call.state !== "executing")
-			.map((call) => getOrchestrationCallOutcome("browser_execute", call.state, call.result)),
-	);
+	// One row, one verdict: the outcome follows the same "where did the run end
+	// up" rule as the state. Aggregating every call instead would report
+	// `codemode_tool_error` for a reset-and-retry that already recovered, and
+	// would count an in-flight call — which has no result yet, and which
+	// getOrchestrationCallOutcome reads as a failure — as a failure.
+	const decidingCall = state === "executing" ? undefined : calls.at(-1);
+	const outcome: AIToolOutcome = decidingCall
+		? getOrchestrationCallOutcome("browser_execute", decidingCall.state, decidingCall.result)
+		: { failureCodes: [], failedCount: 0, status: "success" };
 	const status =
 		state === "executing" ? ("running" as const) : getOrchestrationCallStatus(state, outcome);
 	const summary = summarizeAIThreadBrowserActivity(calls, status);
@@ -278,17 +286,23 @@ function normalizeBrowserCalls(calls: z.output<typeof rawOrchestrationCallSchema
 	};
 }
 
+/**
+ * The browser guidance tells the model to call `cdp.resetSession()` once and
+ * retry when a reused session has gone away, so a failed call followed by a
+ * successful one is the *supported* recovery path, not a failure. The durable
+ * log keeps the original error forever, so the group has to be judged by where
+ * the run ended up: anything still in flight reads as running, and an error
+ * counts only when nothing after it succeeded.
+ */
 function getBrowserCallState(
 	calls: z.output<typeof rawOrchestrationCallSchema>[],
 ): z.output<typeof orchestrationCallStateSchema> {
-	if (calls.some((call) => call.state === "error" || call.state === "reverted")) {
-		return "error";
-	}
 	if (calls.some((call) => call.state === "executing" || call.state === "pending")) {
 		return "executing";
 	}
 
-	return "applied";
+	const lastSettled = calls.at(-1);
+	return lastSettled?.state === "error" || lastSettled?.state === "reverted" ? "error" : "applied";
 }
 
 function getOrchestrationCallStatus(

--- a/src/features/workspaces/ai/ai-thread-orchestration.ts
+++ b/src/features/workspaces/ai/ai-thread-orchestration.ts
@@ -1,4 +1,3 @@
-import { generateTypes } from "@cloudflare/codemode/ai";
 import type { ConnectorTool, ConnectorTools } from "@cloudflare/codemode";
 import { CodemodeConnector, sanitizeToolName } from "@cloudflare/codemode";
 import { createExecuteRuntime } from "@cloudflare/think/tools/execute";
@@ -6,6 +5,7 @@ import type { StateBackend } from "@cloudflare/shell";
 import type { Tool, ToolSet } from "ai";
 import { z } from "zod";
 
+import { generateAIThreadCodemodeTypes } from "#/features/workspaces/ai/ai-codemode-types";
 import { createAIThreadBrowserConnector } from "#/features/workspaces/ai/ai-thread-browser";
 import { normalizeAIThreadOrchestrationOutput } from "#/features/workspaces/ai/ai-thread-orchestration-contract";
 import {
@@ -129,6 +129,6 @@ class AIThreadToolSetConnector extends CodemodeConnector {
 	}
 
 	async getTypeScriptTypes() {
-		return generateTypes(this.#toolSet, this.name());
+		return generateAIThreadCodemodeTypes(this.#toolSet, this.name());
 	}
 }

--- a/src/features/workspaces/ai/ai-thread-orchestration.ts
+++ b/src/features/workspaces/ai/ai-thread-orchestration.ts
@@ -3,13 +3,30 @@ import type { ConnectorTool, ConnectorTools } from "@cloudflare/codemode";
 import { CodemodeConnector, sanitizeToolName } from "@cloudflare/codemode";
 import { createExecuteRuntime } from "@cloudflare/think/tools/execute";
 import type { StateBackend } from "@cloudflare/shell";
-import type { ToolSet } from "ai";
+import type { Tool, ToolSet } from "ai";
+import { z } from "zod";
 
+import { createAIThreadBrowserConnector } from "#/features/workspaces/ai/ai-thread-browser";
+import { normalizeAIThreadOrchestrationOutput } from "#/features/workspaces/ai/ai-thread-orchestration-contract";
 import {
-	aiThreadOrchestrationOutputSchema,
-	normalizeAIThreadOrchestrationOutput,
-} from "#/features/workspaces/ai/ai-thread-orchestration-contract";
-import { requireAIThreadToolRuntime } from "#/features/workspaces/ai/ai-thread-tool";
+	aiThreadActivityTitleSchema,
+	getModelToolDefinition,
+	requireAIThreadToolRuntime,
+} from "#/features/workspaces/ai/ai-thread-tool";
+
+type AIThreadOrchestrationRuntime = ReturnType<typeof createExecuteRuntime>["runtime"];
+
+/**
+ * Code Mode's own input schema is `{ code }` alone, which leaves the chat row
+ * with nothing to say but "Working". Widening it with a leading `title` costs
+ * the execution nothing — Cloudflare's executor destructures `code` and
+ * ignores the rest — and gives the row a model-authored label to show while
+ * the code streams in.
+ */
+const aiThreadOrchestrationInputSchema = z.object({
+	title: aiThreadActivityTitleSchema,
+	code: z.string(),
+});
 
 export {
 	getAIThreadOrchestrationTelemetryOutput,
@@ -20,8 +37,10 @@ export type { AIThreadOrchestrationOutput } from "#/features/workspaces/ai/ai-th
 interface CreateAIThreadOrchestrationToolInput {
 	ctx: DurableObjectState;
 	description: string;
+	browser: Cloudflare.Env["BROWSER"];
 	loader: WorkerLoader;
 	name: string;
+	onRuntime?: (runtime: AIThreadOrchestrationRuntime) => void;
 	state?: StateBackend;
 	tools: ToolSet;
 }
@@ -31,15 +50,19 @@ interface CreateAIThreadOrchestrationToolInput {
  * Cloudflare keeps its full durable execution log; callers receive only the
  * typed, compact application result below.
  */
-export function createAIThreadOrchestrationTool(input: CreateAIThreadOrchestrationToolInput) {
+export function createAIThreadOrchestrationTool(input: CreateAIThreadOrchestrationToolInput): Tool {
 	const runtime = createExecuteRuntime({
 		ctx: input.ctx,
 		loader: input.loader,
 		state: input.state,
-		connectors: [new AIThreadToolSetConnector(input.ctx, input.tools)],
+		connectors: [
+			new AIThreadToolSetConnector(input.ctx, input.tools),
+			createAIThreadBrowserConnector(input.ctx, input.browser),
+		],
 		name: input.name,
 		description: input.description,
 	});
+	input.onRuntime?.(runtime.runtime);
 	const execute = runtime.tool.execute;
 
 	if (!execute) {
@@ -47,12 +70,12 @@ export function createAIThreadOrchestrationTool(input: CreateAIThreadOrchestrati
 	}
 
 	return {
-		...runtime.tool,
-		outputSchema: aiThreadOrchestrationOutputSchema,
+		...getModelToolDefinition(runtime.tool),
+		inputSchema: aiThreadOrchestrationInputSchema,
 		execute: async (...args: Parameters<typeof execute>) => {
 			return normalizeAIThreadOrchestrationOutput(await execute(...args));
 		},
-	};
+	} as Tool;
 }
 
 class AIThreadToolSetConnector extends CodemodeConnector {

--- a/src/features/workspaces/ai/ai-thread-orchestration.worker.test.ts
+++ b/src/features/workspaces/ai/ai-thread-orchestration.worker.test.ts
@@ -43,6 +43,7 @@ describe("AI thread orchestration", () => {
 		} as never);
 
 		createAIThreadOrchestrationTool({
+			browser: {} as Cloudflare.Env["BROWSER"],
 			ctx: {} as DurableObjectState,
 			description: "test",
 			loader: {} as WorkerLoader,

--- a/src/features/workspaces/ai/ai-thread-orchestration.worker.test.ts
+++ b/src/features/workspaces/ai/ai-thread-orchestration.worker.test.ts
@@ -266,6 +266,71 @@ describe("AI thread orchestration", () => {
 		});
 	});
 
+	it("keeps interleaved work in execution order instead of merging every browser stretch", () => {
+		const output = normalizeAIThreadOrchestrationOutput({
+			status: "completed",
+			executionId: "execution-interleaved",
+			result: null,
+			calls: [
+				browserNavigation(1, "https://example.com/start"),
+				{
+					seq: 2,
+					connector: "tools",
+					method: "web_search",
+					state: "applied",
+					requiresApproval: false,
+					args: { query: "notes" },
+					result: { results: [] },
+				},
+				browserNavigation(3, "https://docs.example.org/guide"),
+			],
+		});
+
+		expect(output.calls.map((call) => call.toolName)).toEqual([
+			"browser_execute",
+			"web_search",
+			"browser_execute",
+		]);
+	});
+
+	it("treats a reset-and-retry that recovered as a success, not a failure", () => {
+		const output = normalizeAIThreadOrchestrationOutput({
+			status: "completed",
+			executionId: "execution-recovered",
+			result: null,
+			calls: [
+				{ ...browserNavigation(1, "https://example.com/"), state: "error" },
+				{
+					seq: 2,
+					connector: "cdp",
+					method: "resetSession",
+					state: "applied",
+					requiresApproval: false,
+					args: {},
+				},
+				browserNavigation(3, "https://example.com/"),
+			],
+		});
+
+		expect(output.calls).toMatchObject([{ status: "completed", state: "applied" }]);
+		expect(output.outcome).toEqual({ failureCodes: [], failedCount: 0, status: "success" });
+	});
+
+	it("reports an in-flight browser retry as running rather than failed", () => {
+		const output = normalizeAIThreadOrchestrationOutput({
+			status: "completed",
+			executionId: "execution-in-flight",
+			result: null,
+			calls: [
+				{ ...browserNavigation(1, "https://example.com/"), state: "error" },
+				{ ...browserNavigation(2, "https://example.com/"), state: "executing" },
+			],
+		});
+
+		expect(output.calls).toMatchObject([{ status: "running", state: "executing" }]);
+		expect(output.outcome.status).toBe("success");
+	});
+
 	it("removes the final result from the telemetry projection", () => {
 		const telemetry = getAIThreadOrchestrationTelemetryOutput({
 			status: "completed",
@@ -283,3 +348,15 @@ describe("AI thread orchestration", () => {
 		expect(JSON.stringify(telemetry)).not.toContain("not telemetry");
 	});
 });
+
+function browserNavigation(seq: number, url: string) {
+	return {
+		seq,
+		connector: "cdp",
+		method: "send",
+		state: "applied",
+		requiresApproval: false,
+		args: { method: "Page.navigate", params: { url } },
+		result: {},
+	};
+}

--- a/src/features/workspaces/ai/ai-thread-runtime.ts
+++ b/src/features/workspaces/ai/ai-thread-runtime.ts
@@ -30,6 +30,11 @@ import {
 	type resolveWorkspaceAiChatModelId,
 } from "#/features/workspaces/ai/models";
 import { createAIThreadCodeRunTools } from "#/features/workspaces/ai/code-run-tools";
+import {
+	AI_THREAD_BROWSER_GUIDANCE,
+	createAIThreadBrowserHandoffTool,
+	AI_THREAD_BROWSER_HANDOFF_TOOL_NAME,
+} from "#/features/workspaces/ai/ai-thread-browser";
 import { createAIThreadOrchestrationTool } from "#/features/workspaces/ai/ai-thread-orchestration";
 import { createAIThreadResearchTools } from "#/features/workspaces/ai/research-tools";
 import { createAIThreadTimeTools } from "#/features/workspaces/ai/time-tools";
@@ -95,6 +100,7 @@ export function createAIThreadTurnToolConfig(input: {
 	workspace: WorkspaceLike;
 	getThreadContext: () => Promise<AIThreadContext | null>;
 	canMutate: boolean;
+	onOrchestrationRuntime?: Parameters<typeof createAIThreadOrchestrationTool>[0]["onRuntime"];
 	onWorkspaceReferences?: (records: readonly WorkspaceReferenceRecord[]) => void;
 	timeZone?: string;
 }) {
@@ -103,16 +109,22 @@ export function createAIThreadTurnToolConfig(input: {
 	const state = workspaceFs ? createWorkspaceStateBackend(workspaceFs) : undefined;
 	const hasState = workspaceFs !== undefined;
 	const activeToolNames = toolCatalog.getActiveToolNames(input.canMutate);
+	const codemodeTools = {
+		...toolCatalog.getCodemodeTools(input.canMutate),
+		[AI_THREAD_BROWSER_HANDOFF_TOOL_NAME]: createAIThreadBrowserHandoffTool(),
+	} satisfies ToolSet;
 
 	return {
 		activeTools: activeToolNames,
 		tools: {
 			orchestrate: createAIThreadOrchestrationTool({
+				browser: input.env.BROWSER,
 				ctx: input.ctx,
 				loader: input.env.LOADER,
 				state,
-				tools: toolCatalog.getCodemodeTools(input.canMutate),
+				tools: codemodeTools,
 				name: AI_THREAD_ORCHESTRATE_TOOL_NAME,
+				onRuntime: input.onOrchestrationRuntime,
 				description: getAIThreadOrchestrateDescription(hasState),
 			}),
 		} satisfies ToolSet,
@@ -217,8 +229,8 @@ function getAIThreadOrchestrateDescription(hasState: boolean) {
 		? "3. Call the method shown by the docs, for example `await tools.workspace_list_items(args)` or `await state.readFile(args)`."
 		: "3. Call the method shown by the docs, for example `await tools.workspace_list_items(args)`.";
 	const globalsLine = hasState
-		? "- The only globals are `state`, `tools`, and `codemode` plus standard JavaScript. There is no `host`, `fs`, `require`, `process`, or Node.js API."
-		: "- The only globals are `tools` and `codemode` plus standard JavaScript. There is no `host`, `fs`, `require`, `process`, or Node.js API.";
+		? "- The only globals are `state`, `tools`, `cdp`, and `codemode` plus standard JavaScript. There is no `host`, `fs`, `require`, `process`, or Node.js API."
+		: "- The only globals are `tools`, `cdp`, and `codemode` plus standard JavaScript. There is no `host`, `fs`, `require`, `process`, or Node.js API.";
 
 	return [
 		"Orchestrate multi-step work by running JavaScript in a private assistant sandbox with access to ThinkEx connector SDKs.",
@@ -228,6 +240,7 @@ function getAIThreadOrchestrateDescription(hasState: boolean) {
 		stateLine,
 		"- `tools.*` exposes ThinkEx workspace reads and mutations plus web, research, and time operations.",
 		"- `tools.compute` executes private Python for calculations, data analysis, and charts.",
+		"- `cdp.*` controls one task-scoped browser session through the Chrome DevTools Protocol.",
 		"",
 		"## Workflow",
 		"",
@@ -243,10 +256,12 @@ function getAIThreadOrchestrateDescription(hasState: boolean) {
 		"- Use `codemode.step(name, fn)` for nondeterministic work outside connector calls.",
 		"- Some methods may require approval. If the run pauses, tell the user what is pending and wait. Do not re-issue the code.",
 		"- Keep non-connector logic deterministic so resume can replay it.",
+		...AI_THREAD_BROWSER_GUIDANCE.map((instruction) => `- ${instruction}`),
 		"- Do not use `fetch`. Use connector SDKs.",
 		"",
 		"## Snippets",
 		"",
+		'- Browser navigation: `const created = await cdp.send({ method: "Target.createTarget", params: { url } }); const { sessionId } = await cdp.attachToTarget({ targetId: created.targetId }); const page = await cdp.send({ method: "Runtime.evaluate", params: { expression: "({ readyState: document.readyState, title: document.title, url: location.href })", returnByValue: true }, sessionId });`',
 		'- `codemode.run("name", input)` runs a saved snippet.',
 		"- If a script may be reused later, write it as `async (input) => { ... }`.",
 	].join("\n");

--- a/src/features/workspaces/ai/ai-thread-runtime.ts
+++ b/src/features/workspaces/ai/ai-thread-runtime.ts
@@ -31,7 +31,7 @@ import {
 } from "#/features/workspaces/ai/models";
 import { createAIThreadCodeRunTools } from "#/features/workspaces/ai/code-run-tools";
 import {
-	AI_THREAD_BROWSER_GUIDANCE,
+	AI_THREAD_BROWSER_POLICY,
 	createAIThreadBrowserHandoffTool,
 	AI_THREAD_BROWSER_HANDOFF_TOOL_NAME,
 } from "#/features/workspaces/ai/ai-thread-browser";
@@ -256,7 +256,7 @@ function getAIThreadOrchestrateDescription(hasState: boolean) {
 		"- Use `codemode.step(name, fn)` for nondeterministic work outside connector calls.",
 		"- Some methods may require approval. If the run pauses, tell the user what is pending and wait. Do not re-issue the code.",
 		"- Keep non-connector logic deterministic so resume can replay it.",
-		...AI_THREAD_BROWSER_GUIDANCE.map((instruction) => `- ${instruction}`),
+		...AI_THREAD_BROWSER_POLICY.map((instruction) => `- ${instruction}`),
 		"- Do not use `fetch`. Use connector SDKs.",
 		"",
 		"## Snippets",

--- a/src/features/workspaces/ai/ai-thread-tool.ts
+++ b/src/features/workspaces/ai/ai-thread-tool.ts
@@ -1,5 +1,13 @@
 import type { FlexibleSchema, Tool, ToolExecutionOptions } from "ai";
 import { asSchema, tool } from "ai";
+import { z } from "zod";
+
+export const aiThreadActivityTitleSchema = z
+	.string()
+	.min(1)
+	.describe(
+		"What this run does in 3-6 words of plain present-tense English. Name the work, not code, tools, connectors, sandboxes, or APIs. Examples: “Rewriting the intro section”, “Finding sources to cite”, “Charting revenue by month”.",
+	);
 
 export interface AIThreadToolExecutionContext {
 	abortSignal?: AbortSignal;
@@ -41,6 +49,7 @@ type AIThreadToolDefinition<INPUT, OUTPUT> = Pick<
 		input: INPUT,
 		context: AIThreadToolExecutionContext,
 	): OUTPUT | PromiseLike<OUTPUT>;
+	modelInputSchema?: FlexibleSchema<unknown>;
 	outputSchema: FlexibleSchema<OUTPUT>;
 };
 
@@ -52,7 +61,11 @@ type AIThreadToolDefinition<INPUT, OUTPUT> = Pick<
 export function defineAIThreadTool<INPUT, OUTPUT>(
 	definition: AIThreadToolDefinition<INPUT, OUTPUT>,
 ): AIThreadTool<INPUT, OUTPUT> {
+	const modelDefinition = getModelToolDefinition(definition);
 	const inputSchema = asSchema(definition.inputSchema);
+	const modelInputSchema = definition.modelInputSchema
+		? asSchema(definition.modelInputSchema)
+		: inputSchema;
 	const outputSchema = asSchema(definition.outputSchema);
 	const executeDefinition = definition.execute;
 
@@ -81,7 +94,8 @@ export function defineAIThreadTool<INPUT, OUTPUT>(
 		},
 	};
 	const aiTool = tool<INPUT, OUTPUT, Record<string, unknown>>({
-		...definition,
+		...modelDefinition,
+		inputSchema: modelInputSchema,
 		execute: (input: INPUT, options: ToolExecutionOptions<unknown>) =>
 			runtime.execute(input, directExecutionContext(options)),
 	} as unknown as Tool<INPUT, OUTPUT, Record<string, unknown>>);
@@ -90,6 +104,20 @@ export function defineAIThreadTool<INPUT, OUTPUT>(
 		INPUT,
 		OUTPUT
 	>;
+}
+
+/**
+ * Providers only need a tool's input contract. Keep output schemas inside
+ * ThinkEx, where they validate execution results without entering a
+ * provider-specific JSON Schema dialect.
+ */
+export function getModelToolDefinition<
+	T extends { modelInputSchema?: unknown; outputSchema?: unknown },
+>(definition: T): Omit<T, "modelInputSchema" | "outputSchema"> {
+	const { modelInputSchema, outputSchema, ...modelDefinition } = definition;
+	void modelInputSchema;
+	void outputSchema;
+	return modelDefinition;
 }
 
 export function requireAIThreadToolRuntime(

--- a/src/features/workspaces/ai/ai-thread-tool.ts
+++ b/src/features/workspaces/ai/ai-thread-tool.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 export const aiThreadActivityTitleSchema = z
 	.string()
+	.trim()
 	.min(1)
 	.describe(
 		"What this run does in 3-6 words of plain present-tense English. Name the work, not code, tools, connectors, sandboxes, or APIs. Examples: “Rewriting the intro section”, “Finding sources to cite”, “Charting revenue by month”.",

--- a/src/features/workspaces/ai/ai-thread.ts
+++ b/src/features/workspaces/ai/ai-thread.ts
@@ -16,8 +16,17 @@ import type {
 	TurnContext,
 } from "@cloudflare/think";
 import { defaultContextOverflowClassifier, Think } from "@cloudflare/think";
+import { callable } from "agents";
 import { generateText, type LanguageModel, type ToolSet } from "ai";
 
+import {
+	createAIThreadBrowserConnector,
+	getAIThreadBrowserHandoff,
+	getAIThreadBrowserPresence,
+	getAIThreadBrowserLiveView,
+	type AIThreadBrowserLiveView,
+	type AIThreadBrowserState,
+} from "#/features/workspaces/ai/ai-thread-browser";
 import {
 	AI_THREAD_COMPACTION_SYSTEM_PROMPT,
 	createAIThreadCompactFunction,
@@ -163,6 +172,51 @@ export function createAIThreadClass(getUserAIStore: () => typeof UserAIStore) {
 			});
 		}
 
+		/**
+		 * Everything the chat's browser card polls for, in one call: the card
+		 * needs presence and handoff together to decide what it shows, and
+		 * narrowing the handoff here keeps every other pending action's raw
+		 * arguments off the wire.
+		 */
+		@callable()
+		async getBrowserState(): Promise<AIThreadBrowserState> {
+			const [handoff, presence] = await Promise.all([
+				this._getBrowserHandoff(),
+				getAIThreadBrowserPresence(this.ctx.storage),
+			]);
+			return { handoff, presence };
+		}
+
+		@callable()
+		async getBrowserLiveView(): Promise<AIThreadBrowserLiveView | null> {
+			return getAIThreadBrowserLiveView(this._browserConnector());
+		}
+
+		@callable()
+		async resolveBrowserHandoff(executionId: string, approved: boolean): Promise<void> {
+			await this._resolveBrowserHandoff(
+				executionId,
+				approved,
+				"The user could not complete the requested browser handoff.",
+			);
+		}
+
+		@callable()
+		async stopBrowserSession(executionId?: string): Promise<void> {
+			try {
+				if (executionId) {
+					const handoff = await this._getBrowserHandoff(executionId);
+					if (handoff) {
+						assertAIThreadExecutionResolved(
+							await super.rejectExecution(executionId, "Browser handoff was stopped by the user."),
+						);
+					}
+				}
+			} finally {
+				await this._browserConnector().closeSession();
+			}
+		}
+
 		async beforeTurn(ctx: TurnContext): Promise<TurnConfig | undefined> {
 			const directory = await this.parentAgent(getUserAIStore());
 			const thread = await directory.getThreadContext(this.name);
@@ -203,18 +257,10 @@ export function createAIThreadClass(getUserAIStore: () => typeof UserAIStore) {
 				timeZone: getBodyString(ctx.body, "timeZone"),
 				workspaceAiContext: ctx.body?.workspaceAiContext,
 			});
-			const turnToolConfig = createAIThreadTurnToolConfig({
-				env: this.env,
-				ctx: this.ctx,
-				threadId: this.name,
-				workspace: this.workspace,
-				getThreadContext: () => this._getThreadContext(),
-				canMutate: thread.promptScope.canMutate,
-				onWorkspaceReferences: (records) => {
-					this._recordWorkspaceReferences(records);
-				},
-				timeZone: getBodyString(ctx.body, "timeZone"),
-			});
+			const turnToolConfig = this._createTurnToolConfig(
+				thread,
+				getBodyString(ctx.body, "timeZone"),
+			);
 			const activeTools = filterToolSetByNames(
 				{ ...ctx.tools, ...turnToolConfig.tools },
 				turnToolConfig.activeTools,
@@ -270,12 +316,18 @@ export function createAIThreadClass(getUserAIStore: () => typeof UserAIStore) {
 				return;
 			}
 
+			if (result.status !== "completed") {
+				await this._cleanupBrowserSession(
+					result.status === "aborted" ? "turn_aborted" : "turn_failed",
+				);
+			}
 			await this._settleActiveRun({ kind: "finished", result });
 		}
 
 		override onChatError(error: unknown, ctx?: ChatErrorContext) {
 			this.telemetry.recordTurnError(error, ctx);
 			void this.keepAliveWhile(async () => {
+				await this._cleanupBrowserSession("turn_failed");
 				await this._settleActiveRun({
 					error,
 					errorClassification: ctx?.classification,
@@ -310,6 +362,77 @@ export function createAIThreadClass(getUserAIStore: () => typeof UserAIStore) {
 		private async _getThreadContext() {
 			const directory = await this.parentAgent(getUserAIStore());
 			return directory.getThreadContext(this.name);
+		}
+
+		private _createTurnToolConfig(thread: AIThreadContext, timeZone?: string) {
+			return createAIThreadTurnToolConfig({
+				env: this.env,
+				ctx: this.ctx,
+				threadId: this.name,
+				workspace: this.workspace,
+				getThreadContext: () => this._getThreadContext(),
+				canMutate: thread.promptScope.canMutate,
+				onOrchestrationRuntime: (runtime) => {
+					this.codemode = runtime;
+				},
+				onWorkspaceReferences: (records) => {
+					this._recordWorkspaceReferences(records);
+				},
+				timeZone,
+			});
+		}
+
+		private async _ensureOrchestrationRuntime() {
+			if (this.codemode) {
+				return;
+			}
+
+			const thread = await this._getThreadContext();
+			if (!thread) {
+				throw new Error("Chat thread not found");
+			}
+
+			this._createTurnToolConfig(thread);
+		}
+
+		private async _getBrowserHandoff(executionId?: string) {
+			await this._ensureOrchestrationRuntime();
+			return getAIThreadBrowserHandoff(await super.pendingExecutions(executionId));
+		}
+
+		private async _resolveBrowserHandoff(
+			executionId: string,
+			approved: boolean,
+			rejectionReason: string,
+		) {
+			const handoff = await this._getBrowserHandoff(executionId);
+			if (!handoff || handoff.executionId !== executionId) {
+				throw new Error("The browser handoff is no longer waiting for input.");
+			}
+
+			const result = approved
+				? await super.approveExecution(executionId)
+				: await super.rejectExecution(executionId, rejectionReason);
+			assertAIThreadExecutionResolved(result);
+		}
+
+		private _browserConnector() {
+			return createAIThreadBrowserConnector(this.ctx, this.env.BROWSER);
+		}
+
+		private async _cleanupBrowserSession(reason: "turn_aborted" | "turn_failed") {
+			try {
+				await this.stopBrowserSession();
+			} catch (error) {
+				recordOperationalFailure({
+					error,
+					event: "ai_browser_cleanup",
+					fields: {
+						reason,
+						thread_id: this.name,
+					},
+				});
+			}
 		}
 
 		private _shouldSettleRunAfterResponse(result: ChatResponseResult) {
@@ -584,6 +707,14 @@ export function createAIThreadClass(getUserAIStore: () => typeof UserAIStore) {
 			});
 		}
 	};
+}
+
+function assertAIThreadExecutionResolved(result: unknown) {
+	if (result && typeof result === "object" && "status" in result && result.status === "error") {
+		const message =
+			"error" in result && typeof result.error === "string" ? result.error : undefined;
+		throw new Error(message ?? "The browser handoff could not be resolved.");
+	}
 }
 
 function filterToolSetByNames(tools: ToolSet, activeToolNames: string[] | undefined): ToolSet {

--- a/src/features/workspaces/ai/ai-thread.ts
+++ b/src/features/workspaces/ai/ai-thread.ts
@@ -202,19 +202,8 @@ export function createAIThreadClass(getUserAIStore: () => typeof UserAIStore) {
 		}
 
 		@callable()
-		async stopBrowserSession(executionId?: string): Promise<void> {
-			try {
-				if (executionId) {
-					const handoff = await this._getBrowserHandoff(executionId);
-					if (handoff) {
-						assertAIThreadExecutionResolved(
-							await super.rejectExecution(executionId, "Browser handoff was stopped by the user."),
-						);
-					}
-				}
-			} finally {
-				await this._browserConnector().closeSession();
-			}
+		async stopBrowserSession(): Promise<void> {
+			await this._endBrowserSession("Browser handoff was stopped by the user.");
 		}
 
 		async beforeTurn(ctx: TurnContext): Promise<TurnConfig | undefined> {
@@ -420,9 +409,30 @@ export function createAIThreadClass(getUserAIStore: () => typeof UserAIStore) {
 			return createAIThreadBrowserConnector(this.ctx, this.env.BROWSER);
 		}
 
+		/**
+		 * Ending a session always resolves whatever handoff it parked. Leaving one
+		 * pending keeps the chat polling and offering "Done, continue" for a run
+		 * whose browser is already gone, and the agent is the only party that can
+		 * name the pending execution without racing its own poll.
+		 */
+		private async _endBrowserSession(rejectionReason: string) {
+			try {
+				const handoff = await this._getBrowserHandoff();
+				if (handoff) {
+					await this._resolveBrowserHandoff(handoff.executionId, false, rejectionReason);
+				}
+			} finally {
+				await this._browserConnector().closeSession();
+			}
+		}
+
 		private async _cleanupBrowserSession(reason: "turn_aborted" | "turn_failed") {
 			try {
-				await this.stopBrowserSession();
+				await this._endBrowserSession(
+					reason === "turn_aborted"
+						? "The run was stopped before the browser handoff could be completed."
+						: "The run failed before the browser handoff could be completed.",
+				);
 			} catch (error) {
 				recordOperationalFailure({
 					error,

--- a/src/features/workspaces/ai/ai-tool-registry.ts
+++ b/src/features/workspaces/ai/ai-tool-registry.ts
@@ -1,4 +1,4 @@
-export type AiToolActivityIconKind = "code" | "edit" | "file" | "search" | "web";
+export type AiToolActivityIconKind = "code" | "edit" | "file" | "search" | "web" | "work";
 export type AiToolAccess = "read" | "write";
 export type AiToolVisibility = "hidden" | "visible";
 
@@ -24,7 +24,9 @@ function defineAiToolRegistry<const TRegistry extends Record<string, AiToolDefin
 
 export const AI_TOOL_REGISTRY = defineAiToolRegistry({
 	sandbox_bash: readTool({ icon: "code", title: "Sandbox", visibility: "hidden" }, false),
-	orchestrate: readTool({ icon: "code", title: "Work through task" }, false),
+	orchestrate: readTool({ icon: "work", title: "Work through task" }, false),
+	browser_execute: readTool({ icon: "web", title: "Browse web" }, false),
+	browser_handoff: readTool({ icon: "web", title: "Browser handoff", visibility: "hidden" }),
 	compute: readTool({ icon: "code", title: "Run Python" }),
 	web_search: readTool({ icon: "search", title: "Search web" }),
 	web_markdown: readTool({ icon: "web", title: "Read webpage" }),

--- a/src/features/workspaces/ai/ai-tool-registry.ts
+++ b/src/features/workspaces/ai/ai-tool-registry.ts
@@ -9,6 +9,12 @@ export interface AiToolModelPolicy {
 
 interface AiToolDefinition {
 	model: AiToolModelPolicy;
+	/**
+	 * True when the entry exists only to label activity in the transcript and
+	 * has no tool factory behind it — `browser_execute` is the receipt for a
+	 * stretch of collapsed CDP traffic, not something the model can call.
+	 */
+	presentationOnly: boolean;
 	ui: {
 		icon: AiToolActivityIconKind;
 		title: string;
@@ -25,7 +31,7 @@ function defineAiToolRegistry<const TRegistry extends Record<string, AiToolDefin
 export const AI_TOOL_REGISTRY = defineAiToolRegistry({
 	sandbox_bash: readTool({ icon: "code", title: "Sandbox", visibility: "hidden" }, false),
 	orchestrate: readTool({ icon: "work", title: "Work through task" }, false),
-	browser_execute: readTool({ icon: "web", title: "Browse web" }, false),
+	browser_execute: activityTool({ icon: "web", title: "Browse web" }),
 	browser_handoff: readTool({ icon: "web", title: "Browser handoff", visibility: "hidden" }),
 	compute: readTool({ icon: "code", title: "Run Python" }),
 	web_search: readTool({ icon: "search", title: "Search web" }),
@@ -94,6 +100,11 @@ function readTool(ui: AiToolPresentationInput, codemode = true): AiToolDefinitio
 	return toolDefinition("read", codemode, ui);
 }
 
+/** A transcript label with no tool behind it. See `presentationOnly`. */
+function activityTool(ui: AiToolPresentationInput): AiToolDefinition {
+	return { ...toolDefinition("read", false, ui), presentationOnly: true };
+}
+
 function writeTool(ui: AiToolPresentationInput): AiToolDefinition {
 	// Code Mode's durable log is what makes a mutation safe to replay: an
 	// applied call returns its recorded result on resume instead of executing
@@ -109,6 +120,7 @@ function toolDefinition(
 ): AiToolDefinition {
 	return {
 		model: { access, codemode },
+		presentationOnly: false,
 		ui: {
 			icon: ui.icon,
 			title: ui.title,

--- a/src/features/workspaces/ai/code-run-tools.ts
+++ b/src/features/workspaces/ai/code-run-tools.ts
@@ -6,7 +6,10 @@ import {
 } from "@cloudflare/sandbox";
 import type { ToolSet } from "ai";
 import { z } from "zod";
-import { defineAIThreadTool } from "#/features/workspaces/ai/ai-thread-tool";
+import {
+	aiThreadActivityTitleSchema,
+	defineAIThreadTool,
+} from "#/features/workspaces/ai/ai-thread-tool";
 
 const COMPUTE_LANGUAGE = "python" as const;
 const COMPUTE_RUN_TIMEOUT_MS = 120_000;
@@ -19,6 +22,7 @@ const AI_THREAD_SANDBOX_OPTIONS = {
 } satisfies SandboxOptions;
 
 const codeRunInputSchema = z.object({
+	title: aiThreadActivityTitleSchema,
 	code: z.string().min(1).describe("Python code to execute in the private code sandbox."),
 });
 const codeRunErrorSchema = z.object({
@@ -57,11 +61,13 @@ const codeRunOutputSchema = z.object({
 const codeRunInputExamples = [
 	{
 		input: {
+			title: "Calculating the circle area",
 			code: "import math\nmath.pi * 5 ** 2",
 		},
 	},
 	{
 		input: {
+			title: "Plotting the growth curve",
 			code: "import matplotlib.pyplot as plt\nplt.plot([1, 2, 3], [1, 4, 9])\nplt.show()",
 		},
 	},

--- a/src/features/workspaces/ai/research-tools.ts
+++ b/src/features/workspaces/ai/research-tools.ts
@@ -37,6 +37,19 @@ const researchDeepenInputSchema = z.discriminatedUnion("mode", [
 	}),
 ]);
 
+/** Gemini requires custom-tool parameters to be a top-level object. */
+const researchDeepenModelInputSchema = z.object({
+	mode: z.enum(["passages", "related"]),
+	paper_id: z.string().trim().min(1).describe("Paper identifier."),
+	question: z.string().trim().min(1).optional().describe("Required for passage retrieval."),
+	relation: z
+		.enum(["similar", "citers", "references"])
+		.optional()
+		.describe("Required for related work."),
+	intent: z.string().trim().min(1).optional().describe("Required for related work."),
+	limit: z.number().int().min(1).max(50).optional().describe("Maximum results to return."),
+});
+
 const researchDiscoverInputExamples = [
 	{
 		input: {
@@ -72,6 +85,7 @@ export function createAIThreadResearchTools(env: Cloudflare.Env): ToolSet {
 		research_deepen: defineAIThreadTool({
 			description: "Go deeper on one paper by reading relevant passages or finding related work.",
 			inputSchema: zodSchema(researchDeepenInputSchema),
+			modelInputSchema: researchDeepenModelInputSchema,
 			outputSchema: researchDeepenResultSchema,
 			strict: true,
 			execute: async (input: z.infer<typeof researchDeepenInputSchema>) => {

--- a/src/features/workspaces/components/ai-chat/AiChatBrowserSessionCard.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatBrowserSessionCard.tsx
@@ -1,0 +1,444 @@
+import { useQuery } from "@tanstack/react-query";
+import { Check, LoaderCircle, Square, X } from "lucide-react";
+import { useState } from "react";
+
+import {
+	CodeBlockActions,
+	CodeBlockHeader,
+	CodeBlockTitle,
+} from "#/components/code-block/code-block-chrome";
+import { Button } from "#/components/ui/button";
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogTitle,
+} from "#/components/ui/dialog";
+import type { AIThreadBrowserLiveViewTarget } from "#/features/workspaces/ai/ai-thread-browser";
+import type { AiChatBrowserSessionController } from "#/features/workspaces/components/ai-chat/useWorkspaceAiBrowserSession";
+
+const LIVE_VIEW_RETRY_MS = 15_000;
+const LIVE_VIEW_MIN_REFRESH_MS = 30_000;
+const LIVE_VIEW_FALLBACK_REFRESH_MS = 4 * 60 * 1000;
+
+interface AiChatBrowserLiveViewState {
+	error?: string;
+	isFetching: boolean;
+	refresh: () => void;
+	targets: AIThreadBrowserLiveViewTarget[];
+}
+
+export function AiChatBrowserSessionCard({
+	browser,
+	isChatBusy,
+	onStop,
+}: {
+	browser: AiChatBrowserSessionController;
+	isChatBusy: boolean;
+	onStop: () => void;
+}) {
+	const [open, setOpen] = useState(false);
+	const isWaitingForUser = Boolean(browser.handoff);
+	const liveViewQuery = useQuery({
+		queryFn: browser.getLiveView,
+		queryKey: ["workspace-ai-browser-live-view", browser.sessionKey],
+		// Every fetch mints fresh signed Live View URLs, so a refresh swaps the
+		// iframe's src and reloads it — wiping out whatever the person was in the
+		// middle of typing. Refreshes stop while the view is open or a handoff is
+		// waiting on them; an already-open Live View keeps streaming past the
+		// URL's expiry, which only gates opening it in the first place.
+		refetchInterval: (query) => {
+			if (open) {
+				return false;
+			}
+
+			const data = query.state.data;
+			const hasTarget = Boolean(data?.targets.length);
+			if (isWaitingForUser && hasTarget) {
+				return false;
+			}
+
+			return hasTarget ? getLiveViewRefreshMs(data?.expiresInMs) : LIVE_VIEW_RETRY_MS;
+		},
+		refetchOnWindowFocus: false,
+		retry: false,
+		staleTime: Number.POSITIVE_INFINITY,
+	});
+	const liveView: AiChatBrowserLiveViewState = {
+		error: getLiveViewErrorMessage(liveViewQuery.error),
+		isFetching: liveViewQuery.isFetching,
+		refresh: () => {
+			void liveViewQuery.refetch();
+		},
+		targets: liveViewQuery.data?.targets ?? [],
+	};
+	const liveTarget = getPreferredTarget(liveView.targets);
+	const isConnecting = liveView.isFetching && !liveTarget;
+	const copy = getBrowserCardCopy({
+		handoffInstructions: browser.handoff?.instructions,
+		hasLiveTarget: Boolean(liveTarget),
+		isChatBusy,
+		isConnecting,
+	});
+
+	if (!isChatBusy && !isWaitingForUser && liveViewQuery.isSuccess && !liveTarget) {
+		return null;
+	}
+
+	return (
+		<>
+			<div className="w-full max-w-xl overflow-hidden rounded-xl border bg-card shadow-xs">
+				<div className="flex items-center">
+					<button
+						type="button"
+						className="flex min-w-0 flex-1 items-center gap-2 px-3 py-2.5 text-left outline-none transition-colors hover:bg-muted/30 focus-visible:bg-muted/30"
+						disabled={isConnecting}
+						aria-label={
+							isWaitingForUser
+								? "Take control of browser"
+								: liveTarget
+									? "Open browser live view"
+									: "Check browser connection"
+						}
+						onClick={() => {
+							setOpen(true);
+							if (!liveTarget) {
+								liveView.refresh();
+							}
+						}}
+					>
+						<p className="min-w-0 truncate text-sm">
+							<span className="font-medium">{copy.title}</span>
+							<span className="text-muted-foreground"> · {copy.description}</span>
+						</p>
+						{(isConnecting || (isChatBusy && liveTarget)) && !isWaitingForUser ? (
+							<LoaderCircle
+								className="size-3.5 shrink-0 animate-spin text-muted-foreground"
+								aria-hidden="true"
+							/>
+						) : null}
+					</button>
+					<Button
+						type="button"
+						variant="ghost"
+						size="icon-xs"
+						className="mr-2 text-muted-foreground"
+						disabled={browser.isActing}
+						aria-label="Stop browser"
+						title="Stop browser"
+						onClick={onStop}
+					>
+						<Square className="size-3 fill-current" aria-hidden="true" />
+					</Button>
+				</div>
+				{liveTarget && !open ? (
+					<div className="relative h-40 w-full overflow-hidden border-t bg-muted/20">
+						<BrowserLiveViewFrame interactive={false} target={liveTarget} />
+						<button
+							type="button"
+							className="absolute inset-0 outline-none transition-colors hover:bg-muted/10 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/50"
+							aria-label="Expand browser live view"
+							onClick={() => setOpen(true)}
+						/>
+					</div>
+				) : null}
+				{browser.actionError ? (
+					<p className="border-t bg-destructive/5 px-3 py-2 text-destructive text-xs">
+						{browser.actionError}
+					</p>
+				) : null}
+			</div>
+
+			<AiChatBrowserLiveViewDialog
+				browser={browser}
+				liveView={liveView}
+				open={open}
+				onOpenChange={setOpen}
+				onStop={() => {
+					setOpen(false);
+					onStop();
+				}}
+			/>
+		</>
+	);
+}
+
+function AiChatBrowserLiveViewDialog({
+	browser,
+	liveView,
+	onOpenChange,
+	onStop,
+	open,
+}: {
+	browser: AiChatBrowserSessionController;
+	liveView: AiChatBrowserLiveViewState;
+	onOpenChange: (open: boolean) => void;
+	onStop: () => void;
+	open: boolean;
+}) {
+	const [selectedTargetId, setSelectedTargetId] = useState<string>();
+	const { targets } = liveView;
+	const selectedTarget =
+		targets.find((target) => target.id === selectedTargetId) ?? getPreferredTarget(targets);
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent
+				className="fixed inset-0 top-0 left-0 flex h-dvh w-dvw max-w-none translate-x-0 translate-y-0 flex-col gap-0 rounded-none border-0 bg-background p-0 sm:max-w-none"
+				showCloseButton={false}
+			>
+				<CodeBlockHeader className="min-h-14 shrink-0 bg-background px-3 sm:px-4">
+					<CodeBlockTitle className="min-w-0">
+						<div className="min-w-0">
+							<DialogTitle className="truncate text-sm leading-5">Browser live view</DialogTitle>
+							<DialogDescription className="truncate text-xs leading-4">
+								{browser.handoff?.instructions ??
+									getBrowserTargetLabel(selectedTarget) ??
+									"Interactive task browser"}
+							</DialogDescription>
+						</div>
+					</CodeBlockTitle>
+					<CodeBlockActions>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							className="text-muted-foreground"
+							disabled={browser.isActing}
+							onClick={onStop}
+						>
+							<Square className="size-3 fill-current" aria-hidden="true" />
+							<span className="hidden sm:inline">Stop browser</span>
+						</Button>
+						<span className="mx-0.5 h-4 w-px bg-border" aria-hidden="true" />
+						<DialogClose
+							render={
+								<Button type="button" variant="ghost" size="icon-sm" aria-label="Close live view" />
+							}
+						>
+							<X className="size-4" aria-hidden="true" />
+						</DialogClose>
+					</CodeBlockActions>
+				</CodeBlockHeader>
+
+				{targets.length > 1 ? (
+					<div
+						className="flex shrink-0 gap-1 overflow-x-auto border-b bg-muted/30 px-3 py-1.5"
+						role="group"
+						aria-label="Browser tabs"
+					>
+						{targets.map((target, index) => (
+							<Button
+								key={target.id}
+								type="button"
+								variant={target.id === selectedTarget?.id ? "secondary" : "ghost"}
+								size="xs"
+								className="max-w-48 shrink-0"
+								aria-pressed={target.id === selectedTarget?.id}
+								onClick={() => setSelectedTargetId(target.id)}
+							>
+								<span className="truncate">
+									{getBrowserTargetLabel(target) ?? `Tab ${index + 1}`}
+								</span>
+							</Button>
+						))}
+					</div>
+				) : null}
+
+				<div className="relative min-h-0 flex-1 bg-muted/20">
+					{selectedTarget ? (
+						<BrowserLiveViewFrame
+							key={selectedTarget.liveViewUrl}
+							interactive
+							target={selectedTarget}
+						/>
+					) : (
+						<LiveViewPlaceholder liveView={liveView} />
+					)}
+				</div>
+
+				{browser.handoff ? (
+					<div className="flex min-h-14 items-center justify-between gap-3 border-t bg-background px-3 py-2.5 sm:px-4">
+						<p className="min-w-0 truncate text-muted-foreground text-xs">
+							Complete the step above, then return control to the agent.
+						</p>
+						<div className="flex shrink-0 items-center gap-2">
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								className="gap-1.5"
+								disabled={browser.isActing}
+								onClick={() => {
+									void browser.resolveHandoff(false).catch(() => undefined);
+								}}
+							>
+								<X className="size-3.5" aria-hidden="true" />
+								Couldn’t finish
+							</Button>
+							<Button
+								type="button"
+								size="sm"
+								className="gap-1.5"
+								disabled={browser.isActing}
+								onClick={() => {
+									void browser.resolveHandoff(true).catch(() => undefined);
+								}}
+							>
+								<Check className="size-3.5" aria-hidden="true" />
+								Done, continue
+							</Button>
+						</div>
+					</div>
+				) : null}
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function LiveViewPlaceholder({ liveView }: { liveView: AiChatBrowserLiveViewState }) {
+	if (liveView.isFetching) {
+		return (
+			<div className="grid size-full place-items-center p-6 text-center">
+				<div>
+					<LoaderCircle
+						className="mx-auto size-5 animate-spin text-muted-foreground"
+						aria-hidden="true"
+					/>
+					<p className="mt-3 font-medium text-sm">Connecting to the browser…</p>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="grid size-full place-items-center p-6 text-center">
+			<div className="max-w-sm">
+				{liveView.error ? (
+					<X className="mx-auto mb-3 size-5 text-destructive" aria-hidden="true" />
+				) : null}
+				<p className="font-medium text-sm">
+					{liveView.error ? "Couldn’t open the live view" : "No browser tab yet"}
+				</p>
+				<p className="mt-1 text-muted-foreground text-xs">
+					{liveView.error ?? "The agent may still be opening a page."}
+				</p>
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					className="mt-3"
+					onClick={liveView.refresh}
+				>
+					{liveView.error ? "Try again" : "Refresh"}
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+function BrowserLiveViewFrame({
+	interactive,
+	target,
+}: {
+	interactive: boolean;
+	target: AIThreadBrowserLiveViewTarget;
+}) {
+	return (
+		<iframe
+			src={target.liveViewUrl}
+			title={`${interactive ? "Browser Live View" : "Browser preview"} — ${getBrowserTargetLabel(target) ?? "active tab"}`}
+			className={
+				interactive
+					? "size-full border-0 bg-background"
+					: "pointer-events-none size-full border-0 bg-background"
+			}
+			allow="clipboard-read; clipboard-write"
+			referrerPolicy="no-referrer"
+			tabIndex={interactive ? undefined : -1}
+		/>
+	);
+}
+
+function getBrowserCardCopy(input: {
+	handoffInstructions?: string;
+	hasLiveTarget: boolean;
+	isChatBusy: boolean;
+	isConnecting: boolean;
+}) {
+	if (input.handoffInstructions) {
+		return { title: "Browser needs you", description: input.handoffInstructions };
+	}
+	if (input.hasLiveTarget) {
+		return input.isChatBusy
+			? {
+					title: "Browser is running",
+					description: "Watch or take control while the agent works.",
+				}
+			: {
+					title: "Browser is ready",
+					description: "The interactive browser is still open.",
+				};
+	}
+	if (input.isConnecting) {
+		return {
+			title: "Connecting to browser",
+			description: "Connecting to the interactive browser.",
+		};
+	}
+	return {
+		title: "Browser unavailable",
+		description: "The live session could not be reached.",
+	};
+}
+
+/**
+ * Refresh comfortably inside the URL's own lifetime rather than on a guessed
+ * cadence — Browser Run mints Live View URLs with a ~5 minute default TTL and
+ * reports it as `expiresInMs`.
+ */
+function getLiveViewRefreshMs(expiresInMs: number | undefined) {
+	if (!expiresInMs || expiresInMs <= 0) {
+		return LIVE_VIEW_FALLBACK_REFRESH_MS;
+	}
+
+	return Math.max(LIVE_VIEW_MIN_REFRESH_MS, Math.round(expiresInMs * 0.8));
+}
+
+function getLiveViewErrorMessage(error: unknown) {
+	if (!error) {
+		return undefined;
+	}
+
+	return error instanceof Error ? error.message : "Live View could not be opened.";
+}
+
+function getPreferredTarget<T extends AIThreadBrowserLiveViewTarget>(targets: T[]): T | undefined {
+	for (let index = targets.length - 1; index >= 0; index -= 1) {
+		const target = targets[index];
+		if (target?.url) {
+			return target;
+		}
+	}
+
+	return targets.at(-1);
+}
+
+function getBrowserTargetLabel(target: AIThreadBrowserLiveViewTarget | undefined) {
+	if (!target) {
+		return undefined;
+	}
+	if (target.title && target.title !== target.url) {
+		return target.title;
+	}
+	if (!target.url) {
+		return undefined;
+	}
+
+	try {
+		return new URL(target.url).hostname;
+	} catch {
+		return target.url;
+	}
+}

--- a/src/features/workspaces/components/ai-chat/AiChatBrowserSessionCard.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatBrowserSessionCard.tsx
@@ -44,18 +44,17 @@ export function AiChatBrowserSessionCard({
 		queryFn: browser.getLiveView,
 		queryKey: ["workspace-ai-browser-live-view", browser.sessionKey],
 		// Every fetch mints fresh signed Live View URLs, so a refresh swaps the
-		// iframe's src and reloads it — wiping out whatever the person was in the
-		// middle of typing. Refreshes stop while the view is open or a handoff is
-		// waiting on them; an already-open Live View keeps streaming past the
-		// URL's expiry, which only gates opening it in the first place.
+		// iframe's src and reloads it. That only costs something once someone is
+		// interacting: refreshes stop when the expanded view is showing a live
+		// tab, and nowhere else. The closed card's preview is non-interactive, so
+		// reloading it wipes out nothing, and a handoff that outlives the URL's
+		// expiry still has a working link when the person finally opens it. An
+		// already-open Live View keeps streaming past the expiry, which only
+		// gates opening the URL in the first place.
 		refetchInterval: (query) => {
-			if (open) {
-				return false;
-			}
-
 			const data = query.state.data;
 			const hasTarget = Boolean(data?.targets.length);
-			if (isWaitingForUser && hasTarget) {
+			if (open && hasTarget) {
 				return false;
 			}
 

--- a/src/features/workspaces/components/ai-chat/AiChatMessageList.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatMessageList.tsx
@@ -17,6 +17,7 @@ import {
 } from "#/components/ui/message-scroller";
 import { Message, MessageContent } from "#/components/ui/message";
 import { AiChatAssistantPending } from "#/features/workspaces/components/ai-chat/AiChatAssistantPending";
+import { AiChatBrowserSessionCard } from "#/features/workspaces/components/ai-chat/AiChatBrowserSessionCard";
 import {
 	aiChatMessageScrollerButtonClassName,
 	aiChatMessageScrollerContentClassName,
@@ -31,6 +32,7 @@ import {
 	isAiChatStreamActive,
 } from "#/features/workspaces/components/ai-chat/ai-chat-display-state";
 import type { AiChatMessage } from "#/features/workspaces/components/ai-chat/types";
+import type { AiChatBrowserSessionController } from "#/features/workspaces/components/ai-chat/useWorkspaceAiBrowserSession";
 import { WorkspaceFloatingAskSelectionMenu } from "#/features/workspaces/components/WorkspaceFloatingAskSelectionMenu";
 import { stageComposerQuote } from "#/features/workspaces/composer/workspace-composer-actions";
 import { createAssistantResponseSelectedQuote } from "#/features/workspaces/model/workspace-selected-quotes";
@@ -91,8 +93,10 @@ type AiChatListRow =
 
 interface AiChatMessageListProps {
 	assistantError?: AiChatAssistantErrorState | null;
+	browser: AiChatBrowserSessionController;
 	messages: AiChatMessage[];
 	onRegenerateLastResponse?: () => void;
+	onStopBrowser: () => void;
 	presentation: AiChatPresentation;
 	sentMessageAnimationId?: string | null;
 	workspaceId: string;
@@ -100,8 +104,10 @@ interface AiChatMessageListProps {
 
 export default function AiChatMessageList({
 	assistantError,
+	browser,
 	messages,
 	onRegenerateLastResponse,
+	onStopBrowser,
 	presentation,
 	sentMessageAnimationId,
 	workspaceId,
@@ -171,6 +177,26 @@ export default function AiChatMessageList({
 										/>
 									</AiChatMessageScrollerItem>
 								))}
+								{browser.hasSession || browser.handoff ? (
+									<AiChatMessageScrollerItem
+										enableLayoutMotion={!shouldReduceMotion}
+										entryAnimation={shouldReduceMotion ? null : "tail"}
+										messageId="browser-session"
+										scrollAnchor={false}
+									>
+										<AiChatTranscriptRail>
+											<Message>
+												<MessageContent>
+													<AiChatBrowserSessionCard
+														browser={browser}
+														isChatBusy={presentation.isBusy}
+														onStop={onStopBrowser}
+													/>
+												</MessageContent>
+											</Message>
+										</AiChatTranscriptRail>
+									</AiChatMessageScrollerItem>
+								) : null}
 							</LazyMotion>
 						</MessageScrollerContent>
 					</MessageScrollerViewport>

--- a/src/features/workspaces/components/ai-chat/AiChatMessagePartView.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatMessagePartView.tsx
@@ -45,7 +45,7 @@ export function AiChatMessagePartView({
 	}
 
 	if (isAiChatToolGroupPart(part)) {
-		return <AiChatToolActivityRow attempts={part.attempts} part={part.part} />;
+		return <AiChatToolActivityRow nestedChildren={part.children} part={part.part} />;
 	}
 
 	if (isToolUIPart(part)) {

--- a/src/features/workspaces/components/ai-chat/AiChatMessagePartView.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatMessagePartView.tsx
@@ -9,7 +9,10 @@ import {
 	getFileAttachmentData,
 	getSourceDocumentAttachmentData,
 } from "#/features/workspaces/components/ai-chat/ai-chat-attachments";
-import type { AiChatToolGroupPart } from "#/features/workspaces/components/ai-chat/ai-chat-display-state";
+import {
+	type AiChatToolGroupPart,
+	isAiChatToolGroupPart,
+} from "#/features/workspaces/components/ai-chat/ai-chat-display-state";
 import { AiChatMessageResponse } from "#/features/workspaces/components/ai-chat/AiChatMessageResponse";
 import { AiChatToolActivityRow } from "#/features/workspaces/components/ai-chat/AiChatToolActivityRow";
 import type { AiChatMessagePart } from "#/features/workspaces/components/ai-chat/types";
@@ -42,7 +45,7 @@ export function AiChatMessagePartView({
 	}
 
 	if (isAiChatToolGroupPart(part)) {
-		return <AiChatToolActivityRow part={part.part} nestedChildren={part.children} />;
+		return <AiChatToolActivityRow attempts={part.attempts} part={part.part} />;
 	}
 
 	if (isToolUIPart(part)) {
@@ -84,10 +87,4 @@ export function AiChatMessagePartView({
 	}
 
 	return null;
-}
-
-function isAiChatToolGroupPart(
-	part: AiChatMessagePart | AiChatToolGroupPart,
-): part is AiChatToolGroupPart {
-	return part.type === "data-tool-group" && "part" in part && "children" in part;
 }

--- a/src/features/workspaces/components/ai-chat/AiChatThreadView.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatThreadView.tsx
@@ -37,6 +37,7 @@ export default function AiChatThreadView({
 	const chat = useWorkspaceAiChat({ modelId, threadId });
 	const [sentMessageAnimationId, setSentMessageAnimationId] = useState<string | null>(null);
 	const {
+		browser,
 		connectionError,
 		inputStatus,
 		messages,
@@ -65,6 +66,12 @@ export default function AiChatThreadView({
 		inputStatus,
 		threadSummary,
 	});
+	const stopChatAndBrowser = () => {
+		void stop();
+		if (browser.hasSession || browser.handoff) {
+			void browser.stopBrowser().catch(() => undefined);
+		}
+	};
 
 	const sendMessage = (message: PromptInputMessage) => {
 		const chatMessage = getChatMessageFromPrompt(message, generateId());
@@ -91,11 +98,13 @@ export default function AiChatThreadView({
 		<div className="relative flex min-h-0 flex-1 flex-col">
 			<AiChatMessageList
 				assistantError={assistantError}
+				browser={browser}
 				messages={messages}
 				presentation={presentation}
 				sentMessageAnimationId={sentMessageAnimationId}
 				workspaceId={context.workspaceId}
 				onRegenerateLastResponse={regenerate}
+				onStopBrowser={stopChatAndBrowser}
 			/>
 
 			<div className="px-3 pb-3">
@@ -109,7 +118,7 @@ export default function AiChatThreadView({
 						onModelChange={onModelChange}
 						onSubmit={sendMessage}
 						onStop={() => {
-							void stop();
+							stopChatAndBrowser();
 						}}
 					/>
 				</div>

--- a/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
@@ -25,7 +25,6 @@ import {
 import {
 	getToolActivityForPart,
 	type AiChatToolActivity,
-	type AiChatToolAttempt,
 } from "#/features/workspaces/components/ai-chat/ai-chat-display-state";
 import type { AiChatToolChildActivity } from "#/features/workspaces/components/ai-chat/ai-chat-codemode-activity";
 import type { AiChatToolReceiptSegment } from "#/features/workspaces/components/ai-chat/ai-chat-tool-receipts";
@@ -42,10 +41,10 @@ const DETAIL_SOURCE_LIMIT = 8;
 const EMPTY_TOOL_CHILDREN: AiChatToolChildActivity[] = [];
 
 export function AiChatToolActivityRow({
-	attempts,
+	nestedChildren = EMPTY_TOOL_CHILDREN,
 	part,
 }: {
-	attempts?: AiChatToolAttempt[];
+	nestedChildren?: AiChatToolChildActivity[];
 	part: AiChatToolPart;
 }) {
 	const shouldReduceMotion = useReducedMotion();
@@ -55,17 +54,6 @@ export function AiChatToolActivityRow({
 		return null;
 	}
 
-	if (attempts && attempts.length > 1) {
-		return (
-			<ToolActivityMotion disabled={shouldReduceMotion}>
-				<ToolAttemptGroup attempts={attempts} activity={activity} />
-			</ToolActivityMotion>
-		);
-	}
-
-	// A single attempt renders as an ordinary row whose trail is that attempt's
-	// activity; a plain tool part has no attempts and no trail.
-	const nestedChildren = attempts?.at(-1)?.children ?? EMPTY_TOOL_CHILDREN;
 	const details = getActivityDetails(activity);
 	const inlineContent = getInlineActivityContent(activity);
 	const sourcePreviews = getToolSourcePreviews(activity);
@@ -131,73 +119,6 @@ function ToolActivityMotion({
 	);
 }
 
-function ToolAttemptGroup({
-	activity,
-	attempts,
-}: {
-	activity: AiChatToolActivity;
-	attempts: AiChatToolAttempt[];
-}) {
-	return (
-		<Collapsible className="group/attempts w-full max-w-xl">
-			<CollapsibleTrigger className="inline-flex max-w-full items-center gap-1.5 text-left">
-				<ActivitySummary activity={activity} showCompletedStatus={false} sourcePreviews={[]} />
-				<ChevronDown
-					className="size-3.5 shrink-0 text-muted-foreground/70 transition-transform group-data-[panel-open]/attempts:rotate-180"
-					aria-hidden="true"
-				/>
-			</CollapsibleTrigger>
-			<CollapsibleContent className="mt-1 w-full space-y-0.5 px-0.5">
-				{attempts.map((attempt) => (
-					<ToolAttemptRow key={attempt.part.toolCallId} attempt={attempt} />
-				))}
-			</CollapsibleContent>
-		</Collapsible>
-	);
-}
-
-function ToolAttemptRow({ attempt }: { attempt: AiChatToolAttempt }) {
-	const activity = getToolActivityForPart(attempt.part);
-
-	if (!activity) {
-		return null;
-	}
-
-	const hasChildren = attempt.children.length > 0;
-	const row = (
-		<div
-			className={cn(
-				"flex min-w-0 items-center rounded-md px-1 py-1.5",
-				hasChildren && "transition-colors hover:bg-muted/25",
-			)}
-		>
-			<ActivitySummary
-				activity={activity}
-				canExpand={hasChildren}
-				showCompletedStatus={false}
-				sourcePreviews={[]}
-			/>
-		</div>
-	);
-
-	if (!hasChildren) {
-		return row;
-	}
-
-	return (
-		<Collapsible className="group/collapsible">
-			<CollapsibleTrigger className="block w-full text-left">{row}</CollapsibleTrigger>
-			<CollapsibleContent className="ml-3 border-border/60 border-l py-1 pl-2">
-				<div className="space-y-0.5">
-					{attempt.children.map((child) => (
-						<ActivitySummary key={child.id} activity={child} sourcePreviews={[]} />
-					))}
-				</div>
-			</CollapsibleContent>
-		</Collapsible>
-	);
-}
-
 function getInlineActivityContent(activity: AiChatToolActivity) {
 	if (activity.toolName !== "compute" || activity.status === "running") {
 		return null;
@@ -217,7 +138,6 @@ function getActivityDetails(activity: AiChatToolActivity) {
 function ActivitySummary({
 	activity,
 	canExpand = false,
-	showCompletedStatus = true,
 	sourcePreviews,
 }: {
 	activity: {
@@ -227,7 +147,6 @@ function ActivitySummary({
 		segments?: AiChatToolReceiptSegment[];
 	};
 	canExpand?: boolean;
-	showCompletedStatus?: boolean;
 	sourcePreviews: ToolSourcePreview[];
 }) {
 	const isRunning = activity.status === "running";
@@ -249,9 +168,7 @@ function ActivitySummary({
 				isRunning={isRunning}
 			/>
 			<InlineSourceFavicons sources={sourcePreviews.slice(0, INLINE_SOURCE_LIMIT)} />
-			{showCompletedStatus || activity.status !== "completed" ? (
-				<ToolStatusIcon status={activity.status} />
-			) : null}
+			<ToolStatusIcon status={activity.status} />
 			{canExpand ? (
 				<ChevronDown
 					className="size-3.5 shrink-0 self-center text-muted-foreground/70 transition-transform group-data-[panel-open]/collapsible:rotate-180"

--- a/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
@@ -8,6 +8,7 @@ import {
 	LoaderCircle,
 	PencilLine,
 	Search,
+	Wrench,
 } from "lucide-react";
 import { LazyMotion, domAnimation, m, useReducedMotion } from "motion/react";
 import type { ReactNode } from "react";
@@ -24,6 +25,7 @@ import {
 import {
 	getToolActivityForPart,
 	type AiChatToolActivity,
+	type AiChatToolAttempt,
 } from "#/features/workspaces/components/ai-chat/ai-chat-display-state";
 import type { AiChatToolChildActivity } from "#/features/workspaces/components/ai-chat/ai-chat-codemode-activity";
 import type { AiChatToolReceiptSegment } from "#/features/workspaces/components/ai-chat/ai-chat-tool-receipts";
@@ -40,11 +42,11 @@ const DETAIL_SOURCE_LIMIT = 8;
 const EMPTY_TOOL_CHILDREN: AiChatToolChildActivity[] = [];
 
 export function AiChatToolActivityRow({
+	attempts,
 	part,
-	nestedChildren = EMPTY_TOOL_CHILDREN,
 }: {
+	attempts?: AiChatToolAttempt[];
 	part: AiChatToolPart;
-	nestedChildren?: AiChatToolChildActivity[];
 }) {
 	const shouldReduceMotion = useReducedMotion();
 	const activity = getToolActivityForPart(part);
@@ -53,6 +55,17 @@ export function AiChatToolActivityRow({
 		return null;
 	}
 
+	if (attempts && attempts.length > 1) {
+		return (
+			<ToolActivityMotion disabled={shouldReduceMotion}>
+				<ToolAttemptGroup attempts={attempts} activity={activity} />
+			</ToolActivityMotion>
+		);
+	}
+
+	// A single attempt renders as an ordinary row whose trail is that attempt's
+	// activity; a plain tool part has no attempts and no trail.
+	const nestedChildren = attempts?.at(-1)?.children ?? EMPTY_TOOL_CHILDREN;
 	const details = getActivityDetails(activity);
 	const inlineContent = getInlineActivityContent(activity);
 	const sourcePreviews = getToolSourcePreviews(activity);
@@ -91,6 +104,7 @@ export function AiChatToolActivityRow({
 
 	return <ToolActivityMotion disabled={shouldReduceMotion}>{content}</ToolActivityMotion>;
 }
+
 function ToolActivityMotion({
 	children,
 	disabled,
@@ -117,6 +131,73 @@ function ToolActivityMotion({
 	);
 }
 
+function ToolAttemptGroup({
+	activity,
+	attempts,
+}: {
+	activity: AiChatToolActivity;
+	attempts: AiChatToolAttempt[];
+}) {
+	return (
+		<Collapsible className="group/attempts w-full max-w-xl">
+			<CollapsibleTrigger className="inline-flex max-w-full items-center gap-1.5 text-left">
+				<ActivitySummary activity={activity} showCompletedStatus={false} sourcePreviews={[]} />
+				<ChevronDown
+					className="size-3.5 shrink-0 text-muted-foreground/70 transition-transform group-data-[panel-open]/attempts:rotate-180"
+					aria-hidden="true"
+				/>
+			</CollapsibleTrigger>
+			<CollapsibleContent className="mt-1 w-full space-y-0.5 px-0.5">
+				{attempts.map((attempt) => (
+					<ToolAttemptRow key={attempt.part.toolCallId} attempt={attempt} />
+				))}
+			</CollapsibleContent>
+		</Collapsible>
+	);
+}
+
+function ToolAttemptRow({ attempt }: { attempt: AiChatToolAttempt }) {
+	const activity = getToolActivityForPart(attempt.part);
+
+	if (!activity) {
+		return null;
+	}
+
+	const hasChildren = attempt.children.length > 0;
+	const row = (
+		<div
+			className={cn(
+				"flex min-w-0 items-center rounded-md px-1 py-1.5",
+				hasChildren && "transition-colors hover:bg-muted/25",
+			)}
+		>
+			<ActivitySummary
+				activity={activity}
+				canExpand={hasChildren}
+				showCompletedStatus={false}
+				sourcePreviews={[]}
+			/>
+		</div>
+	);
+
+	if (!hasChildren) {
+		return row;
+	}
+
+	return (
+		<Collapsible className="group/collapsible">
+			<CollapsibleTrigger className="block w-full text-left">{row}</CollapsibleTrigger>
+			<CollapsibleContent className="ml-3 border-border/60 border-l py-1 pl-2">
+				<div className="space-y-0.5">
+					{attempt.children.map((child) => (
+						<ActivitySummary key={child.id} activity={child} sourcePreviews={[]} />
+					))}
+				</div>
+			</CollapsibleContent>
+		</Collapsible>
+	);
+}
+
 function getInlineActivityContent(activity: AiChatToolActivity) {
 	if (activity.toolName !== "compute" || activity.status === "running") {
 		return null;
@@ -136,6 +217,7 @@ function getActivityDetails(activity: AiChatToolActivity) {
 function ActivitySummary({
 	activity,
 	canExpand = false,
+	showCompletedStatus = true,
 	sourcePreviews,
 }: {
 	activity: {
@@ -145,6 +227,7 @@ function ActivitySummary({
 		segments?: AiChatToolReceiptSegment[];
 	};
 	canExpand?: boolean;
+	showCompletedStatus?: boolean;
 	sourcePreviews: ToolSourcePreview[];
 }) {
 	const isRunning = activity.status === "running";
@@ -166,7 +249,9 @@ function ActivitySummary({
 				isRunning={isRunning}
 			/>
 			<InlineSourceFavicons sources={sourcePreviews.slice(0, INLINE_SOURCE_LIMIT)} />
-			<ToolStatusIcon status={activity.status} />
+			{showCompletedStatus || activity.status !== "completed" ? (
+				<ToolStatusIcon status={activity.status} />
+			) : null}
 			{canExpand ? (
 				<ChevronDown
 					className="size-3.5 shrink-0 self-center text-muted-foreground/70 transition-transform group-data-[panel-open]/collapsible:rotate-180"
@@ -351,6 +436,8 @@ function ToolActivityIcon({ icon }: { icon: AiToolActivityIconKind }) {
 			return <Search className="size-3.5" aria-hidden="true" />;
 		case "web":
 			return <Globe2 className="size-3.5" aria-hidden="true" />;
+		case "work":
+			return <Wrench className="size-3.5" aria-hidden="true" />;
 		default:
 			icon satisfies never;
 			return null;

--- a/src/features/workspaces/components/ai-chat/ai-chat-codemode-activity.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-codemode-activity.ts
@@ -1,5 +1,6 @@
 import type { ToolLogEntry } from "@cloudflare/codemode";
 
+import { summarizeAIThreadBrowserActivity } from "#/features/workspaces/ai/ai-thread-browser-activity";
 import {
 	getAiToolPresentation,
 	type AiToolPresentation,
@@ -30,16 +31,43 @@ const callStatusByState = {
 
 export function getCodemodeCallActivities(output: unknown): AiChatToolChildActivity[] | undefined {
 	const calls = getCalls(output);
-	return calls?.flatMap((call) => {
+	if (!calls) {
+		return undefined;
+	}
+
+	const activities: AiChatToolChildActivity[] = [];
+	const browserCalls: ToolLogEntry[] = [];
+	let browserActivityIndex = 0;
+
+	for (const call of calls) {
 		if (isCompactToolActivity(call)) {
 			const presentation = getAiToolPresentation(call.toolName);
-			return presentation.visibility === "visible" ? [{ ...call, presentation }] : [];
+			if (presentation.visibility === "visible") {
+				activities.push({ ...call, presentation });
+			}
+			continue;
 		}
 
-		return isToolLogEntry(call) && getAiToolPresentation(call.method).visibility === "visible"
-			? [toToolActivity(call)]
-			: [];
-	});
+		if (!isToolLogEntry(call)) {
+			continue;
+		}
+		if (call.connector === "cdp") {
+			if (browserCalls.length === 0) {
+				browserActivityIndex = activities.length;
+			}
+			browserCalls.push(call);
+			continue;
+		}
+
+		if (getAiToolPresentation(call.method).visibility === "visible") {
+			activities.push(toToolActivity(call));
+		}
+	}
+	const browserActivity = toBrowserActivity(browserCalls);
+	if (browserActivity) {
+		activities.splice(browserActivityIndex, 0, browserActivity);
+	}
+	return activities;
 }
 
 function isCompactToolActivity(
@@ -91,6 +119,33 @@ function toToolActivity(call: ToolLogEntry): AiChatToolChildActivity {
 		segments,
 		toolName: call.method,
 	};
+}
+
+function toBrowserActivity(calls: readonly ToolLogEntry[]): AiChatToolChildActivity | undefined {
+	const status = getBrowserActivityStatus(calls);
+	const summary = summarizeAIThreadBrowserActivity(calls, status);
+	if (!summary) {
+		return undefined;
+	}
+
+	return {
+		id: `${calls[0]?.seq ?? 0}:cdp:browser_execute`,
+		presentation: getAiToolPresentation("browser_execute"),
+		status,
+		summary,
+		toolName: "browser_execute",
+	};
+}
+
+function getBrowserActivityStatus(
+	calls: readonly ToolLogEntry[],
+): AiChatToolChildActivity["status"] {
+	if (calls.some((call) => call.state === "error" || call.state === "reverted")) {
+		return "failed";
+	}
+	return calls.some((call) => call.state === "executing" || call.state === "pending")
+		? "running"
+		: "completed";
 }
 
 function getCalls(value: unknown): unknown[] | undefined {

--- a/src/features/workspaces/components/ai-chat/ai-chat-display-state.test.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-display-state.test.ts
@@ -34,7 +34,7 @@ describe("Code Mode tool groups", () => {
 		const parts = getDisplayableParts(createMessage([createOrchestratePart(output), siblingTool]));
 		const group = parts[0] as AiChatToolGroupPart;
 
-		expect(group.children).toEqual([
+		expect(getGroupChildren(group)).toEqual([
 			{
 				id: "1:tools:web_search",
 				presentation: {
@@ -69,7 +69,7 @@ describe("Code Mode tool groups", () => {
 
 		const [group] = getDisplayableParts(message) as AiChatToolGroupPart[];
 
-		expect(group.children).toEqual([
+		expect(getGroupChildren(group)).toEqual([
 			{
 				id: "tool-1",
 				presentation: {
@@ -108,7 +108,7 @@ describe("Code Mode tool groups", () => {
 			createMessage([createOrchestratePart(output)]),
 		) as AiChatToolGroupPart[];
 
-		expect(group.children).toEqual([]);
+		expect(getGroupChildren(group)).toEqual([]);
 	});
 
 	it("does not absorb sibling tools when a durable call log is malformed", () => {
@@ -124,10 +124,15 @@ describe("Code Mode tool groups", () => {
 		);
 		const group = parts[0] as AiChatToolGroupPart;
 
-		expect(group.children).toEqual([]);
+		expect(getGroupChildren(group)).toEqual([]);
 		expect(parts[1]).toMatchObject({ toolCallId: "direct-tool-1" });
 	});
 });
+
+/** The trail a single-attempt group renders — the last attempt's activity. */
+function getGroupChildren(group: AiChatToolGroupPart) {
+	return group.attempts.at(-1)?.children;
+}
 
 function createMessage(parts: unknown[]) {
 	return {

--- a/src/features/workspaces/components/ai-chat/ai-chat-display-state.test.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-display-state.test.ts
@@ -34,9 +34,9 @@ describe("Code Mode tool groups", () => {
 		const parts = getDisplayableParts(createMessage([createOrchestratePart(output), siblingTool]));
 		const group = parts[0] as AiChatToolGroupPart;
 
-		expect(getGroupChildren(group)).toEqual([
+		expect(group.children).toEqual([
 			{
-				id: "1:tools:web_search",
+				id: "orchestrate-1:1:tools:web_search",
 				presentation: {
 					icon: "search",
 					title: "Search web",
@@ -69,7 +69,7 @@ describe("Code Mode tool groups", () => {
 
 		const [group] = getDisplayableParts(message) as AiChatToolGroupPart[];
 
-		expect(getGroupChildren(group)).toEqual([
+		expect(group.children).toEqual([
 			{
 				id: "tool-1",
 				presentation: {
@@ -108,7 +108,46 @@ describe("Code Mode tool groups", () => {
 			createMessage([createOrchestratePart(output)]),
 		) as AiChatToolGroupPart[];
 
-		expect(getGroupChildren(group)).toEqual([]);
+		expect(group.children).toEqual([]);
+	});
+
+	it("merges every orchestration call in the message into one ordered trail", () => {
+		const callLog = (seq: number, query: string) => ({
+			status: "completed",
+			executionId: `execution-${seq}`,
+			result: null,
+			calls: [
+				{
+					seq,
+					connector: "tools",
+					method: "web_search",
+					args: { query },
+					result: { results: [] },
+					requiresApproval: false,
+					state: "applied",
+				},
+			],
+		});
+		const parts = getDisplayableParts(
+			createMessage([
+				createOrchestratePart(callLog(1, "first"), "orchestrate-1"),
+				createOrchestratePart(callLog(1, "second"), "orchestrate-2"),
+			]),
+		);
+
+		expect(parts).toHaveLength(1);
+		const group = parts[0] as AiChatToolGroupPart;
+		// Both calls log `seq: 1`, so ids must stay distinct for React keys.
+		expect(group.children.map((child) => child.id)).toEqual([
+			"orchestrate-1:1:tools:web_search",
+			"orchestrate-2:1:tools:web_search",
+		]);
+		expect(group.children.map((child) => child.summary)).toEqual([
+			"Found 0 sources for “first”",
+			"Found 0 sources for “second”",
+		]);
+		// The header describes the latest call, so the row reads as current work.
+		expect(group.part.toolCallId).toBe("orchestrate-2");
 	});
 
 	it("does not absorb sibling tools when a durable call log is malformed", () => {
@@ -124,15 +163,10 @@ describe("Code Mode tool groups", () => {
 		);
 		const group = parts[0] as AiChatToolGroupPart;
 
-		expect(getGroupChildren(group)).toEqual([]);
+		expect(group.children).toEqual([]);
 		expect(parts[1]).toMatchObject({ toolCallId: "direct-tool-1" });
 	});
 });
-
-/** The trail a single-attempt group renders — the last attempt's activity. */
-function getGroupChildren(group: AiChatToolGroupPart) {
-	return group.attempts.at(-1)?.children;
-}
 
 function createMessage(parts: unknown[]) {
 	return {
@@ -142,10 +176,10 @@ function createMessage(parts: unknown[]) {
 	} as AiChatMessage;
 }
 
-function createOrchestratePart(output: unknown) {
+function createOrchestratePart(output: unknown, toolCallId = "orchestrate-1") {
 	return {
 		type: "tool-orchestrate",
-		toolCallId: "orchestrate-1",
+		toolCallId,
 		state: "output-available",
 		input: { code: "async () => null" },
 		output,

--- a/src/features/workspaces/components/ai-chat/ai-chat-display-state.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-display-state.ts
@@ -23,13 +23,27 @@ import {
 
 export type AssistantPendingKind = "thinking" | "working" | "recovering";
 
-export interface AiChatToolGroupPart {
-	type: "data-tool-group";
+export interface AiChatToolAttempt {
 	children: AiChatToolChildActivity[];
 	part: AiChatToolPart;
 }
 
+/**
+ * One row for every `orchestrate` call in a message. `attempts` is ordered and
+ * always non-empty; the last attempt is the one the row header describes, and
+ * its children are the activity trail shown when a single attempt is expanded.
+ */
+export interface AiChatToolGroupPart {
+	type: "data-tool-group";
+	attempts: AiChatToolAttempt[];
+	part: AiChatToolPart;
+}
+
 export type AiChatRenderablePart = AiChatMessagePart | AiChatToolGroupPart;
+
+export function isAiChatToolGroupPart(part: AiChatRenderablePart): part is AiChatToolGroupPart {
+	return part.type === "data-tool-group" && "attempts" in part;
+}
 
 export type AssistantRowDisplay =
 	| { kind: "content"; parts: AiChatRenderablePart[] }
@@ -145,9 +159,10 @@ export function getAssistantRowDisplay(
 
 export function getDisplayableParts(message: AiChatMessage): AiChatRenderablePart[] {
 	const parts = message.parts.filter(isDisplayableMessagePart);
-	const codemodePart = parts.find(
+	const codemodeParts = parts.filter(
 		(part): part is AiChatToolPart => isToolUIPart(part) && getToolPartName(part) === "orchestrate",
 	);
+	const codemodePart = codemodeParts.at(-1);
 
 	if (!codemodePart) {
 		return parts;
@@ -156,10 +171,18 @@ export function getDisplayableParts(message: AiChatMessage): AiChatRenderablePar
 	const loggedChildren = getCodemodeCallActivities(codemodePart.output);
 	const groupsSiblingTools = loggedChildren === undefined;
 	const codemodeChildren = loggedChildren ?? getLegacyCodemodeChildren(parts, codemodePart);
+	const attempts = codemodeParts.map((part) => ({
+		part,
+		children:
+			getCodemodeCallActivities(part.output) ?? (part === codemodePart ? codemodeChildren : []),
+	}));
 
 	const result: AiChatRenderablePart[] = [];
 
 	for (const part of parts) {
+		if (isToolUIPart(part) && getToolPartName(part) === "orchestrate" && part !== codemodePart) {
+			continue;
+		}
 		if (
 			groupsSiblingTools &&
 			isToolUIPart(part) &&
@@ -173,7 +196,7 @@ export function getDisplayableParts(message: AiChatMessage): AiChatRenderablePar
 			result.push({
 				type: "data-tool-group",
 				part,
-				children: codemodeChildren,
+				attempts,
 			});
 			continue;
 		}
@@ -189,24 +212,33 @@ function getLegacyCodemodeChildren(
 	codemodePart: AiChatToolPart,
 ): AiChatToolChildActivity[] {
 	return parts.flatMap((part) => {
-		if (!isToolUIPart(part) || part === codemodePart || !isVisibleToolPart(part)) {
+		if (
+			!isToolUIPart(part) ||
+			part === codemodePart ||
+			getToolPartName(part) === "orchestrate" ||
+			!isVisibleToolPart(part)
+		) {
 			return [];
 		}
 
-		const activity = getToolActivityForPart(part);
-		return activity
-			? [
-					{
-						id: part.toolCallId,
-						presentation: activity.presentation,
-						status: activity.status,
-						summary: activity.summary,
-						segments: activity.segments,
-						toolName: activity.toolName,
-					},
-				]
-			: [];
+		return getToolPartActivities(part);
 	});
+}
+
+function getToolPartActivities(part: AiChatToolPart): AiChatToolChildActivity[] {
+	const activity = getToolActivityForPart(part);
+	return activity
+		? [
+				{
+					id: part.toolCallId,
+					presentation: activity.presentation,
+					status: activity.status,
+					summary: activity.summary,
+					segments: activity.segments,
+					toolName: activity.toolName,
+				},
+			]
+		: [];
 }
 
 export function isDisplayableMessagePart(part: AiChatMessagePart): boolean {

--- a/src/features/workspaces/components/ai-chat/ai-chat-display-state.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-display-state.ts
@@ -23,26 +23,22 @@ import {
 
 export type AssistantPendingKind = "thinking" | "working" | "recovering";
 
-export interface AiChatToolAttempt {
-	children: AiChatToolChildActivity[];
-	part: AiChatToolPart;
-}
-
 /**
- * One row for every `orchestrate` call in a message. `attempts` is ordered and
- * always non-empty; the last attempt is the one the row header describes, and
- * its children are the activity trail shown when a single attempt is expanded.
+ * Every `orchestrate` call in a message collapses into one row: the header
+ * describes the last call — the model's most recent title, so it reads as
+ * current activity — and `children` is the whole message's activity trail in
+ * execution order, regardless of which call produced each entry.
  */
 export interface AiChatToolGroupPart {
 	type: "data-tool-group";
-	attempts: AiChatToolAttempt[];
+	children: AiChatToolChildActivity[];
 	part: AiChatToolPart;
 }
 
 export type AiChatRenderablePart = AiChatMessagePart | AiChatToolGroupPart;
 
 export function isAiChatToolGroupPart(part: AiChatRenderablePart): part is AiChatToolGroupPart {
-	return part.type === "data-tool-group" && "attempts" in part;
+	return part.type === "data-tool-group" && "children" in part;
 }
 
 export type AssistantRowDisplay =
@@ -170,12 +166,16 @@ export function getDisplayableParts(message: AiChatMessage): AiChatRenderablePar
 
 	const loggedChildren = getCodemodeCallActivities(codemodePart.output);
 	const groupsSiblingTools = loggedChildren === undefined;
-	const codemodeChildren = loggedChildren ?? getLegacyCodemodeChildren(parts, codemodePart);
-	const attempts = codemodeParts.map((part) => ({
-		part,
-		children:
-			getCodemodeCallActivities(part.output) ?? (part === codemodePart ? codemodeChildren : []),
-	}));
+	// Each call logs its own `seq`, so ids repeat across calls. Namespace them by
+	// the call that produced them to keep the merged trail's keys unique.
+	const codemodeChildren = groupsSiblingTools
+		? getLegacyCodemodeChildren(parts, codemodePart)
+		: codemodeParts.flatMap((part) =>
+				(getCodemodeCallActivities(part.output) ?? []).map((child) => ({
+					...child,
+					id: `${part.toolCallId}:${child.id}`,
+				})),
+			);
 
 	const result: AiChatRenderablePart[] = [];
 
@@ -196,7 +196,7 @@ export function getDisplayableParts(message: AiChatMessage): AiChatRenderablePar
 			result.push({
 				type: "data-tool-group",
 				part,
-				attempts,
+				children: codemodeChildren,
 			});
 			continue;
 		}

--- a/src/features/workspaces/components/ai-chat/ai-chat-tool-receipts.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-tool-receipts.ts
@@ -137,9 +137,9 @@ export function getRunningToolReceipt(input: {
 		case "research_discover":
 			return receipt.running("Finding sources for ", ...name(getString(toolInput.query)));
 		case "compute":
-			return receipt.running("Running Python");
+			return activityTitleReceipt("running", toolInput) ?? receipt.running("Running Python");
 		case "orchestrate":
-			return receipt.running("Working through the task");
+			return activityTitleReceipt("running", toolInput) ?? receipt.running("Working");
 		default:
 			return receipt.running(`Running ${formatToolNameFallback(input.toolName)}`);
 	}
@@ -193,9 +193,9 @@ export function getFinishedToolReceipt(input: {
 		case "research_deepen":
 			return summarizeResearchDeepen(input.output, input.toolInput);
 		case "orchestrate":
-			return summarizeCodemode(input.output);
+			return summarizeCodemode(input.output, input.toolInput);
 		case "compute":
-			return summarizeCompute(input.output);
+			return summarizeCompute(input.output, input.toolInput);
 		default:
 			return receipt.completed(summarizeUnknownResult(input.output, input.toolName));
 	}
@@ -445,22 +445,49 @@ function summarizeRunningResearchDeepen(input: Record<string, unknown>): AiChatT
 	return receipt.running("Researching ", ...name(paper));
 }
 
-function summarizeCodemode(output: unknown): AiChatToolReceipt {
+/**
+ * `orchestrate` and `compute` are the only tools whose arguments carry no noun
+ * to build a row from — the input is an opaque blob of code — so the model
+ * names the work itself in a leading `title` field and the row shows that
+ * instead of the mechanism. The derived summaries below stay as the fallback
+ * for a title that has not streamed in yet, or a model that skipped the field.
+ *
+ * States the title must not mask (a paused approval, a failed run) are settled
+ * by their callers before this is consulted.
+ */
+function activityTitleReceipt(
+	status: Exclude<AiChatToolReceiptStatus, "failed">,
+	toolInput: unknown,
+): AiChatToolReceipt | undefined {
+	const title = getString(asRecord(toolInput).title)?.trim();
+	if (!title) return undefined;
+
+	return status === "running" ? receipt.running(title) : receipt.completed(title);
+}
+
+function summarizeCodemode(output: unknown, toolInput: unknown): AiChatToolReceipt {
 	const record = asRecord(output);
 	const status = getString(record.status);
 
 	if (status === "paused") return receipt.completed("Needs input");
 	if (status === "error") return receipt.failed("Couldn’t work through the task");
+
+	const titled = activityTitleReceipt("completed", toolInput);
+	if (titled) return titled;
+
 	if (status === "completed")
 		return receipt.completed(summarizeUnknownResult(record.result, "orchestrate"));
 
 	return receipt.completed(summarizeUnknownResult(output, "orchestrate"));
 }
 
-function summarizeCompute(output: unknown): AiChatToolReceipt {
+function summarizeCompute(output: unknown, toolInput: unknown): AiChatToolReceipt {
 	const record = asRecord(output);
 
 	if (record.error) return receipt.failed("Couldn’t compute");
+
+	const titled = activityTitleReceipt("completed", toolInput);
+	if (titled) return titled;
 
 	const results = getArray(record.results);
 	const imageCount = results.filter((result) => {

--- a/src/features/workspaces/components/ai-chat/useWorkspaceAiBrowserSession.ts
+++ b/src/features/workspaces/components/ai-chat/useWorkspaceAiBrowserSession.ts
@@ -1,0 +1,95 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+import type {
+	AIThreadBrowserHandoff,
+	AIThreadBrowserLiveView,
+	AIThreadBrowserState,
+} from "#/features/workspaces/ai/ai-thread-browser";
+
+const BROWSER_SESSION_POLL_MS = 1_500;
+
+interface WorkspaceAiAgent {
+	call<T = unknown>(method: string, args?: unknown[]): Promise<T>;
+	ready: Promise<void>;
+}
+
+export interface AiChatBrowserSessionController {
+	actionError?: string;
+	getLiveView: () => Promise<AIThreadBrowserLiveView | null>;
+	hasSession: boolean;
+	handoff?: AIThreadBrowserHandoff;
+	isActing: boolean;
+	resolveHandoff: (approved: boolean) => Promise<void>;
+	sessionKey: string;
+	stopBrowser: () => Promise<void>;
+}
+
+export function useWorkspaceAiBrowserSession(input: {
+	agent: WorkspaceAiAgent;
+	isChatBusy: boolean;
+	threadId: string;
+}): AiChatBrowserSessionController {
+	const stateQuery = useQuery({
+		queryFn: async () => {
+			await input.agent.ready;
+			return input.agent.call<AIThreadBrowserState>("getBrowserState");
+		},
+		queryKey: ["workspace-ai-browser-state", input.threadId],
+		// A pending handoff outlives the turn that raised it — the run parks and
+		// the chat goes idle — so an open session or handoff keeps the poll alive
+		// on its own.
+		refetchInterval: (query) =>
+			input.isChatBusy || query.state.data?.presence || query.state.data?.handoff
+				? BROWSER_SESSION_POLL_MS
+				: false,
+		retry: false,
+	});
+	const action = useMutation({
+		mutationFn: async (
+			request:
+				| { executionId?: string; kind: "stop" }
+				| { approved: boolean; executionId: string; kind: "resolve" },
+		) => {
+			if (request.kind === "resolve") {
+				await input.agent.call("resolveBrowserHandoff", [request.executionId, request.approved]);
+				return;
+			}
+
+			await input.agent.call(
+				"stopBrowserSession",
+				request.executionId ? [request.executionId] : [],
+			);
+		},
+		onSettled: async () => {
+			await stateQuery.refetch();
+		},
+	});
+	const handoff = stateQuery.data?.handoff ?? undefined;
+	const presence = stateQuery.data?.presence;
+
+	return {
+		actionError: action.error instanceof Error ? action.error.message : undefined,
+		getLiveView: () => input.agent.call<AIThreadBrowserLiveView | null>("getBrowserLiveView"),
+		hasSession: Boolean(presence),
+		handoff,
+		isActing: action.isPending,
+		resolveHandoff: async (approved) => {
+			if (!handoff) {
+				return;
+			}
+
+			await action.mutateAsync({
+				approved,
+				executionId: handoff.executionId,
+				kind: "resolve",
+			});
+		},
+		sessionKey: `${input.threadId}:${presence?.startedAt ?? "none"}`,
+		stopBrowser: async () => {
+			await action.mutateAsync({
+				executionId: handoff?.executionId,
+				kind: "stop",
+			});
+		},
+	};
+}

--- a/src/features/workspaces/components/ai-chat/useWorkspaceAiBrowserSession.ts
+++ b/src/features/workspaces/components/ai-chat/useWorkspaceAiBrowserSession.ts
@@ -46,19 +46,14 @@ export function useWorkspaceAiBrowserSession(input: {
 	});
 	const action = useMutation({
 		mutationFn: async (
-			request:
-				| { executionId?: string; kind: "stop" }
-				| { approved: boolean; executionId: string; kind: "resolve" },
+			request: { kind: "stop" } | { approved: boolean; executionId: string; kind: "resolve" },
 		) => {
 			if (request.kind === "resolve") {
 				await input.agent.call("resolveBrowserHandoff", [request.executionId, request.approved]);
 				return;
 			}
 
-			await input.agent.call(
-				"stopBrowserSession",
-				request.executionId ? [request.executionId] : [],
-			);
+			await input.agent.call("stopBrowserSession");
 		},
 		onSettled: async () => {
 			await stateQuery.refetch();
@@ -86,10 +81,7 @@ export function useWorkspaceAiBrowserSession(input: {
 		},
 		sessionKey: `${input.threadId}:${presence?.startedAt ?? "none"}`,
 		stopBrowser: async () => {
-			await action.mutateAsync({
-				executionId: handoff?.executionId,
-				kind: "stop",
-			});
+			await action.mutateAsync({ kind: "stop" });
 		},
 	};
 }

--- a/src/features/workspaces/components/ai-chat/useWorkspaceAiChat.ts
+++ b/src/features/workspaces/components/ai-chat/useWorkspaceAiChat.ts
@@ -14,6 +14,7 @@ import type {
 	AiChatSendMessageOptions,
 	AiChatStatus,
 } from "#/features/workspaces/components/ai-chat/types";
+import { useWorkspaceAiBrowserSession } from "#/features/workspaces/components/ai-chat/useWorkspaceAiBrowserSession";
 
 interface UseWorkspaceAiChatOptions {
 	modelId: AiChatModelId;
@@ -66,6 +67,11 @@ export function useWorkspaceAiChat({ modelId, threadId }: UseWorkspaceAiChatOpti
 					? "ready"
 					: status;
 	const canSend = inputStatus === "ready" && !presentation.isBusy && !connectionError;
+	const browser = useWorkspaceAiBrowserSession({
+		agent,
+		isChatBusy: canStop,
+		threadId,
+	});
 
 	const sendMessage = (message: AiChatSendMessage, options?: AiChatSendMessageOptions) => {
 		if (message.parts.length === 0 || !canSend) {
@@ -86,6 +92,7 @@ export function useWorkspaceAiChat({ modelId, threadId }: UseWorkspaceAiChatOpti
 	};
 
 	return {
+		browser,
 		connectionError,
 		inputStatus,
 		messages,

--- a/src/features/workspaces/documents/document-session-auth.ts
+++ b/src/features/workspaces/documents/document-session-auth.ts
@@ -1,13 +1,15 @@
-import { createDbContext } from "#/db/server";
 import {
 	getDocumentSessionRoomName,
 	getDocumentSessionRouteParams,
 	isDocumentSessionRequestPath,
 } from "#/features/workspaces/agent-routes";
-import { canReadWorkspace, WorkspaceAuthError } from "#/features/workspaces/server/permissions";
+import {
+	forwardDocumentSessionConnectionAccess,
+	resolveDocumentSessionConnectionAccess,
+} from "#/features/workspaces/documents/document-session-connection-access";
+import { WorkspaceAuthError } from "#/features/workspaces/server/permissions";
 import { recordOperationalFailure } from "#/integrations/observability/operational-events";
 import { getTelemetryRequestDetails } from "#/integrations/posthog/server-context";
-import { getSessionFromRequest } from "#/lib/auth-queries.server";
 
 export async function routeDocumentSessionRequest(request: Request, env: Env) {
 	const url = new URL(request.url);
@@ -23,30 +25,21 @@ export async function routeDocumentSessionRequest(request: Request, env: Env) {
 	}
 
 	try {
-		const session = await getSessionFromRequest(request);
+		const access = await resolveDocumentSessionConnectionAccess(request, params.workspaceId);
 
-		if (!session?.user) {
+		if (access.status === "unauthenticated") {
 			return new Response("Unauthorized", { status: 401 });
 		}
 
-		const dbContext = await createDbContext();
-
-		try {
-			const canRead = await canReadWorkspace(dbContext.db, {
-				workspaceId: params.workspaceId,
-				userId: session.user.id,
-			});
-
-			if (!canRead) {
-				return new Response("Forbidden", { status: 403 });
-			}
-
-			const documentSession = env.DocumentSession.getByName(getDocumentSessionRoomName(params));
-
-			return documentSession.fetch(request);
-		} finally {
-			await dbContext.dispose();
+		if (access.status === "forbidden") {
+			return new Response("Forbidden", { status: 403 });
 		}
+
+		const documentSession = env.DocumentSession.getByName(getDocumentSessionRoomName(params));
+
+		return documentSession.fetch(
+			forwardDocumentSessionConnectionAccess(request, access.connectionState),
+		);
 	} catch (error) {
 		if (error instanceof WorkspaceAuthError) {
 			return new Response("Unauthorized", { status: 401 });

--- a/src/features/workspaces/documents/document-session-connection-access.ts
+++ b/src/features/workspaces/documents/document-session-connection-access.ts
@@ -3,19 +3,30 @@ import { getWorkspaceMemberRole } from "#/features/workspaces/server/permissions
 import { getWorkspaceMemberCapabilities } from "#/features/workspaces/workspace-member-capabilities";
 import { getSessionFromRequest } from "#/lib/auth-queries.server";
 
+const documentSessionUserIdHeader = "x-thinkex-document-session-user-id";
+const documentSessionCanMutateHeader = "x-thinkex-document-session-can-mutate";
+
 export interface DocumentSessionConnectionState {
 	canMutate: boolean;
 	userId: string;
 }
 
+export type DocumentSessionConnectionAccess =
+	| { status: "unauthenticated" }
+	| { status: "forbidden" }
+	| {
+			status: "allowed";
+			connectionState: DocumentSessionConnectionState;
+	  };
+
 export async function resolveDocumentSessionConnectionAccess(
 	request: Request,
 	workspaceId: string,
-): Promise<DocumentSessionConnectionState | null> {
+): Promise<DocumentSessionConnectionAccess> {
 	const session = await getSessionFromRequest(request);
 
 	if (!session?.user) {
-		return null;
+		return { status: "unauthenticated" };
 	}
 
 	const dbContext = await createDbContext();
@@ -27,14 +38,44 @@ export async function resolveDocumentSessionConnectionAccess(
 		});
 
 		if (!role) {
-			return null;
+			return { status: "forbidden" };
 		}
 
 		return {
-			userId: session.user.id,
-			canMutate: getWorkspaceMemberCapabilities(role).canMutateContent,
+			status: "allowed",
+			connectionState: {
+				userId: session.user.id,
+				canMutate: getWorkspaceMemberCapabilities(role).canMutateContent,
+			},
 		};
 	} finally {
 		await dbContext.dispose();
 	}
+}
+
+export function forwardDocumentSessionConnectionAccess(
+	request: Request,
+	connectionState: DocumentSessionConnectionState,
+) {
+	const headers = new Headers(request.headers);
+	headers.set(documentSessionUserIdHeader, connectionState.userId);
+	headers.set(documentSessionCanMutateHeader, connectionState.canMutate ? "true" : "false");
+
+	return new Request(request, { headers });
+}
+
+export function readForwardedDocumentSessionConnectionAccess(
+	request: Request,
+): DocumentSessionConnectionState | null {
+	const userId = request.headers.get(documentSessionUserIdHeader);
+	const canMutate = request.headers.get(documentSessionCanMutateHeader);
+
+	if (!userId || (canMutate !== "true" && canMutate !== "false")) {
+		return null;
+	}
+
+	return {
+		userId,
+		canMutate: canMutate === "true",
+	};
 }

--- a/src/features/workspaces/documents/document-session.ts
+++ b/src/features/workspaces/documents/document-session.ts
@@ -25,7 +25,7 @@ import {
 } from "#/features/workspaces/documents/document-markdown-edits";
 import {
 	type DocumentSessionConnectionState,
-	resolveDocumentSessionConnectionAccess,
+	readForwardedDocumentSessionConnectionAccess,
 } from "#/features/workspaces/documents/document-session-connection-access";
 import {
 	coerceTiptapDocumentJson,
@@ -41,7 +41,6 @@ import {
 	getWorkspaceKernelFromEnv,
 	type WorkspaceKernelClient,
 } from "#/features/workspaces/kernel/workspace-kernel-access";
-import { recordOperationalFailure } from "#/integrations/observability/operational-events";
 import { sha256Base64Url } from "#/lib/binary";
 
 const persistedYDocUpdateKey = "document-session:yjs-update";
@@ -83,23 +82,7 @@ export class DocumentSession extends YServer {
 		connection: Connection<DocumentSessionConnectionState>,
 		context: ConnectionContext,
 	) {
-		const room = getDocumentSessionRoomNameParts(this.name);
-		let access: Awaited<ReturnType<typeof resolveDocumentSessionConnectionAccess>>;
-
-		try {
-			access = await resolveDocumentSessionConnectionAccess(context.request, room.workspaceId);
-		} catch (error) {
-			recordOperationalFailure({
-				error,
-				event: "document_session_connection",
-				fields: {
-					item_id: room.itemId,
-					workspace_id: room.workspaceId,
-				},
-			});
-			connection.close(1011, "Document session unavailable");
-			return;
-		}
+		const access = readForwardedDocumentSessionConnectionAccess(context.request);
 
 		if (!access) {
 			connection.close(1011, "Unauthorized");
@@ -118,17 +101,16 @@ export class DocumentSession extends YServer {
 	}
 
 	override async onLoad() {
-		const room = getDocumentSessionRoomNameParts(this.name);
-		const kernel = await this.getWorkspaceKernel(room.workspaceId);
-		const [{ content }, persistedUpdate] = await Promise.all([
-			kernel.readDocumentCheckpoint({ itemId: room.itemId }),
-			this.ctx.storage.get<Uint8Array>(persistedYDocUpdateKey),
-		]);
+		const persistedUpdate = await this.ctx.storage.get<Uint8Array>(persistedYDocUpdateKey);
+
 		if (persistedUpdate) {
 			Y.applyUpdate(this.document, persistedUpdate, this);
 			return;
 		}
 
+		const room = getDocumentSessionRoomNameParts(this.name);
+		const kernel = await this.getWorkspaceKernel(room.workspaceId);
+		const { content } = await kernel.readDocumentCheckpoint({ itemId: room.itemId });
 		const snapshot = parseTiptapDocumentJson(content);
 		const seededDoc = prosemirrorJSONToYDoc(
 			getTiptapDocumentSchema(),

--- a/src/features/workspaces/documents/use-document-collaboration-session.ts
+++ b/src/features/workspaces/documents/use-document-collaboration-session.ts
@@ -173,12 +173,22 @@ function createActiveDocumentSession(input: {
 		};
 		notifyDocumentSessionSubscribers(session);
 	};
+	/**
+	 * Persistence is an optimization, so a failed write must stay silent rather
+	 * than surfacing as an unhandled rejection on every sync — IndexedDB is
+	 * unavailable in private windows and can be over quota anywhere.
+	 */
+	const rememberServerSync = () => {
+		void session.persistence.set(localDocumentReadyKey, localDocumentReadyValue).catch(() => {
+			// The live collaboration session remains canonical.
+		});
+	};
 	const handleSync = (synced: boolean) => {
 		if (!synced) {
 			return;
 		}
 
-		void session.persistence.set(localDocumentReadyKey, localDocumentReadyValue);
+		rememberServerSync();
 		markReady();
 	};
 
@@ -187,7 +197,7 @@ function createActiveDocumentSession(input: {
 			provider: session.provider,
 			ydoc: session.ydoc,
 		};
-		void session.persistence.set(localDocumentReadyKey, localDocumentReadyValue);
+		rememberServerSync();
 	}
 
 	void session.persistence.whenSynced

--- a/src/features/workspaces/documents/use-document-collaboration-session.ts
+++ b/src/features/workspaces/documents/use-document-collaboration-session.ts
@@ -1,14 +1,14 @@
 import { useCallback, useSyncExternalStore } from "react";
+import { IndexeddbPersistence } from "y-indexeddb";
 import { WebsocketProvider } from "y-partyserver/provider";
 import * as Y from "yjs";
 
 import { getDocumentSessionBaseUrl } from "#/features/workspaces/agent-routes";
 import { getCollaborationUserColor } from "#/lib/design-system-colors";
 
-const idleDestroyDelayMs = 300_000;
-const maxIdleSessions = 8;
-
-export type DocumentCollaborationStatus = "connecting" | "connected" | "disconnected";
+const localDocumentReadyKey = "server-synced";
+const localDocumentReadyValue = "true";
+const localDocumentStorePrefix = "thinkex-document";
 
 interface DocumentCollaborationUser {
 	id: string;
@@ -17,26 +17,24 @@ interface DocumentCollaborationUser {
 }
 
 export interface DocumentCollaborationSession {
-	itemId: string;
 	provider: WebsocketProvider;
-	ready: boolean;
-	status: DocumentCollaborationStatus;
-	workspaceId: string;
 	ydoc: Y.Doc;
 }
 
-interface CachedDocumentCollaborationSession extends DocumentCollaborationSession {
+interface ActiveDocumentCollaborationSession {
 	destroy(): void;
-	destroyTimer: ReturnType<typeof setTimeout> | null;
 	key: string;
-	lastUsedAt: number;
+	persistence: IndexeddbPersistence;
+	provider: WebsocketProvider;
 	publicSession: DocumentCollaborationSession | null;
+	ready: boolean;
 	refs: number;
 	subscribe(listener: () => void): () => void;
 	subscribers: Set<() => void>;
+	ydoc: Y.Doc;
 }
 
-const documentSessionCache = new Map<string, CachedDocumentCollaborationSession>();
+const activeDocumentSessions = new Map<string, ActiveDocumentCollaborationSession>();
 
 export function useDocumentCollaborationSession(input: {
 	itemId: string;
@@ -47,7 +45,7 @@ export function useDocumentCollaborationSession(input: {
 }) {
 	const { itemId, userId, userImage, userName, workspaceId } = input;
 	const sessionKey =
-		userId && userName ? getDocumentSessionCacheKey({ itemId, workspaceId }) : null;
+		userId && userName ? getDocumentSessionKey({ itemId, userId, workspaceId }) : null;
 
 	const subscribe = useCallback(
 		(listener: () => void) => {
@@ -55,7 +53,7 @@ export function useDocumentCollaborationSession(input: {
 				return () => {};
 			}
 
-			const cachedSession = acquireDocumentSession({
+			const activeSession = acquireDocumentSession({
 				itemId,
 				user: {
 					id: userId,
@@ -64,35 +62,24 @@ export function useDocumentCollaborationSession(input: {
 				},
 				workspaceId,
 			});
-			const unsubscribe = cachedSession.subscribe(listener);
+			const unsubscribe = activeSession.subscribe(listener);
 
 			queueMicrotask(listener);
 
 			return () => {
 				unsubscribe();
-				releaseDocumentSession(cachedSession);
+				releaseDocumentSession(activeSession);
 			};
 		},
 		[itemId, userId, userImage, userName, workspaceId],
 	);
 
-	const getSnapshot = useCallback(() => {
-		if (!userId || !userName) {
-			return null;
-		}
+	const getSnapshot = useCallback(
+		() => (sessionKey ? (activeDocumentSessions.get(sessionKey)?.publicSession ?? null) : null),
+		[sessionKey],
+	);
 
-		return sessionKey ? (documentSessionCache.get(sessionKey)?.publicSession ?? null) : null;
-	}, [sessionKey, userId, userName]);
-
-	const session = useSyncExternalStore(subscribe, getSnapshot, () => null);
-
-	return session?.workspaceId === input.workspaceId &&
-		session.itemId === input.itemId &&
-		input.userId &&
-		input.userName &&
-		session.ready
-		? session
-		: null;
+	return useSyncExternalStore(subscribe, getSnapshot, () => null);
 }
 
 function acquireDocumentSession(input: {
@@ -100,21 +87,28 @@ function acquireDocumentSession(input: {
 	user: DocumentCollaborationUser;
 	workspaceId: string;
 }) {
-	const key = getDocumentSessionCacheKey(input);
-	const cachedSession = documentSessionCache.get(key);
+	const key = getDocumentSessionKey({
+		itemId: input.itemId,
+		userId: input.user.id,
+		workspaceId: input.workspaceId,
+	});
+	const activeSession = activeDocumentSessions.get(key);
 
-	if (cachedSession) {
-		cachedSession.refs += 1;
-		cachedSession.lastUsedAt = Date.now();
-		if (cachedSession.destroyTimer) {
-			clearTimeout(cachedSession.destroyTimer);
-			cachedSession.destroyTimer = null;
-		}
-		cachedSession.provider.awareness.setLocalStateField("user", getCollaborationUser(input.user));
-		return cachedSession;
+	if (activeSession) {
+		activeSession.refs += 1;
+		activeSession.provider.awareness.setLocalStateField("user", getCollaborationUser(input.user));
+		return activeSession;
 	}
 
 	const ydoc = new Y.Doc();
+	const persistence = new IndexeddbPersistence(
+		getDocumentLocalStoreName({
+			itemId: input.itemId,
+			userId: input.user.id,
+			workspaceId: input.workspaceId,
+		}),
+		ydoc,
+	);
 	const provider = new WebsocketProvider(
 		getDocumentSessionBaseUrl(input.workspaceId),
 		encodeURIComponent(input.itemId),
@@ -124,45 +118,39 @@ function acquireDocumentSession(input: {
 			resyncInterval: 10_000,
 		},
 	);
-	const session = createCachedDocumentSession({
+	const session = createActiveDocumentSession({
 		key,
-		itemId: input.itemId,
+		persistence,
 		provider,
-		workspaceId: input.workspaceId,
 		ydoc,
 	});
 
 	provider.awareness.setLocalStateField("user", getCollaborationUser(input.user));
-	documentSessionCache.set(key, session);
-	pruneIdleDocumentSessions();
+	activeDocumentSessions.set(key, session);
 
 	return session;
 }
 
-function createCachedDocumentSession(input: {
-	itemId: string;
+function createActiveDocumentSession(input: {
 	key: string;
+	persistence: IndexeddbPersistence;
 	provider: WebsocketProvider;
-	workspaceId: string;
 	ydoc: Y.Doc;
-}): CachedDocumentCollaborationSession {
-	const session: CachedDocumentCollaborationSession = {
+}): ActiveDocumentCollaborationSession {
+	const session: ActiveDocumentCollaborationSession = {
 		destroy() {
-			input.provider.off("status", handleStatus);
 			input.provider.off("sync", handleSync);
+			void input.persistence.destroy();
 			input.provider.destroy();
 			input.ydoc.destroy();
-			documentSessionCache.delete(input.key);
+			activeDocumentSessions.delete(input.key);
 		},
-		destroyTimer: null,
-		itemId: input.itemId,
 		key: input.key,
-		lastUsedAt: Date.now(),
+		persistence: input.persistence,
 		provider: input.provider,
 		publicSession: null,
 		ready: input.provider.synced,
 		refs: 1,
-		status: input.provider.wsconnected ? "connected" : "connecting",
 		subscribe(listener: () => void) {
 			session.subscribers.add(listener);
 			return () => {
@@ -170,76 +158,83 @@ function createCachedDocumentSession(input: {
 			};
 		},
 		subscribers: new Set<() => void>(),
-		workspaceId: input.workspaceId,
 		ydoc: input.ydoc,
 	};
-	session.publicSession = session.ready ? getPublicSession(session) : null;
-	const handleStatus = (event: { status: DocumentCollaborationStatus }) => {
-		session.status = event.status;
-		session.publicSession = session.ready ? getPublicSession(session) : null;
+
+	const markReady = () => {
+		if (session.ready) {
+			return;
+		}
+
+		session.ready = true;
+		session.publicSession = {
+			provider: session.provider,
+			ydoc: session.ydoc,
+		};
 		notifyDocumentSessionSubscribers(session);
 	};
 	const handleSync = (synced: boolean) => {
-		session.ready ||= synced;
-		session.publicSession = session.ready ? getPublicSession(session) : null;
-		notifyDocumentSessionSubscribers(session);
+		if (!synced) {
+			return;
+		}
+
+		void session.persistence.set(localDocumentReadyKey, localDocumentReadyValue);
+		markReady();
 	};
 
-	input.provider.on("status", handleStatus);
+	if (session.ready) {
+		session.publicSession = {
+			provider: session.provider,
+			ydoc: session.ydoc,
+		};
+		void session.persistence.set(localDocumentReadyKey, localDocumentReadyValue);
+	}
+
+	void session.persistence.whenSynced
+		.then(() => session.persistence.get(localDocumentReadyKey))
+		.then((wasServerSynced) => {
+			if (wasServerSynced === localDocumentReadyValue) {
+				markReady();
+			}
+		})
+		.catch(() => {
+			// IndexedDB is an optimization. The live collaboration session remains canonical.
+		});
+
 	input.provider.on("sync", handleSync);
 
 	return session;
 }
 
-function releaseDocumentSession(session: CachedDocumentCollaborationSession) {
+function releaseDocumentSession(session: ActiveDocumentCollaborationSession) {
 	session.refs = Math.max(0, session.refs - 1);
-	session.lastUsedAt = Date.now();
 
 	if (session.refs > 0) {
 		return;
 	}
 
 	session.provider.awareness.setLocalState(null);
-	session.destroyTimer = setTimeout(() => {
+	queueMicrotask(() => {
 		if (session.refs === 0) {
 			session.destroy();
 		}
-	}, idleDestroyDelayMs);
-}
-
-function pruneIdleDocumentSessions() {
-	const idleSessions = Array.from(documentSessionCache.values())
-		.filter((session) => session.refs === 0)
-		.sort((a, b) => a.lastUsedAt - b.lastUsedAt);
-
-	while (documentSessionCache.size > maxIdleSessions && idleSessions.length) {
-		idleSessions.shift()?.destroy();
-	}
+	});
 }
 
 function notifyDocumentSessionSubscribers(
-	session: Pick<CachedDocumentCollaborationSession, "subscribers">,
+	session: Pick<ActiveDocumentCollaborationSession, "subscribers">,
 ) {
 	for (const subscriber of session.subscribers) {
 		subscriber();
 	}
 }
 
-function getPublicSession(
-	session: CachedDocumentCollaborationSession,
-): DocumentCollaborationSession {
-	return {
-		itemId: session.itemId,
-		provider: session.provider,
-		ready: session.ready,
-		status: session.status,
-		workspaceId: session.workspaceId,
-		ydoc: session.ydoc,
-	};
+function getDocumentSessionKey(input: { itemId: string; userId: string; workspaceId: string }) {
+	return `${input.userId}:${input.workspaceId}:${input.itemId}`;
 }
 
-function getDocumentSessionCacheKey(input: { itemId: string; workspaceId: string }) {
-	return `${input.workspaceId}:${input.itemId}`;
+function getDocumentLocalStoreName(input: { itemId: string; userId: string; workspaceId: string }) {
+	return `${localDocumentStorePrefix}:${getDocumentSessionKey(input)}`;
 }
 
 function getCollaborationUser(user: DocumentCollaborationUser) {

--- a/src/lib/http/content-security-policy.test.ts
+++ b/src/lib/http/content-security-policy.test.ts
@@ -21,6 +21,7 @@ describe("content security policy", () => {
 		expect(policy).not.toContain("*.r2.cloudflarestorage.com");
 		expect(policy).not.toContain("connect-src https:");
 		expect(policy).not.toContain("'unsafe-eval'");
+		expect(policy).toContain("frame-src https://live.browser.run");
 		expect(policy).toContain("report-uri https://h.thinkex.app/report/?token=test");
 	});
 

--- a/src/lib/http/content-security-policy.ts
+++ b/src/lib/http/content-security-policy.ts
@@ -8,6 +8,7 @@ interface ContentSecurityPolicyOptions {
 
 const cloudflareInsightsScriptOrigin = "https://static.cloudflareinsights.com";
 const cloudflareInsightsConnectOrigin = "https://cloudflareinsights.com";
+const cloudflareBrowserLiveViewOrigin = "https://live.browser.run";
 const cloudflareAccountIdPattern = /^[a-f\d]{32}$/i;
 
 export function buildContentSecurityPolicy(options: ContentSecurityPolicyOptions) {
@@ -45,7 +46,7 @@ export function buildContentSecurityPolicy(options: ContentSecurityPolicyOptions
 		"base-uri 'self'",
 		"object-src 'none'",
 		"frame-ancestors 'none'",
-		"frame-src 'none'",
+		`frame-src ${cloudflareBrowserLiveViewOrigin}`,
 		"form-action 'self'",
 		"manifest-src 'self'",
 		"img-src 'self' data: blob: https:",


### PR DESCRIPTION
## Summary
- reduce document collaboration startup work and centralize connection-access handling
- add task-scoped Browser Run sessions with an embedded Live View, stop controls, and durable user handoff for login or other private interaction
- let browser automation recover once from a disconnected reusable session
- simplify Code Mode activity rows, collapse repeated orchestration attempts, and show richer browser activity labels
- normalize model-facing tool schemas across providers

## Why
Document collaboration was doing avoidable startup work, while interactive AI browser tasks had no reliable in-chat lifecycle or user handoff. Browser runs could also become stranded when a reused session disconnected, and the activity transcript exposed low-level CDP calls instead of useful summaries.

## Changes
- streamline document session authorization and collaboration initialization
- add the Browser Run connector and browser-specific orchestration guidance
- add a mandatory approval-backed `browser_handoff` flow for login, MFA, CAPTCHA, private input, and consequential actions
- surface an embedded browser thumbnail and expandable interactive Live View in chat
- add session stop, cleanup, polling, and one-time reset recovery
- group CDP activity into descriptive browser receipts and collapse consecutive orchestration attempts
- permit `live.browser.run` in the frame CSP and document the browser experience

## Testing
- commit hooks ran `vp check --fix` successfully for every focused commit
- manually verified a normal Example Domain browser run
- manually verified GitHub login reaches the paused `Browser needs you` state with the live thumbnail visible
- full automated test suite was not run at the user's request

## Review Notes
- start with `src/features/workspaces/ai/ai-thread-browser.ts` for browser lifecycle and handoff behavior
- review `src/features/workspaces/components/ai-chat/AiChatBrowserSessionCard.tsx` for the Live View UI
- document collaboration startup changes are isolated in the earliest commit
- the generated `src/routeTree.gen.ts` working-tree change is not included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787890253&installation_model_id=425282&pr_number=688&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F688&signature=fdf51bf003bb5f2b5a130e84749da6e9008c526dea9bf4e5ac904e7eb54d14db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

