### PR TITLE
chore(containers): ship the LiteParse page-ceiling image

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -312,7 +312,7 @@
 				},
 				{
 					"class_name": "WorkspaceFileProcessor",
-					"image": "registry.cloudflare.com/676650ed1ca37ffdeba997fb2a7fa24a/thinkex-liteparsepdfextractor-production@sha256:c48cadd235f934e07d4616414c4718ddeafcd3dcff6342022368e3e7593fc90a",
+					"image": "registry.cloudflare.com/676650ed1ca37ffdeba997fb2a7fa24a/thinkex-liteparsepdfextractor-production@sha256:6f5ce1241aa607fd4b12588656aa587974352fe4a0eff3f0e526dbf78a78da49",
 					"instance_type": "standard-2",
 					"max_instances": 2,
 				},
@@ -443,7 +443,7 @@
 				},
 				{
 					"class_name": "WorkspaceFileProcessor",
-					"image": "registry.cloudflare.com/676650ed1ca37ffdeba997fb2a7fa24a/thinkex-liteparsepdfextractor-production@sha256:c48cadd235f934e07d4616414c4718ddeafcd3dcff6342022368e3e7593fc90a",
+					"image": "registry.cloudflare.com/676650ed1ca37ffdeba997fb2a7fa24a/thinkex-liteparsepdfextractor-production@sha256:6f5ce1241aa607fd4b12588656aa587974352fe4a0eff3f0e526dbf78a78da49",
 					"instance_type": "standard-2",
 					"max_instances": 2,
 					"name": "thinkex-liteparsepdfextractor-production",


### PR DESCRIPTION
#744 merged the container-side fixes but could not ship them: staging and production pin the extractor image by **digest**, and Workers Builds deploys the Worker without rebuilding a pinned container. Production is still silently truncating long PDFs at 1,000 pages.

This bumps the pin to an image built from the merge commit.

`c48cadd2` → `6f5ce124`

## What the new image contains

- explicit **5,000-page ceiling** (LiteParse otherwise defaults to 1,000 and truncates without reporting it)
- **422 refusal** for documents no tier can read — too long, encrypted, damaged — which the workflow now treats as terminal instead of buying an identical verdict from a paid provider on every reconciler sweep
- **concurrency gate**: each parse can hold gigabytes resident, so a third concurrent parse gets a retryable 503 rather than risking an OOM that kills every in-flight request

## Verified against the pushed artifact, not a local rebuild

- `Arch=amd64 OS=linux` — wrangler cross-compiled correctly from an arm64 host, which is the failure mode worth catching here
- digest resolves in the Cloudflare registry
- real 8-page PDF parses end to end (`status 200`, 8 pages)
- 3 concurrent parses → **one 503, two 200s**, exactly the intended gate
- `pnpm check` clean; both staging and production pins updated together, other images untouched

## Note

Only the extractor image moves. The dev config builds from the Dockerfile and is unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788733571&installation_model_id=425282&pr_number=745&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F745&signature=3f47f91e2c5abeeb247a4ecaf4afd2b249c820e22f175968c0597516f4df4688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned Workspace File Processor container image for staging and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->