### PR TITLE
style(workspaces): soften theme art to 80% opacity

### DIFF
--- a/src/features/workspaces/components/WorkspaceCard.tsx
+++ b/src/features/workspaces/components/WorkspaceCard.tsx
@@ -56,7 +56,7 @@ export default function WorkspaceCard({ workspace, className, search }: Workspac
 						// starts in roughly the right hue and the illustration resolves
 						// onto it instead of popping out of an empty rectangle.
 						className={cn(
-							"aspect-[5/2] w-full object-cover opacity-85 transition-[filter,opacity] duration-200 group-hover/card:opacity-100 group-hover/card:brightness-90",
+							"aspect-[5/2] w-full object-cover opacity-80 transition-[filter,opacity] duration-200 group-hover/card:opacity-100 group-hover/card:brightness-90",
 							color.bg,
 						)}
 					/>


### PR DESCRIPTION
One-line follow-up to #748: theme art on the workspace card drops from `opacity-85` to `opacity-80`.

Hover still lifts to full opacity. No behavioural change, no migration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788890125&installation_model_id=425282&pr_number=749&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F749&signature=4a867c5c6aa72b24ff68bcd0e088bb7ee096ecd526adeb793cea72948eec4cc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the default opacity of themed workspace artwork for a subtler visual appearance.
  * Hover behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->