### PR TITLE
Make the landing navbar auth aware

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -10,7 +10,11 @@ import { LatestBlogSection } from "#/components/landing/LatestBlogSection";
 import { PricingSection } from "#/components/landing/PricingSection";
 import { useLandingSectionScroll } from "#/components/landing/useLandingSectionScroll";
 
-export default function LandingPage() {
+interface LandingPageProps {
+	signedIn?: boolean;
+}
+
+export default function LandingPage({ signedIn = false }: LandingPageProps) {
 	const scrollRootRef = useLandingSectionScroll();
 
 	return (
@@ -18,7 +22,7 @@ export default function LandingPage() {
 			data-app-shell
 			className="flex h-screen flex-col overflow-hidden bg-background text-foreground dark:bg-black"
 		>
-			<PublicHeader />
+			<PublicHeader signedIn={signedIn} />
 
 			{/* `relative` keeps absolutely positioned descendants (e.g. `sr-only` labels) inside this
 			    scroll container: without it they resolve against the initial containing block, escape

--- a/src/components/PublicHeader.tsx
+++ b/src/components/PublicHeader.tsx
@@ -11,7 +11,11 @@ import { useMarketingHomePath } from "#/components/use-marketing-home-path";
 import { isPlainLeftClick } from "#/lib/plain-link-click";
 import { smoothScrollViewportTop } from "#/lib/smooth-scroll";
 
-export function PublicHeader() {
+interface PublicHeaderProps {
+	signedIn?: boolean;
+}
+
+export function PublicHeader({ signedIn = false }: PublicHeaderProps) {
 	const pathname = useRouterState({ select: (state) => state.location.pathname });
 	const marketingHome = useMarketingHomePath();
 
@@ -49,11 +53,8 @@ export function PublicHeader() {
 
 				<nav className="ml-auto hidden items-center gap-3 lg:flex" aria-label="Account">
 					<ModeToggle className="size-9" />
-					<Button nativeButton={false} render={<Link to="/login" />} variant="outline">
-						Sign in
-					</Button>
-					<Button nativeButton={false} render={<Link to="/login" />}>
-						Get started
+					<Button nativeButton={false} render={<Link to={signedIn ? "/home" : "/login"} />}>
+						{signedIn ? "Home" : "Get started"}
 					</Button>
 				</nav>
 
@@ -86,20 +87,11 @@ export function PublicHeader() {
 								/>
 								<Button
 									nativeButton={false}
-									render={<Link to="/login" />}
-									variant="outline"
+									render={<Link to={signedIn ? "/home" : "/login"} />}
 									size="lg"
 									className="h-12"
 								>
-									Sign in
-								</Button>
-								<Button
-									nativeButton={false}
-									render={<Link to="/login" />}
-									size="lg"
-									className="h-12"
-								>
-									Get started
+									{signedIn ? "Home" : "Get started"}
 								</Button>
 							</div>
 						</SheetContent>

--- a/src/components/PublicHeader.tsx
+++ b/src/components/PublicHeader.tsx
@@ -18,6 +18,8 @@ interface PublicHeaderProps {
 export function PublicHeader({ signedIn = false }: PublicHeaderProps) {
 	const pathname = useRouterState({ select: (state) => state.location.pathname });
 	const marketingHome = useMarketingHomePath();
+	const accountHref = signedIn ? "/home" : "/login";
+	const accountLabel = signedIn ? "Home" : "Get started";
 
 	function handleHomeLogoClick(event: MouseEvent<HTMLAnchorElement>) {
 		if (!isPlainLeftClick(event)) {
@@ -53,8 +55,8 @@ export function PublicHeader({ signedIn = false }: PublicHeaderProps) {
 
 				<nav className="ml-auto hidden items-center gap-3 lg:flex" aria-label="Account">
 					<ModeToggle className="size-9" />
-					<Button nativeButton={false} render={<Link to={signedIn ? "/home" : "/login"} />}>
-						{signedIn ? "Home" : "Get started"}
+					<Button nativeButton={false} render={<Link to={accountHref} />}>
+						{accountLabel}
 					</Button>
 				</nav>
 
@@ -87,11 +89,11 @@ export function PublicHeader({ signedIn = false }: PublicHeaderProps) {
 								/>
 								<Button
 									nativeButton={false}
-									render={<Link to={signedIn ? "/home" : "/login"} />}
+									render={<Link to={accountHref} />}
 									size="lg"
 									className="h-12"
 								>
-									{signedIn ? "Home" : "Get started"}
+									{accountLabel}
 								</Button>
 							</div>
 						</SheetContent>

--- a/src/lib/session-query.ts
+++ b/src/lib/session-query.ts
@@ -19,6 +19,19 @@ export function getAuthSessionQueryOptions() {
 	});
 }
 
+/**
+ * Public routes use auth only to personalize navigation, so an unavailable
+ * session endpoint must not make the page unavailable. Protected routes use
+ * the query options directly and keep their stricter failure behavior.
+ */
+export async function hasClientAuthSessionForPublicRoute(queryClient: QueryClient) {
+	try {
+		return Boolean(await queryClient.ensureQueryData(getAuthSessionQueryOptions()));
+	} catch {
+		return false;
+	}
+}
+
 export function removeAuthSession(queryClient: QueryClient) {
 	queryClient.setQueryData<AuthSession | null>(authSessionQueryKey, null);
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 
 import LandingPage from "#/components/LandingPage";
 import { buildPublicMeta, getAbsoluteUrl } from "#/lib/seo";
-import { getAuthSessionQueryOptions } from "#/lib/session-query";
+import { hasClientAuthSessionForPublicRoute } from "#/lib/session-query";
 
 /** Neither branch of this route may be stored by a shared cache. See below. */
 const UNCACHEABLE = "private, no-store";
@@ -26,12 +26,21 @@ export const Route = createFileRoute("/")({
 		// the server module never enters the browser bundle.
 		const signedIn = import.meta.env.SSR
 			? (await import("#/lib/auth-session-cookie.server")).hasSessionCookie()
-			: Boolean(await context.queryClient.ensureQueryData(getAuthSessionQueryOptions()));
+			: await hasClientAuthSessionForPublicRoute(context.queryClient);
 
 		if (signedIn) {
 			throw redirect({ to: "/home", headers: { "Cache-Control": UNCACHEABLE } });
 		}
 	},
+	head: () => ({
+		meta: buildPublicMeta(),
+		links: [
+			{
+				rel: "canonical",
+				href: getAbsoluteUrl("/"),
+			},
+		],
+	}),
 	/**
 	 * This response depends on a cookie, and Cloudflare's cache key does not
 	 * include cookies. A stored copy would pin whichever branch happened to fill
@@ -42,15 +51,6 @@ export const Route = createFileRoute("/")({
 	 */
 	headers: () => ({
 		"Cache-Control": UNCACHEABLE,
-	}),
-	head: () => ({
-		meta: buildPublicMeta(),
-		links: [
-			{
-				rel: "canonical",
-				href: getAbsoluteUrl("/"),
-			},
-		],
 	}),
 	component: LandingPage,
 });

--- a/src/routes/welcome.tsx
+++ b/src/routes/welcome.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import LandingPage from "#/components/LandingPage";
 import { buildPublicMeta, getAbsoluteUrl } from "#/lib/seo";
-import { getAuthSessionQueryOptions } from "#/lib/session-query";
+import { hasClientAuthSessionForPublicRoute } from "#/lib/session-query";
 
 const UNCACHEABLE = "private, no-store";
 
@@ -22,7 +22,7 @@ export const Route = createFileRoute("/welcome")({
 		// label; `/home` still performs full session validation.
 		return import.meta.env.SSR
 			? (await import("#/lib/auth-session-cookie.server")).hasSessionCookie()
-			: Boolean(await context.queryClient.ensureQueryData(getAuthSessionQueryOptions()));
+			: hasClientAuthSessionForPublicRoute(context.queryClient);
 	},
 	head: () => ({
 		meta: buildPublicMeta(),

--- a/src/routes/welcome.tsx
+++ b/src/routes/welcome.tsx
@@ -2,17 +2,28 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import LandingPage from "#/components/LandingPage";
 import { buildPublicMeta, getAbsoluteUrl } from "#/lib/seo";
+import { getAuthSessionQueryOptions } from "#/lib/session-query";
+
+const UNCACHEABLE = "private, no-store";
 
 /**
- * The marketing page at a path that never checks auth, so it stays reachable
- * once someone is signed in. `/` redirects those visitors to `/home`, which
- * makes it useless as a link target for campaigns, docs, or the site chrome —
- * this is where those should point.
+ * The marketing page at a path that never redirects based on auth, so it stays
+ * reachable once someone is signed in. `/` redirects those visitors to `/home`,
+ * which makes it useless as a link target for campaigns, docs, or the site
+ * chrome — this is where those should point.
  *
  * Deliberately not in `sitemap.xml`, and canonical points at `/`: this is the
  * same content at a second address, and `/` is the URL that ranks.
  */
 export const Route = createFileRoute("/welcome")({
+	loader: async ({ context }) => {
+		// Resolve this before rendering so the account action never swaps after
+		// first paint. Cookie presence is enough for this non-security-sensitive
+		// label; `/home` still performs full session validation.
+		return import.meta.env.SSR
+			? (await import("#/lib/auth-session-cookie.server")).hasSessionCookie()
+			: Boolean(await context.queryClient.ensureQueryData(getAuthSessionQueryOptions()));
+	},
 	head: () => ({
 		meta: buildPublicMeta(),
 		links: [
@@ -22,5 +33,14 @@ export const Route = createFileRoute("/welcome")({
 			},
 		],
 	}),
-	component: LandingPage,
+	headers: () => ({
+		"Cache-Control": UNCACHEABLE,
+	}),
+	component: WelcomeLandingPage,
 });
+
+function WelcomeLandingPage() {
+	const signedIn = Route.useLoaderData();
+
+	return <LandingPage signedIn={signedIn} />;
+}


### PR DESCRIPTION
## Summary

- replace the duplicate signed-out `Sign in` and `Get started` navbar actions with one `Get started` action
- show a single `Home` action when an authenticated user opens the landing page
- resolve the lightweight session-cookie signal before rendering `/welcome`, avoiding a post-render button swap or database lookup for anonymous server requests
- apply the behavior to desktop and mobile landing navigation while leaving other public-page headers and landing CTAs unchanged
- make client-side auth-presence probes fail open across both public landing routes

## Why

Both signed-out navbar actions led to the same login route. Authenticated users can reach the marketing page through the ThinkEx logo on `/home`, but the navbar still invited them to sign in again.

## Reviewer follow-up and root cause

The initial implementation called `ensureQueryData` directly from `/welcome`. A rejected session request therefore escaped the loader and made a public page render the router error screen. The same unguarded probe already existed on the canonical `/` route, so catching only the new loader would have left the underlying policy duplicated and one public route vulnerable.

The fix centralizes client auth-presence lookup in `hasClientAuthSessionForPublicRoute`. Public navigation now falls back to its signed-out state when session infrastructure is unavailable; protected routes continue using strict session validation. The desktop and mobile navbar actions also share one label and destination mapping.

## Validation

- `pnpm exec vp check`
- `pnpm build:app`
- `pnpm doctor` (92/100, no findings)
- `git diff --check`

No new test files or test scaffolding were added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public landing pages now adapt based on sign-in status.
  * Signed-in visitors see a “Home” link, while signed-out visitors see “Get started.”
  * Authentication state is detected from server sessions or cached client data.
* **Bug Fixes**
  * Authentication check failures now safely treat visitors as signed out.
  * Welcome-page responses are prevented from being cached across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->