### PR TITLE
ci(actions): trust PR validate and slim deploy path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,8 @@ jobs:
       url: https://thinkex.app
     concurrency:
       group: deploy-production
-      cancel-in-progress: true
+      # Queue instead of cancel so a newer push cannot abort an in-flight migrate/deploy.
+      cancel-in-progress: false
 
     env:
       # Runtime and deploy secrets are synced into GitHub Actions secrets from Infisical.
@@ -90,9 +91,7 @@ jobs:
       - name: Install dependencies
         run: vp install --frozen-lockfile
 
-      - name: Verify branch quality gates
-        run: vp run check && vp run test
-
+      # Quality gates live on PRs (`validate` / `vp run verify`) and are required to merge to main.
       - name: Build production bundle
         run: vp run build:production
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install dependencies
         run: vp install --frozen-lockfile
 
-      # Quality gates live on PRs (`validate` / `vp run verify`) and are required to merge to main.
+      # Quality gates live on PRs (`validate` / `vp run verify`); required when merging via PR.
       - name: Build production bundle
         run: vp run build:production
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -45,9 +45,7 @@ jobs:
       - name: Install dependencies
         run: vp install --frozen-lockfile
 
-      - name: Verify branch quality gates
-        run: vp run check && vp run test
-
+      # Quality gates live on PRs (`validate` / `vp run verify`); staging deploys ship the staging bundle.
       - name: Build staging bundle
         env:
           CLOUDFLARE_VITE_FORCE_LOCAL: "true"

--- a/docs/configuration/deployments.mdx
+++ b/docs/configuration/deployments.mdx
@@ -14,22 +14,23 @@ ThinkEx deploys from GitHub Actions to Cloudflare Workers. Deploy, migration, an
 
 ## CI
 
-The `CI` workflow runs on pull requests, pushes to `main`, and manual dispatch. It installs with Vite+ and runs:
+The `CI` workflow runs on pull requests, pushes to `main`, and manual dispatch.
+
+On pull requests (and non-`main` pushes), it installs with Vite+ and runs:
 
 ```bash
 vp run verify
 ```
 
-`verify` runs the repo's check, test, and build tasks using Vite Task caching.
+`verify` runs the repo's check, test, and build tasks using Vite Task caching. Merges into `main` require the `validate` check to pass.
 
 The separate `React Doctor` workflow runs on pull requests and pushes to `main`. It scans changed React files on pull requests, posts inline diagnostics, and records the React Doctor score without folding those comments into the main Vite+ verification job.
 
 ## Production Deploy
 
-The production workflow checks out the successful `main` commit, installs dependencies, runs quality gates, builds the production bundle, applies remote D1 migrations, and deploys the production Worker.
+Production deploy trusts PR `validate` and ships the production artifact: build, remote D1 migrations, then Worker deploy. Concurrent production deploys queue instead of cancelling mid-flight.
 
 ```bash
-vp run check && vp run test
 vp run build:production
 vp run db:migrate
 vp run deploy:worker
@@ -37,10 +38,9 @@ vp run deploy:worker
 
 ## Staging Deploy
 
-The staging workflow follows the same shape against staging bindings and routes:
+The staging workflow follows the same ship shape against staging bindings and routes:
 
 ```bash
-vp run check && vp run test
 vp run build:staging
 vp run db:migrate:staging
 vp run deploy:worker:staging

--- a/docs/configuration/deployments.mdx
+++ b/docs/configuration/deployments.mdx
@@ -22,13 +22,13 @@ On pull requests (and non-`main` pushes), it installs with Vite+ and runs:
 vp run verify
 ```
 
-`verify` runs the repo's check, test, and build tasks using Vite Task caching. Merges into `main` require the `validate` check to pass.
+`verify` runs the repo's check, test, and build tasks using Vite Task caching. When changes go through a pull request, the `validate` check must be green before merge.
 
 The separate `React Doctor` workflow runs on pull requests and pushes to `main`. It scans changed React files on pull requests, posts inline diagnostics, and records the React Doctor score without folding those comments into the main Vite+ verification job.
 
 ## Production Deploy
 
-Production deploy trusts PR `validate` and ships the production artifact: build, remote D1 migrations, then Worker deploy. Concurrent production deploys queue instead of cancelling mid-flight.
+Production deploy trusts PR `validate` when present and ships the production artifact: build, remote D1 migrations, then Worker deploy. Concurrent production deploys queue instead of cancelling mid-flight. Direct pushes to `main` are still allowed.
 
 ```bash
 vp run build:production


### PR DESCRIPTION
## Summary
- Drop redundant `check && test` from production and staging deploy jobs (PR `validate` / `vp run verify` is the quality gate when using a PR).
- Queue production deploys (`cancel-in-progress: false`) so a newer push cannot abort an in-flight migrate/deploy.
- Update deployments docs to match.
- Branch protection: require green `validate` for PR merges; **no** required PR, force-push still allowed.

## Test plan
- [ ] PR `validate` still runs `vp run verify`
- [ ] After merge, `deploy-production` builds/migrates/deploys without a separate check/test step
- [ ] Direct push to `main` still works
- [ ] PR merge is blocked until `validate` is green