### PR TITLE
ci(actions): verify with staging-shaped build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
     timeout-minutes: 30
     env:
       CLOUDFLARE_VITE_FORCE_LOCAL: "true"
+      # Staging-shaped verify build (no production-only survey id).
+      POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+      POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+      VITE_POSTHOG_HOST: ${{ secrets.VITE_POSTHOG_HOST }}
+      VITE_POSTHOG_PROJECT_TOKEN: ${{ secrets.VITE_POSTHOG_PROJECT_TOKEN }}
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,6 @@ jobs:
     timeout-minutes: 30
     env:
       CLOUDFLARE_VITE_FORCE_LOCAL: "true"
-      # Staging-shaped verify build (no production-only survey id).
-      POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
-      POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
-      VITE_POSTHOG_HOST: ${{ secrets.VITE_POSTHOG_HOST }}
-      VITE_POSTHOG_PROJECT_TOKEN: ${{ secrets.VITE_POSTHOG_PROJECT_TOKEN }}
 
     steps:
       - uses: actions/checkout@v7
@@ -47,8 +42,10 @@ jobs:
           restore-keys: |
             vite-task-${{ runner.os }}-${{ runner.arch }}-
 
+      # Keep shared `vp run verify` / ciBuild generic for local contributors.
+      # CI additionally compiles the staging-shaped Worker config (PostHog optional).
       - name: Verify
-        run: vp run verify
+        run: vp run ciCheck && vp run ciTest && vp run ciBuildStaging
 
       - name: Save Vite Task cache
         if: success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Install dependencies
         run: vp install --frozen-lockfile
 
-      # Quality gates live on PRs (`validate` / `vp run verify`); required when merging via PR.
+      # Quality gates live on PRs (`validate`: check + test + staging-shaped build).
       - name: Build production bundle
         run: vp run build:production
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -18,7 +18,8 @@ jobs:
       url: https://staging.thinkex.app
     concurrency:
       group: deploy-staging
-      cancel-in-progress: true
+      # Queue instead of cancel so a newer push cannot abort an in-flight migrate/deploy.
+      cancel-in-progress: false
 
     env:
       # Runtime and deploy secrets are synced into GitHub Actions secrets from Infisical.
@@ -45,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: vp install --frozen-lockfile
 
-      # Quality gates live on PRs (`validate` / `vp run verify`); staging deploys ship the staging bundle.
+      # Quality gates live on PRs (`validate`: check + test + staging-shaped build).
       - name: Build staging bundle
         env:
           CLOUDFLARE_VITE_FORCE_LOCAL: "true"

--- a/docs/configuration/deployments.mdx
+++ b/docs/configuration/deployments.mdx
@@ -28,7 +28,7 @@ The separate `React Doctor` workflow runs on pull requests and pushes to `main`.
 
 ## Production Deploy
 
-Production deploy trusts PR `validate` when present and ships the production artifact: build, remote D1 migrations, then Worker deploy. Concurrent production deploys queue instead of cancelling mid-flight. Direct pushes to `main` are still allowed.
+Production deploy trusts PR `validate` when present and ships the production artifact: build, remote D1 migrations, then Worker deploy. Concurrent production and staging deploys queue instead of cancelling mid-flight. Direct pushes to `main` are still allowed.
 
 ```bash
 vp run build:production

--- a/docs/configuration/deployments.mdx
+++ b/docs/configuration/deployments.mdx
@@ -16,13 +16,13 @@ ThinkEx deploys from GitHub Actions to Cloudflare Workers. Deploy, migration, an
 
 The `CI` workflow runs on pull requests, pushes to `main`, and manual dispatch.
 
-On pull requests (and non-`main` pushes), it installs with Vite+ and runs:
+On pull requests (and non-`main` pushes), it installs with Vite+ and runs check, test, and a staging-shaped build:
 
 ```bash
-vp run verify
+vp run ciCheck && vp run ciTest && vp run ciBuildStaging
 ```
 
-`verify` runs the repo's check, test, and build tasks using Vite Task caching. The verify build uses the staging-shaped bundle (`build:staging` / `CLOUDFLARE_ENV=staging`) so PR CI exercises real Wrangler env flattening and base PostHog build env, without requiring production-only secrets like the feedback survey id. When changes go through a pull request, the `validate` check must be green before merge.
+`ciBuildStaging` compiles with `CLOUDFLARE_ENV=staging` so PR CI exercises real Wrangler env flattening. PostHog build secrets are optional for that path (analytics stays off when unset); production deploy still requires the full production PostHog set, including the feedback survey id. Local `vp run verify` stays on the generic `ciBuild` (`build:app`) so contributors without Infisical are unaffected. When changes go through a pull request, the `validate` check must be green before merge.
 
 The separate `React Doctor` workflow runs on pull requests and pushes to `main`. It scans changed React files on pull requests, posts inline diagnostics, and records the React Doctor score without folding those comments into the main Vite+ verification job.
 

--- a/docs/configuration/deployments.mdx
+++ b/docs/configuration/deployments.mdx
@@ -22,7 +22,7 @@ On pull requests (and non-`main` pushes), it installs with Vite+ and runs:
 vp run verify
 ```
 
-`verify` runs the repo's check, test, and build tasks using Vite Task caching. When changes go through a pull request, the `validate` check must be green before merge.
+`verify` runs the repo's check, test, and build tasks using Vite Task caching. The verify build uses the staging-shaped bundle (`build:staging` / `CLOUDFLARE_ENV=staging`) so PR CI exercises real Wrangler env flattening and base PostHog build env, without requiring production-only secrets like the feedback survey id. When changes go through a pull request, the `validate` check must be green before merge.
 
 The separate `React Doctor` workflow runs on pull requests and pushes to `main`. It scans changed React files on pull requests, posts inline diagnostics, and records the React Doctor score without folding those comments into the main Vite+ verification job.
 

--- a/src/features/workspaces/components/ai-chat/AiChatAttachmentItem.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatAttachmentItem.tsx
@@ -18,7 +18,6 @@ import {
 	AttachmentGroup,
 	AttachmentMedia,
 	AttachmentTitle,
-	AttachmentTrigger,
 } from "#/components/ui/attachment";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "#/components/ui/dialog";
 import { Skeleton } from "#/components/ui/skeleton";
@@ -82,14 +81,14 @@ function AiChatImageAttachment({
 
 	return (
 		<>
-			<Attachment
-				className={imageUrl ? "cursor-zoom-in focus-within:ring-2" : undefined}
-				orientation="vertical"
-				size="default"
-				state={getAttachmentState(data)}
-			>
-				<AttachmentMedia variant="image">
-					{imageUrl ? (
+			<div className="relative size-24 shrink-0" data-slot="attachment">
+				{imageUrl ? (
+					<button
+						aria-label={`Preview ${label}`}
+						className="size-full cursor-zoom-in overflow-hidden rounded-xl focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none"
+						onClick={() => setIsOpen(true)}
+						type="button"
+					>
 						<img
 							alt={label}
 							className="size-full object-cover"
@@ -97,18 +96,27 @@ function AiChatImageAttachment({
 							src={imageUrl}
 							width={96}
 						/>
-					) : (
-						<>
-							<Skeleton aria-hidden="true" className="size-full rounded-none bg-foreground/10" />
-							<span className="sr-only">Preparing {label}</span>
-						</>
-					)}
-				</AttachmentMedia>
-				{imageUrl ? (
-					<AttachmentTrigger aria-label={`Preview ${label}`} onClick={() => setIsOpen(true)} />
+					</button>
+				) : (
+					<div className="size-full overflow-hidden rounded-xl">
+						<Skeleton aria-hidden="true" className="size-full rounded-none bg-foreground/10" />
+						<span className="sr-only">Preparing {label}</span>
+					</div>
+				)}
+				{onRemove ? (
+					<button
+						aria-label={`Remove ${label}`}
+						className="absolute top-1 right-1 z-10 flex size-6 items-center justify-center rounded-full bg-black/60 text-white hover:bg-black/75"
+						onClick={(event) => {
+							event.stopPropagation();
+							onRemove();
+						}}
+						type="button"
+					>
+						<XIcon className="size-3.5" />
+					</button>
 				) : null}
-				<AiChatAttachmentRemoveAction data={data} onRemove={onRemove} />
-			</Attachment>
+			</div>
 
 			{imageUrl ? (
 				<Dialog open={isOpen} onOpenChange={setIsOpen}>
@@ -131,20 +139,6 @@ function AiChatAttachmentMedia({ data }: { data: AttachmentData }) {
 		return (
 			<AttachmentMedia>
 				<Spinner className="size-3.5" />
-			</AttachmentMedia>
-		);
-	}
-
-	if (data.type === "file" && data.url && getMediaCategory(data) === "image") {
-		return (
-			<AttachmentMedia variant="image">
-				<img
-					alt={getAttachmentLabel(data)}
-					className="size-full object-cover"
-					height={40}
-					src={data.url}
-					width={40}
-				/>
 			</AttachmentMedia>
 		);
 	}

--- a/src/features/workspaces/components/ai-chat/AiChatPromptContextBar.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatPromptContextBar.tsx
@@ -1,3 +1,6 @@
+import { LazyMotion, domAnimation, m } from "motion/react";
+import { useCallback, useEffect, useState } from "react";
+
 import { usePromptInputAttachments } from "#/features/workspaces/components/ai-chat/ai-chat-prompt-input";
 import AiChatPromptAttachments from "#/features/workspaces/components/ai-chat/AiChatPromptAttachments";
 import WorkspaceAiChatContextChips from "#/features/workspaces/components/ai-chat/WorkspaceAiChatContextChips";
@@ -6,20 +9,53 @@ import {
 	type WorkspaceAiContextScope,
 } from "#/features/workspaces/model/workspace-ai-context";
 
+const contextBarTransition = { duration: 0.22, ease: [0.22, 1, 0.36, 1] as const };
+
 export default function AiChatPromptContextBar({ context }: { context: WorkspaceAiContextScope }) {
 	const attachments = usePromptInputAttachments();
 	const hasAttachments = attachments.files.length > 0;
 	const hasWorkspaceContext =
 		getWorkspaceAiContextChips(context).length > 0 || context.selectedQuotes.length > 0;
+	const visible = hasAttachments || hasWorkspaceContext;
 
-	if (!hasAttachments && !hasWorkspaceContext) {
-		return null;
-	}
+	const [contentNode, setContentNode] = useState<HTMLDivElement | null>(null);
+	const [height, setHeight] = useState<number | "auto">("auto");
+	const contentRef = useCallback((node: HTMLDivElement | null) => {
+		setContentNode(node);
+	}, []);
+
+	useEffect(() => {
+		if (!contentNode) {
+			return;
+		}
+
+		const updateHeight = () => {
+			setHeight(contentNode.getBoundingClientRect().height);
+		};
+
+		updateHeight();
+		const observer = new ResizeObserver(updateHeight);
+		observer.observe(contentNode);
+		return () => observer.disconnect();
+	}, [contentNode]);
 
 	return (
-		<div className="flex w-full min-w-0 flex-col gap-3">
-			<AiChatPromptAttachments />
-			<WorkspaceAiChatContextChips context={context} />
-		</div>
+		<LazyMotion features={domAnimation}>
+			<m.div
+				animate={{ height }}
+				className="w-full min-w-0 overflow-hidden"
+				initial={false}
+				transition={contextBarTransition}
+			>
+				<div ref={contentRef} className="w-full min-w-0">
+					{visible ? (
+						<div className="flex w-full min-w-0 flex-col gap-3 pt-3">
+							<AiChatPromptAttachments />
+							<WorkspaceAiChatContextChips context={context} />
+						</div>
+					) : null}
+				</div>
+			</m.div>
+		</LazyMotion>
 	);
 }

--- a/src/features/workspaces/components/ai-chat/AiChatPromptInput.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatPromptInput.tsx
@@ -47,7 +47,7 @@ import { cn } from "#/lib/utils";
 const PROMPT_INPUT_GROUP_CLASSNAME =
 	"h-auto flex-col border-border/70 bg-muted/30 shadow-none dark:bg-muted/30";
 const PROMPT_INPUT_INLINE_PADDING = "px-3.5";
-const PROMPT_INPUT_HEADER_PADDING = "px-3.5 pt-3 pb-1";
+const PROMPT_INPUT_HEADER_PADDING = "px-3.5 pb-1";
 const PROMPT_INPUT_FOOTER_PADDING = "pl-2 pr-3.5 pt-1 pb-2";
 const CHAT_ATTACHMENT_PICKER_ACCEPT = [
 	...new Set([WORKSPACE_AI_CHAT_ATTACHMENT_POLICY.accept, ...workspaceUploadAccept.split(",")]),

--- a/src/features/workspaces/components/ai-chat/WorkspaceAiChatContextChips.tsx
+++ b/src/features/workspaces/components/ai-chat/WorkspaceAiChatContextChips.tsx
@@ -225,7 +225,7 @@ function getWorkspaceAiChatContextChipIcon(item: WorkspaceItem): {
 
 function getWorkspaceAiChatContextChipClassName(className?: string) {
 	return cn(
-		"flex min-h-6 min-w-0 max-w-48 items-center gap-1 rounded-md bg-muted px-1 py-0.5 text-xs dark:bg-input/30",
+		"flex min-h-6 min-w-0 max-w-48 items-center gap-1 rounded-full bg-muted px-1 py-0.5 text-xs dark:bg-input/30",
 		"outline-none focus-visible:ring-2 focus-visible:ring-ring",
 		className,
 	);

--- a/src/integrations/posthog/build.test.ts
+++ b/src/integrations/posthog/build.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { assertRequiredPostHogBuildEnv } from "./build";
+
+const POSTHOG_BUILD_ENV = [
+	"CLOUDFLARE_ENV",
+	"VITE_POSTHOG_PROJECT_TOKEN",
+	"VITE_POSTHOG_HOST",
+	"POSTHOG_API_KEY",
+	"POSTHOG_PROJECT_ID",
+	"VITE_POSTHOG_FEEDBACK_SURVEY_ID",
+] as const;
+
+afterEach(() => {
+	for (const name of POSTHOG_BUILD_ENV) {
+		delete process.env[name];
+	}
+});
+
+describe("assertRequiredPostHogBuildEnv", () => {
+	it("allows staging builds with no PostHog env", () => {
+		process.env.CLOUDFLARE_ENV = "staging";
+		expect(() => assertRequiredPostHogBuildEnv("build")).not.toThrow();
+	});
+
+	it("requires the full staging PostHog set when any staging value is present", () => {
+		process.env.CLOUDFLARE_ENV = "staging";
+		process.env.VITE_POSTHOG_HOST = "https://us.i.posthog.com";
+		expect(() => assertRequiredPostHogBuildEnv("build")).toThrow(
+			/Missing required environment variables/,
+		);
+	});
+
+	it("requires production PostHog env including the survey id", () => {
+		process.env.CLOUDFLARE_ENV = "production";
+		expect(() => assertRequiredPostHogBuildEnv("build")).toThrow(/VITE_POSTHOG_FEEDBACK_SURVEY_ID/);
+	});
+});

--- a/src/integrations/posthog/build.ts
+++ b/src/integrations/posthog/build.ts
@@ -31,6 +31,12 @@ export function assertRequiredPostHogBuildEnv(command: string) {
 		return typeof value !== "string" || value.trim().length === 0;
 	});
 
+	// Staging-shaped builds (CI/local) may omit PostHog entirely; analytics stays off.
+	// If any staging PostHog var is set, require the full staging set.
+	if (cloudflareEnv === "staging" && missing.length === requiredEnv.length) {
+		return;
+	}
+
 	if (missing.length > 0) {
 		throw new Error(`Missing required environment variables: ${missing.join(", ")}`);
 	}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,12 @@ export default defineConfig(({ command }) => {
 				ciCheck: "vp check",
 				ciTest: "vp test --run",
 				ciBuild: {
+					command: "node --run build:app",
+					untrackedEnv: ["INIT_CWD"],
+					input: [{ auto: true }, "!dist/**"],
+					output: ["dist/**"],
+				},
+				ciBuildStaging: {
 					command: "node --run build:staging",
 					untrackedEnv: ["INIT_CWD"],
 					input: [{ auto: true }, "!dist/**"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig(({ command }) => {
 				ciCheck: "vp check",
 				ciTest: "vp test --run",
 				ciBuild: {
-					command: "node --run build:app",
+					command: "node --run build:staging",
 					untrackedEnv: ["INIT_CWD"],
 					input: [{ auto: true }, "!dist/**"],
 					output: ["dist/**"],


### PR DESCRIPTION
## Summary
- PR `validate` runs `ciCheck` + `ciTest` + `ciBuildStaging` (staging Wrangler env flattening).
- Shared `ciBuild` / local `vp run verify` stays on generic `build:app` (no Infisical required).
- Staging PostHog assert: all-missing is OK; partial set still fails. Production stays strict (incl. survey).
- Dropped ineffective repo-secret injection from `validate` (PostHog secrets live in GitHub Environments only).

## Test plan
- [ ] PR `validate` passes without PostHog secrets
- [ ] Local `vp run verify` still works without PostHog/Infisical
- [ ] Staging/prod deploys with secrets still enforce PostHog requirements
- [ ] Unit tests in `src/integrations/posthog/build.test.ts` pass