### PR TITLE
fix(billing): create Autumn customers before balances.check

### DIFF
--- a/src/integrations/autumn/client.server.ts
+++ b/src/integrations/autumn/client.server.ts
@@ -76,6 +76,32 @@ function getNamedCustomerFields(row: { email: string; name: string }) {
 	};
 }
 
+/**
+ * Autumn rejects balances.check / balances.track for unknown customers
+ * (`customer_not_found`). Track and billing already called get_or_create; the
+ * access gates must too, or a user who has never been billed 404s on their
+ * first check, fail-opens, and lands in PostHog (ThinkEx-OSS/thinkex#727).
+ *
+ * Returns the resolved secret key so callers can keep going without a second
+ * env lookup, or undefined when billing is not configured.
+ */
+export async function ensureAutumnCustomer(input: {
+	env: Cloudflare.Env;
+	userId: string;
+}): Promise<string | undefined> {
+	const secretKey = resolveAutumnSecretKey(input.env);
+
+	if (!secretKey) {
+		return undefined;
+	}
+
+	const customerFields = await getAutumnCustomerFields(input.userId);
+
+	await getOrCreateAutumnCustomer({ customerId: input.userId, secretKey, ...customerFields });
+
+	return secretKey;
+}
+
 export interface TrackAutumnUsageInput {
 	env: Cloudflare.Env;
 	/** Operational event name, used for both the partial log and the failure. */
@@ -92,18 +118,14 @@ export interface TrackAutumnUsageInput {
  * every metered feature — only the feature id and properties differ.
  */
 export async function trackAutumnUsage(input: TrackAutumnUsageInput) {
-	const secretKey = resolveAutumnSecretKey(input.env);
-
-	if (!secretKey) {
-		return;
-	}
-
 	const fields = { ...input.properties, feature_id: input.featureId, user_id: input.userId };
 
 	try {
-		const customerFields = await getAutumnCustomerFields(input.userId);
+		const secretKey = await ensureAutumnCustomer({ env: input.env, userId: input.userId });
 
-		await getOrCreateAutumnCustomer({ customerId: input.userId, secretKey, ...customerFields });
+		if (!secretKey) {
+			return;
+		}
 
 		await trackAutumnBalance({
 			customerId: input.userId,

--- a/src/integrations/autumn/workspace-ai-usage.test.ts
+++ b/src/integrations/autumn/workspace-ai-usage.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { checkWorkspaceAiMessageAccess } from "#/integrations/autumn/workspace-ai-usage";
+
+const CUSTOMER_ID = "tZ4W20sCB3qPZwIf7Bf5F64bOUhz2P0l";
+const CUSTOMER_NOT_FOUND_BODY = JSON.stringify({
+	message: `Customer ${CUSTOMER_ID} not found`,
+	code: "customer_not_found",
+	env: "live",
+});
+
+const autumnPaths: string[] = [];
+const operationalFailures: Array<{ error: unknown; event: string }> = [];
+
+vi.mock("#/db/server", () => ({
+	createDbContext: async () => {
+		throw new Error("no db in unit test");
+	},
+}));
+
+vi.mock("#/integrations/observability/operational-events", () => ({
+	recordOperationalFailure: (input: { error: unknown; event: string }) => {
+		operationalFailures.push({ error: input.error, event: input.event });
+	},
+}));
+
+vi.mock("#/integrations/posthog/server", () => ({
+	capturePostHogServerEvent: vi.fn(),
+}));
+
+function autumnPathFromUrl(url: string) {
+	return url.replace("https://api.useautumn.com/v1/", "");
+}
+
+describe("checkWorkspaceAiMessageAccess", () => {
+	beforeEach(() => {
+		autumnPaths.length = 0;
+		operationalFailures.length = 0;
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = String(input);
+				const path = autumnPathFromUrl(url);
+				autumnPaths.push(path);
+
+				if (path === "customers.get_or_create") {
+					return new Response(
+						JSON.stringify({
+							id: CUSTOMER_ID,
+							balances: {
+								standard_messages: { granted: 50, next_reset_at: null, remaining: 50 },
+								premium_messages: { granted: 10, next_reset_at: null, remaining: 10 },
+							},
+							subscriptions: [],
+						}),
+						{ status: 200, headers: { "content-type": "application/json" } },
+					);
+				}
+
+				if (path === "balances.check") {
+					const body = JSON.parse(String(init?.body ?? "{}")) as { customer_id?: string };
+
+					// Reproduce the production 404: Autumn rejects check when the
+					// customer was never created. get_or_create above would have made
+					// this path succeed — so a call sequence that hits this branch means
+					// the access check skipped ensure-customer.
+					if (body.customer_id === CUSTOMER_ID && !autumnPaths.includes("customers.get_or_create")) {
+						return new Response(CUSTOMER_NOT_FOUND_BODY, {
+							status: 404,
+							headers: { "content-type": "application/json" },
+						});
+					}
+
+					return new Response(JSON.stringify({ allowed: true, balance: null }), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					});
+				}
+
+				throw new Error(`Unexpected Autumn path: ${path}`);
+			}),
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.clearAllMocks();
+	});
+
+	// Regression for ThinkEx-OSS/thinkex#727: balances.check 404 customer_not_found.
+	// Autumn requires customers.get_or_create before check; track/billing already do
+	// that, but the AI access gate did not — so a user who has never been billed
+	// throws on their first message check, gets fail-opened, and lands in PostHog.
+	it("ensures the Autumn customer exists before balances.check", async () => {
+		const access = await checkWorkspaceAiMessageAccess({
+			env: { AUTUMN_PROD_SECRET_KEY: "am_sk_live_test" } as Cloudflare.Env,
+			modelId: "auto",
+			userId: CUSTOMER_ID,
+		});
+
+		expect(access).toEqual({ allowed: true, modelId: "auto" });
+		expect(autumnPaths[0]).toBe("customers.get_or_create");
+		expect(autumnPaths).toContain("balances.check");
+		// DB is stubbed out above, so autumn_customer_fields may log; the access
+		// check itself must not.
+		expect(operationalFailures.map((failure) => failure.event)).not.toContain(
+			"workspace_ai_access_check",
+		);
+	});
+});

--- a/src/integrations/autumn/workspace-ai-usage.ts
+++ b/src/integrations/autumn/workspace-ai-usage.ts
@@ -7,9 +7,8 @@ import {
 	WORKSPACE_AI_MESSAGE_FEATURE_IDS,
 	type WorkspaceAiMessageAccess,
 } from "#/integrations/autumn/workspace-ai-access";
-import { trackAutumnUsage } from "#/integrations/autumn/client.server";
+import { ensureAutumnCustomer, trackAutumnUsage } from "#/integrations/autumn/client.server";
 import { checkAutumnBalance } from "#/integrations/autumn/rest";
-import { resolveAutumnSecretKey } from "#/integrations/autumn/secret-key";
 import { recordOperationalFailure } from "#/integrations/observability/operational-events";
 import { capturePostHogServerEvent } from "#/integrations/posthog/server";
 
@@ -30,17 +29,17 @@ export interface CheckWorkspaceAiMessageAccessInput {
 export async function checkWorkspaceAiMessageAccess(
 	input: CheckWorkspaceAiMessageAccessInput,
 ): Promise<WorkspaceAiMessageAccess> {
-	const secretKey = resolveAutumnSecretKey(input.env);
-
-	// No key configured means no plans to enforce — never gate on infrastructure.
-	if (!secretKey) {
-		return { allowed: true, modelId: input.modelId };
-	}
-
 	const chosenTier = getWorkspaceAiChatModelById(input.modelId).billingTier;
 	const otherTier = chosenTier === "premium" ? "standard" : "premium";
 
 	try {
+		const secretKey = await ensureAutumnCustomer({ env: input.env, userId: input.userId });
+
+		// No key configured means no plans to enforce — never gate on infrastructure.
+		if (!secretKey) {
+			return { allowed: true, modelId: input.modelId };
+		}
+
 		const chosen = await checkAutumnBalance({
 			customerId: input.userId,
 			featureId: WORKSPACE_AI_MESSAGE_FEATURE_IDS[chosenTier],

--- a/src/integrations/autumn/workspace-file-usage.test.ts
+++ b/src/integrations/autumn/workspace-file-usage.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { checkWorkspaceFileUploadAccess } from "#/integrations/autumn/workspace-file-usage";
+
+const CUSTOMER_ID = "tZ4W20sCB3qPZwIf7Bf5F64bOUhz2P0l";
+const CUSTOMER_NOT_FOUND_BODY = JSON.stringify({
+	message: `Customer ${CUSTOMER_ID} not found`,
+	code: "customer_not_found",
+	env: "live",
+});
+
+const autumnPaths: string[] = [];
+const operationalFailures: Array<{ error: unknown; event: string }> = [];
+
+vi.mock("#/db/server", () => ({
+	createDbContext: async () => {
+		throw new Error("no db in unit test");
+	},
+}));
+
+vi.mock("#/integrations/observability/operational-events", () => ({
+	recordOperationalFailure: (input: { error: unknown; event: string }) => {
+		operationalFailures.push({ error: input.error, event: input.event });
+	},
+}));
+
+vi.mock("#/integrations/posthog/server", () => ({
+	capturePostHogServerEvent: vi.fn(),
+}));
+
+function autumnPathFromUrl(url: string) {
+	return url.replace("https://api.useautumn.com/v1/", "");
+}
+
+describe("checkWorkspaceFileUploadAccess", () => {
+	beforeEach(() => {
+		autumnPaths.length = 0;
+		operationalFailures.length = 0;
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = String(input);
+				const path = autumnPathFromUrl(url);
+				autumnPaths.push(path);
+
+				if (path === "customers.get_or_create") {
+					return new Response(
+						JSON.stringify({
+							id: CUSTOMER_ID,
+							balances: {
+								file_uploads: { granted: 20, next_reset_at: null, remaining: 20 },
+							},
+							subscriptions: [],
+						}),
+						{ status: 200, headers: { "content-type": "application/json" } },
+					);
+				}
+
+				if (path === "balances.check") {
+					const body = JSON.parse(String(init?.body ?? "{}")) as { customer_id?: string };
+
+					if (body.customer_id === CUSTOMER_ID && !autumnPaths.includes("customers.get_or_create")) {
+						return new Response(CUSTOMER_NOT_FOUND_BODY, {
+							status: 404,
+							headers: { "content-type": "application/json" },
+						});
+					}
+
+					return new Response(JSON.stringify({ allowed: true, balance: null }), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					});
+				}
+
+				throw new Error(`Unexpected Autumn path: ${path}`);
+			}),
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.clearAllMocks();
+	});
+
+	it("ensures the Autumn customer exists before balances.check", async () => {
+		const access = await checkWorkspaceFileUploadAccess({
+			env: { AUTUMN_PROD_SECRET_KEY: "am_sk_live_test" } as Cloudflare.Env,
+			userId: CUSTOMER_ID,
+		});
+
+		expect(access).toEqual({ allowed: true });
+		expect(autumnPaths[0]).toBe("customers.get_or_create");
+		expect(autumnPaths).toContain("balances.check");
+		expect(operationalFailures.map((failure) => failure.event)).not.toContain(
+			"workspace_file_upload_access_check",
+		);
+	});
+});

--- a/src/integrations/autumn/workspace-file-usage.ts
+++ b/src/integrations/autumn/workspace-file-usage.ts
@@ -1,6 +1,5 @@
-import { trackAutumnUsage } from "#/integrations/autumn/client.server";
+import { ensureAutumnCustomer, trackAutumnUsage } from "#/integrations/autumn/client.server";
 import { checkAutumnBalance } from "#/integrations/autumn/rest";
-import { resolveAutumnSecretKey } from "#/integrations/autumn/secret-key";
 import { recordOperationalFailure } from "#/integrations/observability/operational-events";
 import { capturePostHogServerEvent } from "#/integrations/posthog/server";
 
@@ -65,13 +64,13 @@ export type WorkspaceFileUploadAccess =
 export async function checkWorkspaceFileUploadAccess(
 	input: CheckWorkspaceFileUploadAccessInput,
 ): Promise<WorkspaceFileUploadAccess> {
-	const secretKey = resolveAutumnSecretKey(input.env);
-
-	if (!secretKey) {
-		return { allowed: true };
-	}
-
 	try {
+		const secretKey = await ensureAutumnCustomer({ env: input.env, userId: input.userId });
+
+		if (!secretKey) {
+			return { allowed: true };
+		}
+
 		const result = await checkAutumnBalance({
 			customerId: input.userId,
 			featureId: WORKSPACE_FILE_UPLOAD_FEATURE_ID,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#727](https://github.com/ThinkEx-OSS/thinkex/issues/727).

**True / not PostHog noise.** `posthog[bot]` only surfaced a real production exception: Autumn `balances.check` returned `404 customer_not_found` for user `tZ4W20sCB3qPZwIf7Bf5F64bOUhz2P0l` in `live`. Our fail-open path recorded that via `recordOperationalFailure` → PostHog error tracking → GitHub issue.

**Root cause:** AI message and file-upload access gates called `balances.check` without ensuring the Autumn customer existed first. Track and the billing panel already used `customers.get_or_create`. Autumn requires the customer to exist before check/track (especially after they stopped auto-creating on those endpoints). Removing the better-auth Autumn plugin made this worse: signup no longer creates customers, so a brand-new user 404s on their first access check.

**User impact before fix:** chat/upload still worked (fail-open), but every first check for an unknown customer threw, skipped real allowance enforcement for that request, and spammed PostHog.

## Changes

- Add shared `ensureAutumnCustomer` and call it from AI + file upload access checks (and reuse it in track)
- Regression tests that reproduce the exact `#727` payload and assert `customers.get_or_create` runs before `balances.check`

## Test plan

- [x] `pnpm exec vitest --run --project=node src/integrations/autumn/workspace-ai-usage.test.ts src/integrations/autumn/workspace-file-usage.test.ts src/integrations/autumn/workspace-ai-access.test.ts`
- [ ] After deploy: confirm `#727`-style `customer_not_found` errors stop for new users on first AI message / file upload
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcebb-3e53-743f-9f1f-951cb19de17e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcebb-3e53-743f-9f1f-951cb19de17e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788472070&installation_model_id=425282&pr_number=728&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F728&signature=a04f25d8c5132e93f22a19981c0bb63113bcda6c97c2d8b49316ee21054effc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

