### PR TITLE
feat(ai): attach pending PDFs while extraction runs

### DIFF
--- a/src/features/workspaces/ai/ai-thread-runtime.ts
+++ b/src/features/workspaces/ai/ai-thread-runtime.ts
@@ -158,6 +158,7 @@ function createAIThreadToolCatalog(input: {
 		defaultTimeZone: input.timeZone,
 	});
 	const workspaceTools = createAIThreadWorkspaceTools({
+		env: input.env,
 		getThreadContext: input.getThreadContext,
 		onWorkspaceReferences: input.onWorkspaceReferences,
 		resolveWorkspaceReferences: input.resolveWorkspaceReferences,

--- a/src/features/workspaces/ai/workspace-read-file-fallback.ts
+++ b/src/features/workspaces/ai/workspace-read-file-fallback.ts
@@ -1,54 +1,38 @@
 import type { Tool } from "ai";
 
-import {
-	workspaceReadItemsInputSchema,
-	workspaceReadItemsOutputSchema,
-} from "#/features/workspaces/content/workspace-content-contract";
+import { workspaceReadItemsOutputSchema } from "#/features/workspaces/content/workspace-content-contract";
+import { createWorkspaceReadItemsModelOutput } from "#/features/workspaces/content/workspace-read-references";
 import { getWorkspaceFileSourceObject } from "#/features/workspaces/extraction/workspace-file-source";
 import { getWorkspaceKernelFromEnv } from "#/features/workspaces/kernel/workspace-kernel-access";
-import { resolveWorkspaceFileTypeFromItem } from "#/features/workspaces/model/workspace-file";
 
 const maxPendingPdfBytes = 3.5 * 1024 * 1024;
 type ModelToolOutput = Awaited<ReturnType<NonNullable<Tool["toModelOutput"]>>>;
 
 export async function createPendingPdfModelOutput(input: {
 	env: Cloudflare.Env;
-	toolInput: unknown;
 	toolOutput: unknown;
 	workspaceId: string;
 }): Promise<ModelToolOutput | null> {
-	const parsedInput = workspaceReadItemsInputSchema.safeParse(input.toolInput);
 	const parsedOutput = workspaceReadItemsOutputSchema.safeParse(input.toolOutput);
-	if (!parsedInput.success || !parsedOutput.success) {
+	if (!parsedOutput.success) {
 		return null;
 	}
 
-	const [request] = parsedInput.data.requests;
 	const [result] = parsedOutput.data.results;
 	if (
-		parsedInput.data.requests.length !== 1 ||
 		parsedOutput.data.results.length !== 1 ||
-		!request ||
 		!result ||
 		result.status !== "pending" ||
-		result.path !== request.path
+		!result.itemId
 	) {
 		return null;
 	}
 
 	try {
 		const kernel = await getWorkspaceKernelFromEnv(input.env, input.workspaceId);
-		const [resolution] = await kernel.resolvePaths({ paths: [result.path] });
-		if (
-			resolution?.status !== "item" ||
-			resolveWorkspaceFileTypeFromItem(resolution.item)?.assetKind !== "pdf"
-		) {
-			return null;
-		}
-
 		const { object, source } = await getWorkspaceFileSourceObject({
 			env: input.env,
-			itemId: resolution.item.id,
+			itemId: result.itemId,
 			kernel,
 		});
 		if (source.contentType !== "application/pdf" || object.size > maxPendingPdfBytes) {
@@ -60,7 +44,7 @@ export async function createPendingPdfModelOutput(input: {
 			value: [
 				{
 					type: "text",
-					text: `The original PDF at ${result.path} is attached temporarily because its indexed extraction is still running. Use it for this response. Do not claim extraction is complete or invent ThinkEx page citations. Do not read this path again in this response. On a later turn, call workspace_read_items again so extracted content and citations are used when ready. If the raw PDF is not enough, tell the user extraction is still running and ask them to try again in about ${result.retryAfterSeconds} seconds.`,
+					text: `${JSON.stringify(createWorkspaceReadItemsModelOutput(parsedOutput.data))}\n\nThe original PDF is attached temporarily for this response. Do not claim extraction is complete or invent ThinkEx page citations. On a later turn, call workspace_read_items again for extracted, citable content.`,
 				},
 				{
 					type: "file",

--- a/src/features/workspaces/ai/workspace-read-file-fallback.ts
+++ b/src/features/workspaces/ai/workspace-read-file-fallback.ts
@@ -1,12 +1,22 @@
 import type { Tool } from "ai";
 
-import { workspaceReadItemsOutputSchema } from "#/features/workspaces/content/workspace-content-contract";
+import {
+	workspaceReadItemsInputSchema,
+	workspaceReadItemsOutputSchema,
+} from "#/features/workspaces/content/workspace-content-contract";
 import { createWorkspaceReadItemsModelOutput } from "#/features/workspaces/content/workspace-read-references";
 import { getWorkspaceFileSourceObject } from "#/features/workspaces/extraction/workspace-file-source";
 import { getWorkspaceKernelFromEnv } from "#/features/workspaces/kernel/workspace-kernel-access";
 
 const maxPendingPdfBytes = 3.5 * 1024 * 1024;
 type ModelToolOutput = Awaited<ReturnType<NonNullable<Tool["toModelOutput"]>>>;
+
+export function isPendingPdfFallbackInput(input: unknown) {
+	const parsed = workspaceReadItemsInputSchema.safeParse(input);
+	return (
+		parsed.success && parsed.data.requests.length === 1 && parsed.data.requests[0]?.mode === "start"
+	);
+}
 
 export async function createPendingPdfModelOutput(input: {
 	env: Cloudflare.Env;

--- a/src/features/workspaces/ai/workspace-read-file-fallback.ts
+++ b/src/features/workspaces/ai/workspace-read-file-fallback.ts
@@ -1,0 +1,80 @@
+import type { Tool } from "ai";
+
+import {
+	workspaceReadItemsInputSchema,
+	workspaceReadItemsOutputSchema,
+} from "#/features/workspaces/content/workspace-content-contract";
+import { getWorkspaceFileSourceObject } from "#/features/workspaces/extraction/workspace-file-source";
+import { getWorkspaceKernelFromEnv } from "#/features/workspaces/kernel/workspace-kernel-access";
+import { resolveWorkspaceFileTypeFromItem } from "#/features/workspaces/model/workspace-file";
+
+const maxPendingPdfBytes = 3.5 * 1024 * 1024;
+type ModelToolOutput = Awaited<ReturnType<NonNullable<Tool["toModelOutput"]>>>;
+
+export async function createPendingPdfModelOutput(input: {
+	env: Cloudflare.Env;
+	toolInput: unknown;
+	toolOutput: unknown;
+	workspaceId: string;
+}): Promise<ModelToolOutput | null> {
+	const parsedInput = workspaceReadItemsInputSchema.safeParse(input.toolInput);
+	const parsedOutput = workspaceReadItemsOutputSchema.safeParse(input.toolOutput);
+	if (!parsedInput.success || !parsedOutput.success) {
+		return null;
+	}
+
+	const [request] = parsedInput.data.requests;
+	const [result] = parsedOutput.data.results;
+	if (
+		parsedInput.data.requests.length !== 1 ||
+		parsedOutput.data.results.length !== 1 ||
+		!request ||
+		!result ||
+		result.status !== "pending" ||
+		result.path !== request.path
+	) {
+		return null;
+	}
+
+	try {
+		const kernel = await getWorkspaceKernelFromEnv(input.env, input.workspaceId);
+		const [resolution] = await kernel.resolvePaths({ paths: [result.path] });
+		if (
+			resolution?.status !== "item" ||
+			resolveWorkspaceFileTypeFromItem(resolution.item)?.assetKind !== "pdf"
+		) {
+			return null;
+		}
+
+		const { object, source } = await getWorkspaceFileSourceObject({
+			env: input.env,
+			itemId: resolution.item.id,
+			kernel,
+		});
+		if (source.contentType !== "application/pdf" || object.size > maxPendingPdfBytes) {
+			return null;
+		}
+
+		return {
+			type: "content",
+			value: [
+				{
+					type: "text",
+					text: `The original PDF at ${result.path} is attached temporarily because its indexed extraction is still running. Use it for this response. Do not claim extraction is complete or invent ThinkEx page citations. Do not read this path again in this response. On a later turn, call workspace_read_items again so extracted content and citations are used when ready. If the raw PDF is not enough, tell the user extraction is still running and ask them to try again in about ${result.retryAfterSeconds} seconds.`,
+				},
+				{
+					type: "file",
+					data: {
+						data: new Uint8Array(await object.arrayBuffer()),
+						type: "data",
+					},
+					filename: source.fileName,
+					mediaType: "application/pdf",
+				},
+			],
+		};
+	} catch {
+		// This is an optional bridge while extraction runs; preserve the normal pending result on failure.
+		return null;
+	}
+}

--- a/src/features/workspaces/ai/workspace-read-file-fallback.worker.test.ts
+++ b/src/features/workspaces/ai/workspace-read-file-fallback.worker.test.ts
@@ -1,31 +1,13 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import type { WorkspaceItemSummary } from "#/features/workspaces/contracts";
 import { createPendingPdfModelOutput } from "#/features/workspaces/ai/workspace-read-file-fallback";
 import type { WorkspaceKernelClient } from "#/features/workspaces/kernel/workspace-kernel-access";
 
-const fileItem: WorkspaceItemSummary = {
-	color: null,
-	createdAt: "2026-01-01T00:00:00.000Z",
-	deletedAt: null,
-	id: "file-1",
-	meta: "PDF",
-	metadataJson: { assetKind: "pdf" },
-	name: "Report.pdf",
-	parentId: null,
-	sortOrder: 1,
-	title: "Report",
-	type: "file",
-	updatedAt: "2026-01-01T00:00:00.000Z",
-	workspaceId: "workspace-1",
-};
-
 describe("pending PDF model output", () => {
-	it("attaches one small pending PDF with extraction guidance", async () => {
+	it("attaches only a small pending PDF", async () => {
 		const bytes = new Uint8Array([1, 2, 3]);
 		const output = await createPendingPdfModelOutput({
 			env: createEnv(bytes),
-			toolInput: { requests: [{ mode: "start", path: "/Report.pdf" }] },
 			toolOutput: pendingOutput(),
 			workspaceId: "workspace-1",
 		});
@@ -42,34 +24,18 @@ describe("pending PDF model output", () => {
 				},
 			],
 		});
-		expect(output?.type === "content" ? output.value[0] : null).toMatchObject({
-			text: expect.stringContaining("indexed extraction is still running"),
+		const text = output?.type === "content" ? output.value[0] : null;
+		expect(text).toMatchObject({
+			text: expect.stringContaining('"retryAfterSeconds":15'),
 		});
-		expect(output?.type === "content" ? output.value[0] : null).toMatchObject({
-			text: expect.stringContaining("about 15 seconds"),
+		expect(text).toMatchObject({
+			text: expect.stringContaining("The original PDF is attached temporarily"),
 		});
-	});
 
-	it("keeps the normal pending result for large or batched reads", async () => {
 		const largeBytes = new Uint8Array(3.5 * 1024 * 1024 + 1);
 		await expect(
 			createPendingPdfModelOutput({
 				env: createEnv(largeBytes),
-				toolInput: { requests: [{ mode: "start", path: "/Report.pdf" }] },
-				toolOutput: pendingOutput(),
-				workspaceId: "workspace-1",
-			}),
-		).resolves.toBeNull();
-
-		await expect(
-			createPendingPdfModelOutput({
-				env: createEnv(new Uint8Array([1, 2, 3])),
-				toolInput: {
-					requests: [
-						{ mode: "start", path: "/Report.pdf" },
-						{ mode: "start", path: "/Other.pdf" },
-					],
-				},
 				toolOutput: pendingOutput(),
 				workspaceId: "workspace-1",
 			}),
@@ -83,6 +49,7 @@ function pendingOutput() {
 		results: [
 			{
 				elapsedSeconds: 8,
+				itemId: "file-1",
 				path: "/Report.pdf",
 				phase: "extracting",
 				retryAfterSeconds: 15,
@@ -95,24 +62,21 @@ function pendingOutput() {
 
 function createEnv(bytes: Uint8Array): Cloudflare.Env {
 	const kernel = {
-		getFileSource: vi.fn(async () => ({
+		getFileSource: async () => ({
 			contentType: "application/pdf",
 			fileName: "Report.pdf",
 			objectKey: "sources/file-1.pdf",
 			sizeBytes: bytes.byteLength,
-		})),
-		resolvePaths: vi.fn(async () => [
-			{ item: fileItem, path: "/Report.pdf", status: "item" as const },
-		]),
+		}),
 	} as unknown as WorkspaceKernelClient;
 
 	return {
 		WORKSPACE_KERNEL_FILES: {
-			get: vi.fn(async () => ({
-				arrayBuffer: vi.fn(async () => bytes.buffer),
+			get: async () => ({
+				arrayBuffer: async () => bytes.buffer,
 				size: bytes.byteLength,
-			})),
+			}),
 		},
-		WorkspaceKernel: { getByName: vi.fn(() => kernel) },
+		WorkspaceKernel: { getByName: () => kernel },
 	} as unknown as Cloudflare.Env;
 }

--- a/src/features/workspaces/ai/workspace-read-file-fallback.worker.test.ts
+++ b/src/features/workspaces/ai/workspace-read-file-fallback.worker.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { WorkspaceItemSummary } from "#/features/workspaces/contracts";
+import { createPendingPdfModelOutput } from "#/features/workspaces/ai/workspace-read-file-fallback";
+import type { WorkspaceKernelClient } from "#/features/workspaces/kernel/workspace-kernel-access";
+
+const fileItem: WorkspaceItemSummary = {
+	color: null,
+	createdAt: "2026-01-01T00:00:00.000Z",
+	deletedAt: null,
+	id: "file-1",
+	meta: "PDF",
+	metadataJson: { assetKind: "pdf" },
+	name: "Report.pdf",
+	parentId: null,
+	sortOrder: 1,
+	title: "Report",
+	type: "file",
+	updatedAt: "2026-01-01T00:00:00.000Z",
+	workspaceId: "workspace-1",
+};
+
+describe("pending PDF model output", () => {
+	it("attaches one small pending PDF with extraction guidance", async () => {
+		const bytes = new Uint8Array([1, 2, 3]);
+		const output = await createPendingPdfModelOutput({
+			env: createEnv(bytes),
+			toolInput: { requests: [{ mode: "start", path: "/Report.pdf" }] },
+			toolOutput: pendingOutput(),
+			workspaceId: "workspace-1",
+		});
+
+		expect(output).toMatchObject({
+			type: "content",
+			value: [
+				{ type: "text" },
+				{
+					data: { data: bytes, type: "data" },
+					filename: "Report.pdf",
+					mediaType: "application/pdf",
+					type: "file",
+				},
+			],
+		});
+		expect(output?.type === "content" ? output.value[0] : null).toMatchObject({
+			text: expect.stringContaining("indexed extraction is still running"),
+		});
+		expect(output?.type === "content" ? output.value[0] : null).toMatchObject({
+			text: expect.stringContaining("about 15 seconds"),
+		});
+	});
+
+	it("keeps the normal pending result for large or batched reads", async () => {
+		const largeBytes = new Uint8Array(3.5 * 1024 * 1024 + 1);
+		await expect(
+			createPendingPdfModelOutput({
+				env: createEnv(largeBytes),
+				toolInput: { requests: [{ mode: "start", path: "/Report.pdf" }] },
+				toolOutput: pendingOutput(),
+				workspaceId: "workspace-1",
+			}),
+		).resolves.toBeNull();
+
+		await expect(
+			createPendingPdfModelOutput({
+				env: createEnv(new Uint8Array([1, 2, 3])),
+				toolInput: {
+					requests: [
+						{ mode: "start", path: "/Report.pdf" },
+						{ mode: "start", path: "/Other.pdf" },
+					],
+				},
+				toolOutput: pendingOutput(),
+				workspaceId: "workspace-1",
+			}),
+		).resolves.toBeNull();
+	});
+});
+
+function pendingOutput() {
+	return {
+		references: [],
+		results: [
+			{
+				elapsedSeconds: 8,
+				path: "/Report.pdf",
+				phase: "extracting",
+				retryAfterSeconds: 15,
+				status: "pending",
+				type: "file",
+			},
+		],
+	};
+}
+
+function createEnv(bytes: Uint8Array): Cloudflare.Env {
+	const kernel = {
+		getFileSource: vi.fn(async () => ({
+			contentType: "application/pdf",
+			fileName: "Report.pdf",
+			objectKey: "sources/file-1.pdf",
+			sizeBytes: bytes.byteLength,
+		})),
+		resolvePaths: vi.fn(async () => [
+			{ item: fileItem, path: "/Report.pdf", status: "item" as const },
+		]),
+	} as unknown as WorkspaceKernelClient;
+
+	return {
+		WORKSPACE_KERNEL_FILES: {
+			get: vi.fn(async () => ({
+				arrayBuffer: vi.fn(async () => bytes.buffer),
+				size: bytes.byteLength,
+			})),
+		},
+		WorkspaceKernel: { getByName: vi.fn(() => kernel) },
+	} as unknown as Cloudflare.Env;
+}

--- a/src/features/workspaces/ai/workspace-read-file-fallback.worker.test.ts
+++ b/src/features/workspaces/ai/workspace-read-file-fallback.worker.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { createPendingPdfModelOutput } from "#/features/workspaces/ai/workspace-read-file-fallback";
+import {
+	createPendingPdfModelOutput,
+	isPendingPdfFallbackInput,
+} from "#/features/workspaces/ai/workspace-read-file-fallback";
 import type { WorkspaceKernelClient } from "#/features/workspaces/kernel/workspace-kernel-access";
 
 describe("pending PDF model output", () => {
@@ -40,6 +43,30 @@ describe("pending PDF model output", () => {
 				workspaceId: "workspace-1",
 			}),
 		).resolves.toBeNull();
+	});
+
+	it("allows the fallback only for one initial read", () => {
+		expect(isPendingPdfFallbackInput({ requests: [{ mode: "start", path: "/Report.pdf" }] })).toBe(
+			true,
+		);
+		expect(
+			isPendingPdfFallbackInput({
+				requests: [{ cursor: "opaque", mode: "continue", path: "/Report.pdf" }],
+			}),
+		).toBe(false);
+		expect(
+			isPendingPdfFallbackInput({
+				requests: [{ mode: "pages", path: "/Report.pdf", range: "2" }],
+			}),
+		).toBe(false);
+		expect(
+			isPendingPdfFallbackInput({
+				requests: [
+					{ mode: "start", path: "/Report.pdf" },
+					{ mode: "start", path: "/Appendix.pdf" },
+				],
+			}),
+		).toBe(false);
 	});
 });
 

--- a/src/features/workspaces/ai/workspace-tools.ts
+++ b/src/features/workspaces/ai/workspace-tools.ts
@@ -2,6 +2,7 @@ import type { ToolSet } from "ai";
 
 import type { AIThreadContext } from "#/features/workspaces/ai/ai-thread-metadata";
 import { defineAIThreadTool } from "#/features/workspaces/ai/ai-thread-tool";
+import { createPendingPdfModelOutput } from "#/features/workspaces/ai/workspace-read-file-fallback";
 import { getWorkspaceToolResultAdapter } from "#/features/workspaces/ai/workspace-tool-result-adapters";
 import type { WorkspaceReferenceRecord } from "#/features/workspaces/locations/workspace-location";
 import {
@@ -16,6 +17,7 @@ import {
 
 type WorkspaceThreadToolConfig = {
 	definition: (typeof workspaceToolDefinitions)[number];
+	env: Cloudflare.Env;
 	getThreadContext: () => Promise<AIThreadContext | null>;
 	onWorkspaceReferences?: (records: readonly WorkspaceReferenceRecord[]) => void;
 	resolveWorkspaceReferences?: (refs: readonly string[]) => Promise<WorkspaceReferenceRecord[]>;
@@ -24,6 +26,7 @@ type WorkspaceThreadToolConfig = {
 function createWorkspaceThreadTool(input: WorkspaceThreadToolConfig) {
 	const { definition } = input;
 	const resultAdapter = getWorkspaceToolResultAdapter(definition.name);
+	const freshWorkspaceIds = new Map<string, string>();
 
 	return defineAIThreadTool({
 		description: definition.description,
@@ -32,10 +35,25 @@ function createWorkspaceThreadTool(input: WorkspaceThreadToolConfig) {
 		outputSchema: definition.outputSchema,
 		...(resultAdapter
 			? {
-					toModelOutput: ({ output }) => ({
-						type: "json" as const,
-						value: resultAdapter.projectOutput(output),
-					}),
+					toModelOutput: async ({ input: toolInput, output, toolCallId }) => {
+						const workspaceId = freshWorkspaceIds.get(toolCallId);
+						if (definition.name === "workspace_read_items" && workspaceId) {
+							const fileOutput = await createPendingPdfModelOutput({
+								env: input.env,
+								toolInput,
+								toolOutput: output,
+								workspaceId,
+							});
+							if (fileOutput) {
+								return fileOutput;
+							}
+						}
+
+						return {
+							type: "json" as const,
+							value: resultAdapter.projectOutput(output),
+						};
+					},
 				}
 			: {}),
 		execute: async (args, context) => {
@@ -55,6 +73,9 @@ function createWorkspaceThreadTool(input: WorkspaceThreadToolConfig) {
 			if (references.length > 0 && input.onWorkspaceReferences) {
 				input.onWorkspaceReferences(references);
 			}
+			if (definition.name === "workspace_read_items") {
+				freshWorkspaceIds.set(context.invocationId, thread.workspaceId);
+			}
 
 			return output;
 		},
@@ -62,6 +83,7 @@ function createWorkspaceThreadTool(input: WorkspaceThreadToolConfig) {
 }
 
 export function createAIThreadWorkspaceTools(input: {
+	env: Cloudflare.Env;
 	getThreadContext: () => Promise<AIThreadContext | null>;
 	onWorkspaceReferences?: (records: readonly WorkspaceReferenceRecord[]) => void;
 	resolveWorkspaceReferences?: (refs: readonly string[]) => Promise<WorkspaceReferenceRecord[]>;
@@ -71,6 +93,7 @@ export function createAIThreadWorkspaceTools(input: {
 			definition.name,
 			createWorkspaceThreadTool({
 				definition,
+				env: input.env,
 				getThreadContext: input.getThreadContext,
 				onWorkspaceReferences: input.onWorkspaceReferences,
 				resolveWorkspaceReferences: input.resolveWorkspaceReferences,

--- a/src/features/workspaces/ai/workspace-tools.ts
+++ b/src/features/workspaces/ai/workspace-tools.ts
@@ -26,7 +26,9 @@ type WorkspaceThreadToolConfig = {
 function createWorkspaceThreadTool(input: WorkspaceThreadToolConfig) {
 	const { definition } = input;
 	const resultAdapter = getWorkspaceToolResultAdapter(definition.name);
-	const freshWorkspaceIds = new Map<string, string>();
+	// Projection also runs for history; only fresh calls may hydrate raw bytes.
+	const freshWorkspaceIds =
+		definition.name === "workspace_read_items" ? new Map<string, string>() : null;
 
 	return defineAIThreadTool({
 		description: definition.description,
@@ -35,12 +37,11 @@ function createWorkspaceThreadTool(input: WorkspaceThreadToolConfig) {
 		outputSchema: definition.outputSchema,
 		...(resultAdapter
 			? {
-					toModelOutput: async ({ input: toolInput, output, toolCallId }) => {
-						const workspaceId = freshWorkspaceIds.get(toolCallId);
-						if (definition.name === "workspace_read_items" && workspaceId) {
+					toModelOutput: async ({ output, toolCallId }) => {
+						const workspaceId = freshWorkspaceIds?.get(toolCallId);
+						if (workspaceId) {
 							const fileOutput = await createPendingPdfModelOutput({
 								env: input.env,
-								toolInput,
 								toolOutput: output,
 								workspaceId,
 							});
@@ -73,9 +74,7 @@ function createWorkspaceThreadTool(input: WorkspaceThreadToolConfig) {
 			if (references.length > 0 && input.onWorkspaceReferences) {
 				input.onWorkspaceReferences(references);
 			}
-			if (definition.name === "workspace_read_items") {
-				freshWorkspaceIds.set(context.invocationId, thread.workspaceId);
-			}
+			freshWorkspaceIds?.set(context.invocationId, thread.workspaceId);
 
 			return output;
 		},

--- a/src/features/workspaces/ai/workspace-tools.ts
+++ b/src/features/workspaces/ai/workspace-tools.ts
@@ -2,7 +2,10 @@ import type { ToolSet } from "ai";
 
 import type { AIThreadContext } from "#/features/workspaces/ai/ai-thread-metadata";
 import { defineAIThreadTool } from "#/features/workspaces/ai/ai-thread-tool";
-import { createPendingPdfModelOutput } from "#/features/workspaces/ai/workspace-read-file-fallback";
+import {
+	createPendingPdfModelOutput,
+	isPendingPdfFallbackInput,
+} from "#/features/workspaces/ai/workspace-read-file-fallback";
 import { getWorkspaceToolResultAdapter } from "#/features/workspaces/ai/workspace-tool-result-adapters";
 import type { WorkspaceReferenceRecord } from "#/features/workspaces/locations/workspace-location";
 import {
@@ -74,7 +77,9 @@ function createWorkspaceThreadTool(input: WorkspaceThreadToolConfig) {
 			if (references.length > 0 && input.onWorkspaceReferences) {
 				input.onWorkspaceReferences(references);
 			}
-			freshWorkspaceIds?.set(context.invocationId, thread.workspaceId);
+			if (freshWorkspaceIds && isPendingPdfFallbackInput(args)) {
+				freshWorkspaceIds.set(context.invocationId, thread.workspaceId);
+			}
 
 			return output;
 		},

--- a/src/features/workspaces/content/workspace-content-contract.ts
+++ b/src/features/workspaces/content/workspace-content-contract.ts
@@ -131,6 +131,7 @@ const workspaceContentReadResultSchema = z.union([
 			.int()
 			.nonnegative()
 			.describe("How long extraction has been running."),
+		itemId: z.string().min(1).optional(),
 		path: workspacePathSchema,
 		phase: z
 			.enum(["queued", "extracting"])

--- a/src/features/workspaces/content/workspace-content-reader.ts
+++ b/src/features/workspaces/content/workspace-content-reader.ts
@@ -246,7 +246,7 @@ async function readFile(input: {
 		Date.now(),
 	);
 	if (projection.state !== "ready") {
-		return describeUnreadableProjection(projection, input.path);
+		return describeUnreadableProjection(projection, input.path, input.item.id);
 	}
 
 	const encodedCursor = input.request.mode === "continue" ? input.request.cursor : undefined;
@@ -312,10 +312,12 @@ async function readFile(input: {
 function describeUnreadableProjection(
 	projection: Exclude<WorkspaceProjectionReadiness, { state: "ready" }>,
 	path: string,
+	itemId: string,
 ): WorkspaceContentReadResult {
 	if (projection.state === "pending") {
 		return {
 			elapsedSeconds: projection.elapsedSeconds,
+			itemId,
 			path,
 			phase: projection.phase,
 			retryAfterSeconds: projection.retryAfterSeconds,

--- a/src/features/workspaces/content/workspace-read-references.test.ts
+++ b/src/features/workspaces/content/workspace-read-references.test.ts
@@ -101,6 +101,7 @@ describe("workspace read references", () => {
 		const results = [
 			{
 				elapsedSeconds: 4,
+				itemId: "file-a",
 				path: "/A.pdf",
 				phase: "extracting",
 				retryAfterSeconds: 15,
@@ -116,10 +117,12 @@ describe("workspace read references", () => {
 				type: "file",
 			},
 		] satisfies WorkspaceContentReadResult[];
-		const guidance = createWorkspaceReadItemsModelOutput({ references: [], results }).guidance;
+		const modelOutput = createWorkspaceReadItemsModelOutput({ references: [], results });
+		const { guidance } = modelOutput;
 
 		expect(guidance).toHaveLength(1);
 		expect(guidance?.[0]).toContain("Never sleep");
+		expect(JSON.stringify(modelOutput)).not.toContain("file-a");
 	});
 
 	it("separates failures that will never resolve from transient ones", () => {

--- a/src/features/workspaces/content/workspace-read-references.ts
+++ b/src/features/workspaces/content/workspace-read-references.ts
@@ -60,7 +60,7 @@ export function createWorkspaceReadReferences(
  */
 const workspaceReadGuidance = {
 	pending:
-		"Some paths are still extracting. Never sleep, poll, or otherwise stall waiting for them, including inside compute, sandbox_bash, or orchestrate. Either do other work and read those paths again later in this reply, or tell the user they are still processing and to ask again in about retryAfterSeconds. Never read the same pending path more than twice in one reply.",
+		"Some paths are still extracting. Never sleep, poll, or otherwise stall waiting for them, including inside compute, sandbox_bash, or orchestrate. If an original file is attached, use it and do not read that path again in this reply. Otherwise, either do other work and read pending paths again later in this reply, or tell the user they are still processing and to ask again in about retryAfterSeconds. Never read the same pending path more than twice in one reply.",
 	unrecoverable:
 		"Extraction will not finish for some paths. Report the code and any message to the user; do not retry those reads and do not suggest re-uploading the file.",
 	transient:
@@ -128,7 +128,11 @@ export function createWorkspaceReadItemsModelOutput(output: WorkspaceReadItemsOu
 	return {
 		...(guidance.length > 0 ? { guidance } : {}),
 		results: output.results.map((result) => {
-			if (result.status !== "ready") {
+			if (result.status === "pending") {
+				return omitWorkspaceReadItemId(result);
+			}
+
+			if (result.status === "failed") {
 				return result;
 			}
 
@@ -168,7 +172,7 @@ export function createWorkspaceReadItemsModelOutput(output: WorkspaceReadItemsOu
 	};
 }
 
-function omitWorkspaceReadItemId<T extends { readonly itemId: string }>(
+function omitWorkspaceReadItemId<T extends { readonly itemId?: string }>(
 	result: T,
 ): Omit<T, "itemId"> {
 	const { itemId: _itemId, ...modelResult } = result;


### PR DESCRIPTION
## What changed

- Attach a single pending PDF up to 3.5 MiB as an ephemeral AI SDK file part for the fresh `workspace_read_items` call.
- Keep the existing pending JSON behavior for large files, batched reads, history replay, and fallback hydration failures.
- Preserve the pending file's internal item identity so the fallback does not resolve its path twice, while keeping that ID out of model-visible output.
- Reuse the existing extraction and retry guidance, adding only the temporary-file and citation limitations.

## Why

A PDF can have no usable fast-pass Markdown while higher-quality extraction is still running. Previously the model received only a pending response even though the original workspace PDF was already available. This bridge lets the current response use a small raw PDF without persisting its bytes in chat history or replacing the normal extraction-backed read path.

## Impact

Users can get an immediate answer from small PDFs during extraction. Later turns still use extracted content and ThinkEx page citations. Large or multiple PDFs continue to return `retryAfterSeconds` and wait for extraction.

## Validation

- `pnpm exec vitest run src/features/workspaces/content/workspace-read-references.test.ts src/features/workspaces/content/workspace-content-reader.test.ts`
- `pnpm exec vitest run src/features/workspaces/ai/workspace-read-file-fallback.worker.test.ts --project=workers`
- `pnpm check`
- Conductor review: no findings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788921061&installation_model_id=425282&pr_number=754&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F754&signature=218e5e76d485c1fbb008c3a7719e38e76d199e09f2bc465decfadda4434518b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved workspace PDF reading by attaching eligible pending PDFs for AI processing.
  * Added guidance to use attached files directly instead of rereading them.
  * Added safeguards for invalid, oversized, or unavailable PDF files.
* **Bug Fixes**
  * Prevented internal file identifiers from appearing in model-facing results.
* **Tests**
  * Added coverage for PDF attachments, size limits, metadata, and retry guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->