### PR TITLE
Reject invalid widget scripts before saving

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
 		"@tiptap/pm": "^3.29.2",
 		"@tiptap/react": "^3.29.2",
 		"@tiptap/starter-kit": "^3.29.2",
+		"acorn": "8.18.0",
 		"agents": "^0.19.0",
 		"ai": "^7.0.57",
 		"aws4fetch": "^1.0.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^3.29.2
         version: 3.29.2
+      acorn:
+        specifier: 8.18.0
+        version: 8.18.0
       agents:
         specifier: ^0.19.0
         version: 0.19.0(patch_hash=b4925f176922f992a0781ffa357da123a7e05876e924b4ff009585baa101bf4d)(@ai-sdk/react@4.0.60(react@19.2.8)(zod@4.4.3))(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260807.2)(@tanstack/ai@0.22.0(@opentelemetry/api@1.9.1))(@voidzero-dev/vite-plus-core@0.2.8(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(typescript@6.0.3)(yaml@2.9.0))(ai@7.0.57(zod@4.4.3))(chat@4.31.0(ai@7.0.57(zod@4.4.3))(zod@4.4.3))(just-bash@3.0.2)(react@19.2.8)(rolldown@1.1.2)(zod@4.4.3)

--- a/src/features/workspaces/ai/skills/widget-authoring/SKILL.md
+++ b/src/features/workspaces/ai/skills/widget-authoring/SKILL.md
@@ -22,7 +22,7 @@ Follow this contract:
 3. Use a **native shell and expressive core**. Let the runtime style structural UI such as type, controls, focus, spacing, and panels. Give the diagram, simulation, chart, game, or other central experience the custom SVG, canvas, color, and motion it needs.
 4. Fit the host chrome. The block already provides its title, border, background, and gutter, so never repeat the widget title or wrap the entire source in another card. Reserve panels and borders for distinct internal regions.
 5. Let normal content determine height and fill the available width. Give only elements without natural height, such as a canvas or chart area, an explicit pixel height. The host clamps the frame between 120px and 720px and scrolls taller content.
-6. Let failures throw. The runtime catches errors and offers the user an Ask AI to fix action.
+6. Create and edit tools validate inline script syntax before saving. If one returns `widget_script_syntax_error`, use its detail to repair the existing source and retry the same write. Let later runtime failures throw; the sandbox catches them and offers the user an Ask AI to fix action.
 
 Compose the experience before coding it:
 
@@ -30,6 +30,8 @@ Compose the experience before coding it:
 2. Prefer the runtime's standard controls and `.tx-stack`, `.tx-row`, `.tx-panel`, `.tx-muted`, and `.tx-visual` helpers over rebuilding structural styles. Mark at most one main button with `data-variant="primary"`.
 3. Theme structural UI with the semantic background, foreground, card, primary, secondary, muted, accent, border, input, ring, radius, and font variables. Use `--success`, `--warning`, `--info`, and `--destructive` for status, and `--chart-1` through `--chart-6` for data and expressive visuals. The root also has `data-theme="light|dark"` and the `.dark` class. Hard-code a color only when its literal identity carries meaning.
 4. Keep interface text compact, make layouts wrap on narrow widths, label controls, and ensure every visible control works. Use motion to explain state changes rather than as decoration.
+
+For a complex widget with several interactions or a large script, build in working slices. Create the smallest complete version that delivers the primary interaction, then follow the Edit workflow to add one coherent capability at a time with focused `replace_text` edits. Every saved slice must be functional and presentable; never publish scaffolding, placeholder regions, or dead controls. Create ordinary widgets in one write.
 
 Read these bundled references only when they apply:
 

--- a/src/features/workspaces/ai/workspace-tool-result-adapters.test.ts
+++ b/src/features/workspaces/ai/workspace-tool-result-adapters.test.ts
@@ -24,4 +24,24 @@ describe("workspace tool result adapters", () => {
 			items: [{ path: "/Notes/A", reference: "wr_7Kp2Qa9x", type: "document" }],
 		});
 	});
+
+	it("preserves an actionable widget syntax failure for the creating model", () => {
+		const output = {
+			failed: [
+				{
+					code: "widget_script_syntax_error",
+					detail: "Widget 1 script 1 has invalid JavaScript: Unexpected token (1:14)",
+					index: 0,
+					path: "/Broken widget",
+				},
+			],
+			items: [],
+			references: [],
+		};
+
+		expect(getWorkspaceToolResultAdapter("workspace_create_items")?.projectOutput(output)).toEqual({
+			failed: output.failed,
+			items: [],
+		});
+	});
 });

--- a/src/features/workspaces/ai/workspace-tool-result-adapters.test.ts
+++ b/src/features/workspaces/ai/workspace-tool-result-adapters.test.ts
@@ -44,4 +44,38 @@ describe("workspace tool result adapters", () => {
 			items: [],
 		});
 	});
+
+	it("projects historical create failures without exposing internal references", () => {
+		const output = {
+			failed: [{ code: "path_not_canonical", index: 0, path: "/Old" }],
+			items: [{ itemId: "itm_internal", path: "/Old", type: "document" }],
+			references: [
+				{
+					location: { itemId: "itm_internal", kind: "item", version: 1 },
+					ref: "wr_7Kp2Qa9x",
+				},
+			],
+		};
+
+		expect(getWorkspaceToolResultAdapter("workspace_create_items")?.projectOutput(output)).toEqual({
+			failed: output.failed,
+			items: [{ path: "/Old", reference: "wr_7Kp2Qa9x", type: "document" }],
+		});
+	});
+
+	it("keeps edit receipts limited to the model-facing fields", () => {
+		const output = {
+			applied: 1,
+			failed: [],
+			itemId: "itm_internal",
+			lineChanges: { added: 1, removed: 0 },
+			path: "/Widget",
+		};
+
+		expect(getWorkspaceToolResultAdapter("workspace_edit_item")?.projectOutput(output)).toEqual({
+			applied: 1,
+			failed: [],
+			path: "/Widget",
+		});
+	});
 });

--- a/src/features/workspaces/ai/workspace-tool-result-adapters.ts
+++ b/src/features/workspaces/ai/workspace-tool-result-adapters.ts
@@ -3,10 +3,11 @@ import { z } from "zod";
 
 import { workspaceReadItemsOutputSchema } from "#/features/workspaces/content/workspace-content-contract";
 import { createWorkspaceReadItemsModelOutput } from "#/features/workspaces/content/workspace-read-references";
+import type { WorkspaceReferenceRecord } from "#/features/workspaces/locations/workspace-location";
 import {
-	workspaceReferenceRecordSchema,
-	type WorkspaceReferenceRecord,
-} from "#/features/workspaces/locations/workspace-location";
+	workspaceCreateItemsOutputSchema,
+	workspaceEditItemOutputSchema,
+} from "#/features/workspaces/operations/workspace-tool-schemas";
 import { workspaceSearchOutputSchema } from "#/features/workspaces/search/workspace-search-contract";
 import { createWorkspaceSearchModelOutput } from "#/features/workspaces/search/workspace-search-references";
 
@@ -44,17 +45,7 @@ const workspaceSearchResultAdapter = defineWorkspaceToolResultAdapter({
 
 const workspaceCreateItemsResultAdapter = defineWorkspaceToolResultAdapter({
 	collectReferences: (output) => output.references,
-	outputSchema: z.object({
-		failed: z.array(z.object({ code: z.string(), index: z.number(), path: z.string() })),
-		items: z.array(
-			z.object({
-				itemId: z.string(),
-				path: z.string(),
-				type: z.enum(["document", "folder"]),
-			}),
-		),
-		references: z.array(workspaceReferenceRecordSchema),
-	}),
+	outputSchema: workspaceCreateItemsOutputSchema,
 	projectOutput: (output) => {
 		const refsByItemId = new Map(
 			output.references.flatMap((record) =>
@@ -76,13 +67,7 @@ const workspaceCreateItemsResultAdapter = defineWorkspaceToolResultAdapter({
 // The operation output also carries the durable item id used by the app's
 // review controls. Keep the model-facing receipt limited to actionable counts.
 const workspaceEditItemResultAdapter = defineWorkspaceToolResultAdapter({
-	outputSchema: z.object({
-		applied: z.number(),
-		failed: z.array(
-			z.object({ code: z.string(), detail: z.string().optional(), index: z.number() }),
-		),
-		path: z.string(),
-	}),
+	outputSchema: workspaceEditItemOutputSchema,
 	projectOutput: (output) => output,
 });
 

--- a/src/features/workspaces/ai/workspace-tool-result-adapters.ts
+++ b/src/features/workspaces/ai/workspace-tool-result-adapters.ts
@@ -3,11 +3,10 @@ import { z } from "zod";
 
 import { workspaceReadItemsOutputSchema } from "#/features/workspaces/content/workspace-content-contract";
 import { createWorkspaceReadItemsModelOutput } from "#/features/workspaces/content/workspace-read-references";
-import type { WorkspaceReferenceRecord } from "#/features/workspaces/locations/workspace-location";
 import {
-	workspaceCreateItemsOutputSchema,
-	workspaceEditItemOutputSchema,
-} from "#/features/workspaces/operations/workspace-tool-schemas";
+	workspaceReferenceRecordSchema,
+	type WorkspaceReferenceRecord,
+} from "#/features/workspaces/locations/workspace-location";
 import { workspaceSearchOutputSchema } from "#/features/workspaces/search/workspace-search-contract";
 import { createWorkspaceSearchModelOutput } from "#/features/workspaces/search/workspace-search-references";
 
@@ -45,7 +44,24 @@ const workspaceSearchResultAdapter = defineWorkspaceToolResultAdapter({
 
 const workspaceCreateItemsResultAdapter = defineWorkspaceToolResultAdapter({
 	collectReferences: (output) => output.references,
-	outputSchema: workspaceCreateItemsOutputSchema,
+	outputSchema: z.object({
+		failed: z.array(
+			z.object({
+				code: z.string(),
+				detail: z.string().optional(),
+				index: z.number(),
+				path: z.string(),
+			}),
+		),
+		items: z.array(
+			z.object({
+				itemId: z.string(),
+				path: z.string(),
+				type: z.enum(["document", "folder"]),
+			}),
+		),
+		references: z.array(workspaceReferenceRecordSchema),
+	}),
 	projectOutput: (output) => {
 		const refsByItemId = new Map(
 			output.references.flatMap((record) =>
@@ -67,7 +83,13 @@ const workspaceCreateItemsResultAdapter = defineWorkspaceToolResultAdapter({
 // The operation output also carries the durable item id used by the app's
 // review controls. Keep the model-facing receipt limited to actionable counts.
 const workspaceEditItemResultAdapter = defineWorkspaceToolResultAdapter({
-	outputSchema: workspaceEditItemOutputSchema,
+	outputSchema: z.object({
+		applied: z.number(),
+		failed: z.array(
+			z.object({ code: z.string(), detail: z.string().optional(), index: z.number() }),
+		),
+		path: z.string(),
+	}),
 	projectOutput: (output) => output,
 });
 

--- a/src/features/workspaces/documents/document-ai-edits.test.ts
+++ b/src/features/workspaces/documents/document-ai-edits.test.ts
@@ -131,6 +131,36 @@ describe("document AI edits", () => {
 		);
 		expect(getWidgetSource(result.document)).toBe("<button>Go</button>");
 	});
+
+	it("rejects a widget edit with invalid JavaScript and preserves the existing widget", async () => {
+		const source = '<button id="run">Run</button><script>const ready = true;</script>';
+		const document = createDocument(
+			`<div data-type="widget" title="Runner">${source.replaceAll("<", "&lt;")}</div>`,
+		);
+		const editRef = await getEditRef(document, "div");
+		const brokenSource = '<button id="run">Run</button><script>const ready = ;</script>';
+		const result = await applyDocumentAiEdits(document, [
+			{
+				editRef,
+				html: `<div data-type="widget" title="Runner">${brokenSource.replaceAll("<", "&lt;")}</div>`,
+				op: "replace",
+			},
+		]);
+
+		expect(result).toMatchObject({
+			applied: 0,
+			failed: 1,
+			failures: [
+				{
+					code: "widget_script_syntax_error",
+					detail: expect.stringContaining("Unexpected token"),
+					index: 0,
+				},
+			],
+			status: "failed",
+		});
+		expect(getWidgetSource(result.document)).toBe(source);
+	});
 });
 
 function createDocument(html: string) {

--- a/src/features/workspaces/documents/document-ai-edits.ts
+++ b/src/features/workspaces/documents/document-ai-edits.ts
@@ -10,6 +10,7 @@ import {
 	serializeTiptapNodeToEditableAiHtml,
 	readTiptapNodeBlockId,
 	withTiptapNodeAiRef,
+	WidgetScriptSyntaxError,
 } from "#/features/workspaces/documents/document-ai-html";
 import type { DocumentEditLineChanges } from "#/features/workspaces/documents/document-edit-receipt";
 import {
@@ -66,6 +67,7 @@ export const documentAiEditFailureCodes = [
 	// one of three identical buttons would otherwise change all three, unnoticed.
 	"edit_not_unique",
 	"invalid_html",
+	"widget_script_syntax_error",
 	"no_change",
 	"edit_ref_not_found",
 	"edit_ref_stale",
@@ -217,8 +219,8 @@ function applyDocumentAiEdit(
 	| { document: ProseMirrorNode; status: "applied" } {
 	if (edit.op === "overwrite") {
 		const parsed = parseEditHtml(edit.html);
-		if (!parsed.children) {
-			return { code: "invalid_html", detail: parsed.detail, status: "failed" };
+		if ("code" in parsed) {
+			return { code: parsed.code, detail: parsed.detail, status: "failed" };
 		}
 
 		const next = createDocument(parsed.children);
@@ -258,8 +260,8 @@ function applyDocumentAiEdit(
 		}
 
 		const parsed = parseEditHtml(html);
-		if (!parsed.children) {
-			return { code: "invalid_html", detail: parsed.detail, status: "failed" };
+		if ("code" in parsed) {
+			return { code: parsed.code, detail: parsed.detail, status: "failed" };
 		}
 		const targetBlockId = readTiptapNodeBlockId(document.child(targetIndex));
 		const firstNode = parsed.children[0];
@@ -321,7 +323,11 @@ function replaceUniqueText(
 	return { ok: true, text: haystack.replace(needle, replace) };
 }
 
-function parseEditHtml(html: string) {
+function parseEditHtml(
+	html: string,
+):
+	| { children: ProseMirrorNode[] }
+	| { code: "invalid_html" | "widget_script_syntax_error"; detail: string } {
 	try {
 		return {
 			children: getDocumentChildren(
@@ -330,7 +336,11 @@ function parseEditHtml(html: string) {
 		};
 	} catch (error) {
 		if (error instanceof DocumentAiHtmlError) {
-			return { detail: error.message };
+			return {
+				code:
+					error instanceof WidgetScriptSyntaxError ? "widget_script_syntax_error" : "invalid_html",
+				detail: error.message,
+			};
 		}
 		throw error;
 	}

--- a/src/features/workspaces/documents/document-ai-html.test.ts
+++ b/src/features/workspaces/documents/document-ai-html.test.ts
@@ -107,4 +107,22 @@ describe("document AI HTML", () => {
 			DocumentAiHtmlError,
 		);
 	});
+
+	it("rejects invalid inline JavaScript in a widget before persistence", () => {
+		const source = '<button id="run">Run</button><script>const broken = ;</script>';
+		const html = `<div data-type="widget" title="Broken">${source.replaceAll("<", "&lt;")}</div>`;
+
+		expect(() => parseDocumentAiHtml(html)).toThrow(
+			"Widget 1 script 1 has invalid JavaScript: Unexpected token",
+		);
+	});
+
+	it("accepts valid classic and module scripts while ignoring data blocks", () => {
+		const source = `<script>document.body.dataset.ready = "true";</script>
+<script type="module">const value = await Promise.resolve(1);</script>
+<script type="application/json">{"not": javascript}</script>`;
+		const html = `<div data-type="widget">${source.replaceAll("<", "&lt;")}</div>`;
+
+		expect(parseDocumentAiHtml(html)).toMatchObject({ type: "doc" });
+	});
 });

--- a/src/features/workspaces/documents/document-ai-html.test.ts
+++ b/src/features/workspaces/documents/document-ai-html.test.ts
@@ -5,6 +5,7 @@ import {
 	ensureTiptapDocumentBlockIds,
 	parseDocumentAiHtml,
 	serializeTiptapDocumentToAiHtml,
+	WidgetScriptSyntaxError,
 } from "#/features/workspaces/documents/document-ai-html";
 
 describe("document AI HTML", () => {
@@ -124,5 +125,12 @@ describe("document AI HTML", () => {
 		const html = `<div data-type="widget">${source.replaceAll("<", "&lt;")}</div>`;
 
 		expect(parseDocumentAiHtml(html)).toMatchObject({ type: "doc" });
+	});
+
+	it("rejects invalid JavaScript when its MIME type has spaced parameters", () => {
+		const source = '<script type="text/javascript ; charset=utf-8">const broken = ;</script>';
+		const html = `<div data-type="widget">${source.replaceAll("<", "&lt;")}</div>`;
+
+		expect(() => parseDocumentAiHtml(html)).toThrow(WidgetScriptSyntaxError);
 	});
 });

--- a/src/features/workspaces/documents/document-ai-html.ts
+++ b/src/features/workspaces/documents/document-ai-html.ts
@@ -1,4 +1,5 @@
 import { DOMParser, DOMSerializer, Fragment, type Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { parse as parseJavaScript } from "acorn";
 import { parseHTML } from "linkedom";
 import { nanoid } from "nanoid";
 
@@ -17,6 +18,7 @@ const TEXT_NODE = 3;
 const documentBlockIdPattern = /^b_[A-Za-z0-9_-]{12}$/;
 const documentAiEditRefPattern = /^(b_[A-Za-z0-9_-]{12})\.r_[A-Za-z0-9_-]{10}$/;
 export class DocumentAiHtmlError extends Error {}
+export class WidgetScriptSyntaxError extends DocumentAiHtmlError {}
 
 export interface DocumentAiBlockSnapshot {
 	content: string;
@@ -35,6 +37,7 @@ export function parseDocumentAiHtml(html: string): TiptapDocumentJson {
 
 	rewriteLossyElements(htmlDocument);
 
+	validateWidgetScriptSyntax(htmlDocument.body);
 	validateDocumentAiHtml(htmlDocument.body);
 
 	for (const element of htmlDocument.body.querySelectorAll("[data-edit-ref]")) {
@@ -251,6 +254,62 @@ function validateDocumentAiHtml(root: HTMLElement) {
 			);
 		}
 	}
+}
+
+/**
+ * Parse executable inline scripts exactly where model-authored widgets enter
+ * the document. This runs before create/edit persistence, so a syntax error is
+ * returned to the model by the same tool call instead of becoming a broken
+ * iframe in the browser.
+ *
+ * Widget source is HTML-escaped text in the outer document. Parse that text as
+ * its own fragment first, matching the document the sandbox will construct.
+ * Non-JavaScript data blocks and external scripts are not executed inline and
+ * therefore have no inline JavaScript syntax to validate.
+ */
+function validateWidgetScriptSyntax(root: HTMLElement) {
+	const widgets = Array.from(root.querySelectorAll('div[data-type="widget"]'));
+
+	for (const [widgetIndex, widget] of widgets.entries()) {
+		const widgetDocument = createHtmlDocument();
+		widgetDocument.body.innerHTML = widget.textContent ?? "";
+		const scripts = Array.from(widgetDocument.body.querySelectorAll("script"));
+
+		for (const [scriptIndex, script] of scripts.entries()) {
+			if (script.hasAttribute("src")) {
+				continue;
+			}
+
+			const sourceType = getWidgetScriptSourceType(script.getAttribute("type"));
+			if (!sourceType) {
+				continue;
+			}
+
+			try {
+				parseJavaScript(script.textContent ?? "", {
+					ecmaVersion: "latest",
+					sourceType,
+				});
+			} catch (error) {
+				const message = error instanceof Error ? error.message : "Invalid JavaScript syntax";
+				throw new WidgetScriptSyntaxError(
+					`Widget ${widgetIndex + 1} script ${scriptIndex + 1} has invalid JavaScript: ${message}`,
+					{ cause: error },
+				);
+			}
+		}
+	}
+}
+
+function getWidgetScriptSourceType(typeAttribute: string | null): "module" | "script" | null {
+	const type = (typeAttribute ?? "").trim().toLowerCase().split(";", 1)[0];
+	if (!type) {
+		return "script";
+	}
+	if (type === "module") {
+		return "module";
+	}
+	return /^(?:text|application)\/(?:x-)?(?:java|ecma)script$/.test(type) ? "script" : null;
 }
 
 /** Short refs the assistant cited, for the caller to resolve to locations. */

--- a/src/features/workspaces/documents/document-ai-html.ts
+++ b/src/features/workspaces/documents/document-ai-html.ts
@@ -302,7 +302,7 @@ function validateWidgetScriptSyntax(root: HTMLElement) {
 }
 
 function getWidgetScriptSourceType(typeAttribute: string | null): "module" | "script" | null {
-	const type = (typeAttribute ?? "").trim().toLowerCase().split(";", 1)[0];
+	const type = (typeAttribute ?? "").split(";", 1)[0]?.trim().toLowerCase();
 	if (!type) {
 		return "script";
 	}

--- a/src/features/workspaces/operations/create-items.test.ts
+++ b/src/features/workspaces/operations/create-items.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const kernel = vi.hoisted(() => ({
+	createItem: vi.fn(),
+	resolvePaths: vi.fn(),
+}));
+
+vi.mock("#/features/workspaces/operations/workspace-operation-context", () => ({
+	getAuthorizedWorkspaceKernel: vi.fn(async () => kernel),
+}));
+
+import { createWorkspaceItemsOperation } from "#/features/workspaces/operations/create-items";
+import { createWorkspaceAccessContext } from "#/features/workspaces/operations/workspace-access-context";
+
+describe("createWorkspaceItemsOperation", () => {
+	beforeEach(() => {
+		kernel.createItem.mockReset();
+		kernel.resolvePaths.mockReset();
+		kernel.resolvePaths.mockResolvedValue([{ path: "/", status: "root" }]);
+	});
+
+	it("returns widget syntax errors to the original create call without persisting", async () => {
+		const source = '<button id="run">Run</button><script>const ready = ;</script>';
+		const result = await createWorkspaceItemsOperation(
+			createWorkspaceAccessContext({
+				operationId: "create-call",
+				scopes: ["workspace:write"],
+				userId: "user-1",
+				workspaceId: "workspace-1",
+			}),
+			{
+				items: [
+					{
+						initialContent: `<div data-type="widget">${source.replaceAll("<", "&lt;")}</div>`,
+						path: "/Broken widget",
+						type: "document",
+					},
+				],
+			},
+		);
+
+		expect(result).toMatchObject({
+			failed: [
+				{
+					code: "widget_script_syntax_error",
+					detail: expect.stringContaining("Unexpected token"),
+					index: 0,
+					path: "/Broken widget",
+				},
+			],
+			items: [],
+		});
+		expect(kernel.createItem).not.toHaveBeenCalled();
+	});
+});

--- a/src/features/workspaces/operations/create-items.ts
+++ b/src/features/workspaces/operations/create-items.ts
@@ -6,7 +6,10 @@ import {
 import { createWorkspaceItemsFailureCodes } from "#/features/workspaces/operations/workspace-operation-failure-codes";
 import type { WorkspaceAccessContext } from "#/features/workspaces/operations/workspace-access-context";
 import type { WorkspaceKernelPathResolution } from "#/features/workspaces/kernel/workspace-kernel-types";
-import { parseDocumentAiHtml } from "#/features/workspaces/documents/document-ai-html";
+import {
+	parseDocumentAiHtml,
+	WidgetScriptSyntaxError,
+} from "#/features/workspaces/documents/document-ai-html";
 import { resolveDocumentCitations } from "#/features/workspaces/operations/document-citations";
 import { stringifyTiptapDocumentJson } from "#/features/workspaces/documents/tiptap-document";
 import {
@@ -36,6 +39,7 @@ type CreateWorkspaceItemsFailureCode = (typeof createWorkspaceItemsFailureCodes)
 
 export interface CreateWorkspaceItemsFailure {
 	code: CreateWorkspaceItemsFailureCode;
+	detail?: string;
 	index: number;
 	path: string;
 }
@@ -122,6 +126,7 @@ export async function createWorkspaceItemsOperation(
 		if (initialContent.status === "failed") {
 			failed.push({
 				code: initialContent.code,
+				...(initialContent.detail ? { detail: initialContent.detail } : {}),
 				index,
 				path: path.path,
 			});
@@ -272,7 +277,8 @@ function getCreateWorkspaceItemInitialContent(input: CreateWorkspaceItemOperatio
 			status: "ready";
 	  }
 	| {
-			code: "invalid_initial_content";
+			code: "invalid_initial_content" | "widget_script_syntax_error";
+			detail?: string;
 			status: "failed";
 	  } {
 	if (input.type !== "document" || input.initialContent === undefined) {
@@ -284,9 +290,13 @@ function getCreateWorkspaceItemInitialContent(input: CreateWorkspaceItemOperatio
 			content: stringifyTiptapDocumentJson(parseDocumentAiHtml(input.initialContent)),
 			status: "ready",
 		};
-	} catch {
+	} catch (error) {
 		return {
-			code: "invalid_initial_content",
+			code:
+				error instanceof WidgetScriptSyntaxError
+					? "widget_script_syntax_error"
+					: "invalid_initial_content",
+			...(error instanceof WidgetScriptSyntaxError ? { detail: error.message } : {}),
 			status: "failed",
 		};
 	}

--- a/src/features/workspaces/operations/workspace-operation-failure-codes.ts
+++ b/src/features/workspaces/operations/workspace-operation-failure-codes.ts
@@ -9,6 +9,7 @@ import { workspaceRelationFailureCodes } from "#/features/workspaces/operations/
 export const createWorkspaceItemsFailureCodes = [
 	"cannot_create_root",
 	"invalid_initial_content",
+	"widget_script_syntax_error",
 	"path_already_exists",
 	"path_not_absolute",
 	"path_not_folder",

--- a/src/features/workspaces/operations/workspace-tool-schemas.ts
+++ b/src/features/workspaces/operations/workspace-tool-schemas.ts
@@ -380,7 +380,9 @@ export const workspaceCreateItemsOutputSchema = createWorkspaceItemsResultSchema
 		// files and study items this tool cannot produce.
 		type: z.enum(["document", "folder"]),
 	}),
-	failureSchema: createFailureSchema(createWorkspaceItemsFailureCodes),
+	failureSchema: createFailureSchema(createWorkspaceItemsFailureCodes).extend({
+		detail: z.string().optional().describe("Why this item was refused, when the reason is known."),
+	}),
 }).extend({
 	references: z.array(workspaceReferenceRecordSchema),
 });


### PR DESCRIPTION
## What changed

- Parse executable inline widget scripts with Acorn before document creation or edits are persisted
- Return `widget_script_syntax_error` with an actionable diagnostic to the original tool call
- Preserve existing widgets when a proposed edit has invalid JavaScript
- Keep create and edit model-output adapters on the canonical tool schemas
- Guide complex widgets toward functional, incremental slices with focused edits
- Expose syntax failures through existing workspace operation and AI tool telemetry

## Why

Widget JavaScript syntax errors were discovered only after the document had been saved and the browser mounted the sandbox. New widgets could enter an error state, and edits could replace a working widget with invalid source. The original tool call still appeared successful, so repair required a later user-triggered flow.

Validation now runs at the shared document parsing seam used by both creation and edits. Invalid creation is rejected before storage. Invalid edits leave the previous widget intact. The model receives the diagnostic in the same tool result and can repair and retry.

## User impact

Small widgets continue to be created in one write. Complex widgets are built as working slices, so later failures reject only the focused edit while the last valid version remains available.

## Validation

- `pnpm check`
- 32 focused Vitest tests across document parsing, Worker compatibility, edit atomicity, create persistence, model-result projection, and tool contracts
- `git diff --check origin/main..HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788923188&installation_model_id=425282&pr_number=755&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F755&signature=fe3ebae3b6f9984a528a0fdfb4b34a8b230dd3a278d84b27a8002dd52d84a84b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

