### PR TITLE
fix(ai): stop the compute tool inviting misuse

### DIFF
--- a/src/features/workspaces/ai/code-run-tools.ts
+++ b/src/features/workspaces/ai/code-run-tools.ts
@@ -61,8 +61,8 @@ const codeRunOutputSchema = z.object({
 const codeRunInputExamples = [
 	{
 		input: {
-			title: "Calculating the circle area",
-			code: "import math\nmath.pi * 5 ** 2",
+			title: "Solving the production system",
+			code: "import numpy as np\nA = np.array([[0.4, 0.1], [0.1, 0.4]])\nnp.linalg.inv(np.eye(2) - A) @ np.array([1400, 2100])",
 		},
 	},
 	{
@@ -93,7 +93,7 @@ export function createAIThreadCodeRunTools(input: {
 	return {
 		compute: defineAIThreadTool({
 			description:
-				"Execute private Python code for calculations, data analysis, tables, and charts. Uses the Sandbox default Python context, so variables can persist across compute calls in the same chat thread. The chat UI renders returned image results directly; do not paste base64 image data into the final answer.",
+				"Execute private Python for numeric work you cannot do reliably inline — matrix math, statistics, simulations — and for matplotlib charts. Not for arithmetic, date math, string manipulation, or as a scratchpad for reasoning; do that inline. The sandbox filesystem is empty: it holds no workspace items and no uploads, so read documents with `workspace_read_items` and never by filesystem path. If an import fails the library is not installed; do not retry with a different one. Uses the Sandbox default Python context, so variables can persist across compute calls in the same chat thread. When several runs feed each other, call this from `orchestrate` rather than one compute call per step. The chat UI renders returned image results directly; do not paste base64 image data into the final answer.",
 			inputSchema: codeRunInputSchema,
 			inputExamples: codeRunInputExamples,
 			outputSchema: codeRunOutputSchema,


### PR DESCRIPTION
Thirty days of `ai_tool_invoked` and `$ai_span` telemetry show **40 compute calls, of which about four needed Python** — the numpy linear algebra. The other 36 split three ways.

## What the telemetry showed

| error | count |
|---|---|
| *(no error)* | 32 |
| `No module named 'pypdf'` | 3 |
| `No module named 'fitz'` | 2 |
| `No module named 'sympy'` | 1 |
| `No module named 'PyPDF2'` | 1 |
| `No module named 'pdfplumber'` | 1 |

**Inline arithmetic** — `54/0.54`, `V * i * (n/360)`, summing `MM:SS` strings, weekday enumeration. Roughly 23 calls.

**Scratchpad bodies** — about six calls whose code was entirely comments. One was comments plus an unused `import urllib.request`. A container spun up to compute nothing.

**Reads of user documents by filesystem path** — e.g. `pypdf.PdfReader("/دورات محاسبة شركات.pdf")`. These could never have worked: the sandbox holds no workspace items and no uploads. Every attempt failed, and the model responded by cycling four PDF libraries before giving up. All eight failures in the window are missing modules.

The one PDF-adjacent call that succeeded is the tell — the model got the content through the proper channel, then hand-transcribed it into Python dict literals to do date filtering it could have done in its head.

## The change

Two strings in `code-run-tools.ts`.

The first input example was `math.pi * 5 ** 2`, which reads as an endorsement of the sandbox for arithmetic. It is now a numpy solve that JavaScript genuinely cannot do.

The description never stated the filesystem boundary that `sandbox_bash` already spells out. It now says the sandbox is empty and points document reads at `workspace_read_items` — which returns extracted text with page-level citations (`workspace-read-references.ts:32-48`) that a `pypdf` blob would not carry.

Remaining clauses each answer a measured failure: no scratchpad bodies, no retrying a different library after an import error, and a nudge to drive multi-step work from `orchestrate` rather than one compute call per step — one thread made ten calls in eighty-four seconds.

## Deliberately not done

- **PDF libraries in `containers/sandbox/Dockerfile`.** liteparse already does this on `standard-2` with page-level citations. Installing `pypdf` would hand the model a worse duplicate to prefer.
- **Mounting workspace files into the sandbox.** The SDK has no mount, only copy-in via `writeFile`. Revisit if someone wants pandas-on-uploaded-CSV, with an explicit `files: string[]` param.
- **RPC from Python back into `tools.*`.** Bypasses `needsApproval` gating and tool telemetry.
- **Enumerating installed libraries in the description.** Would drift from the Dockerfile on every image bump; "if an import fails, don't retry" needs no maintenance.

## Testing

`pnpm lint` clean. `ai-tool-registry`, `ai-thread-tool`, `ai-thread-telemetry-format` — 10/10 pass. No test pins these strings.

## Worth a follow-up, not in scope

- Compute earned four legitimate calls in 30 days. If the next 30 look the same, the question is whether a Python container per thread earns its keep.
- Unrelated telemetry gap: `ai_turn_started` / `ai_turn_completed` / `ai_tool_invoked` are **zero on Aug 4–7** while `$ai_generation` kept flowing (103 on Aug 4 alone). The server-event path stopped; the LLM-analytics path did not. Recovered Aug 8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788897984&installation_model_id=425282&pr_number=751&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F751&signature=3374b03d63b03ac7c78278eeeaf3bc1aacc949bed8e18ff21087a07b2a296a77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

