### PR TITLE
fix(documents): hydrate session before RPC reads and edits

### DIFF
--- a/src/features/workspaces/collaborative-content-session.ts
+++ b/src/features/workspaces/collaborative-content-session.ts
@@ -1,0 +1,31 @@
+import { YServer } from "y-partyserver";
+
+/**
+ * Base for collaborative session Durable Objects whose canonical content lives
+ * in an in-memory Yjs document that `onLoad` hydrates from durable storage.
+ *
+ * These sessions are reached two ways. Browser editors connect over
+ * `fetch`/WebSocket, which runs `onStart` — and therefore `onLoad` — before any
+ * handler touches the document. Server tools instead call methods directly over
+ * native Durable Object RPC, which does not run `onStart`. A content method
+ * invoked cold via RPC would read or edit a freshly constructed, empty document:
+ * returning blank content, or checkpointing an empty document over real content.
+ *
+ * Any RPC method that reads or writes the document must `await
+ * this.ensureLoaded()` first. Methods that only touch durable storage (deletion,
+ * for example) must not, so hydration stays opt-in per method rather than a
+ * blanket cost. New editable item types extend this base so the guarantee — and
+ * the reasoning behind it — live in one place.
+ */
+export abstract class CollaborativeContentSession extends YServer {
+	/**
+	 * Runs `onStart`/`onLoad` for this instance if they have not already. Cheap
+	 * and idempotent once started. `__unsafe_ensureInitialized` is the framework's
+	 * sanctioned escape hatch for Durable Objects reached via native RPC; keeping
+	 * the single call here means content methods never touch an unhydrated
+	 * document and the rationale is not repeated at every call site.
+	 */
+	protected async ensureLoaded(): Promise<void> {
+		await this.__unsafe_ensureInitialized();
+	}
+}

--- a/src/features/workspaces/documents/document-session.ts
+++ b/src/features/workspaces/documents/document-session.ts
@@ -4,9 +4,9 @@ import {
 	yDocToProsemirrorJSON,
 } from "@tiptap/y-tiptap";
 import type { Connection, ConnectionContext } from "partyserver";
-import { YServer } from "y-partyserver";
 import * as Y from "yjs";
 import type { DocumentSessionRouteParams } from "#/features/workspaces/agent-routes";
+import { CollaborativeContentSession } from "#/features/workspaces/collaborative-content-session";
 import {
 	parseMarkdownToTiptapDocumentProjection,
 	serializeTiptapDocumentToMarkdown,
@@ -62,7 +62,7 @@ export interface DocumentSessionApplyMarkdownEditsResult {
 	warnings: string[];
 }
 
-export class DocumentSession extends YServer {
+export class DocumentSession extends CollaborativeContentSession {
 	static override options = {
 		hibernate: true,
 	};
@@ -131,6 +131,7 @@ export class DocumentSession extends YServer {
 	async applyMarkdownEdits(
 		input: DocumentSessionApplyMarkdownEditsInput,
 	): Promise<DocumentSessionApplyMarkdownEditsResult> {
+		await this.ensureLoaded();
 		const currentDocument = this.getCurrentTiptapDocument();
 		const markdown = serializeTiptapDocumentToMarkdown(currentDocument);
 		const editResult = applyDocumentMarkdownEdits(markdown, input.edits);
@@ -176,6 +177,7 @@ export class DocumentSession extends YServer {
 	async readMarkdownChunk(
 		input: DocumentMarkdownChunkReadInput,
 	): Promise<DocumentMarkdownChunkReadResult> {
+		await this.ensureLoaded();
 		const stateVector = Uint8Array.from(Y.encodeStateVector(this.document));
 		let currentSnapshot = this.markdownSnapshot;
 		if (!currentSnapshot || !uint8ArraysEqual(currentSnapshot.stateVector, stateVector)) {
@@ -198,6 +200,8 @@ export class DocumentSession extends YServer {
 	}
 
 	async purgeForDeletion(): Promise<void> {
+		// Deliberately no ensureLoaded(): this only wipes durable storage, so
+		// hydrating the in-memory document first would be wasted work.
 		await this.ctx.storage.deleteAll();
 	}
 


### PR DESCRIPTION
## Problem

The AI reads and edits collaborative documents by calling `DocumentSession` over **native Durable Object RPC** (`getByName(...).readMarkdownChunk(...)` / `.applyMarkdownEdits(...)`).

Native DO RPC bypasses partyserver's `onStart`/`onLoad`. `DocumentSession` sets `hibernate: true` and keeps its canonical content as an in-memory Yjs document that only `onLoad` hydrates. So against a hibernated session:

- **`readMarkdownChunk`** serialized a fresh, empty document → the AI saw the document as **empty until the user opened it in a browser** (the WebSocket connects over `fetch`, which runs `onLoad` and hydrates).
- **`applyMarkdownEdits`** could edit that empty document and checkpoint it back to the kernel — **overwriting real content**. (data-loss risk)

Only documents are affected. PDFs/images/folders read from durable SQL + R2 directly, with no in-memory hydration step, so a cold DO returns real data.

## Fix

- New `CollaborativeContentSession` base for session DOs whose content is a hydrated in-memory Yjs document. It exposes `ensureLoaded()` around partyserver's sanctioned init escape hatch, with the reasoning documented once.
- `DocumentSession` awaits `ensureLoaded()` before every RPC method that touches the document. `purgeForDeletion` deliberately does not (it only wipes storage).
- Future editable item types (flashcards, etc.) extend the same base, so the guarantee is inherited rather than rediscovered per type.

## Testing

- `tsc`, lint, full unit suite (195) green.
- A faithful cold-RPC regression test is non-trivial here: `onLoad` is coupled to the kernel checkpoint and reproducing "cold RPC skips onStart" in the workers test pool has no existing precedent. Flagging as a follow-up rather than shipping a fragile/falsely-green test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787977431&installation_model_id=425282&pr_number=698&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F698&signature=58761fcdcd1088df0a7db05376432039be0b66762fc49bf9577f4173fad3de4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collaborative document reliability by ensuring document content is loaded before reading or applying edits.
  * Streamlined document deletion so storage can be cleared without unnecessarily loading document content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->