### PR TITLE
feat(workspaces): add workspace history

### DIFF
--- a/src/features/workspaces/ai/workspace-tools.ts
+++ b/src/features/workspaces/ai/workspace-tools.ts
@@ -69,6 +69,7 @@ function createWorkspaceThreadTool(input: WorkspaceThreadToolConfig) {
 					thread,
 					getWorkspaceToolScopes(definition.access),
 					context.invocationId,
+					context.codemodeExecutionId,
 					input.resolveWorkspaceReferences,
 				),
 			);
@@ -120,10 +121,16 @@ function createThreadWorkspaceAccessContext(
 	thread: AIThreadContext,
 	scopes: readonly WorkspaceAccessScope[],
 	operationId: string,
+	groupId: string | undefined,
 	resolveWorkspaceReferences?: (refs: readonly string[]) => Promise<WorkspaceReferenceRecord[]>,
 ): WorkspaceAccessContext {
 	return createWorkspaceAccessContext({
 		operationId,
+		provenance: {
+			groupId,
+			origin: "ai",
+			threadId: thread.id,
+		},
 		...(resolveWorkspaceReferences ? { resolveWorkspaceReferences } : {}),
 		scopes,
 		userId: thread.userId,

--- a/src/features/workspaces/components/WorkspaceHistoryDialog.tsx
+++ b/src/features/workspaces/components/WorkspaceHistoryDialog.tsx
@@ -1,0 +1,264 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import {
+	Activity,
+	ChevronRight,
+	Clock3,
+	FilePenLine,
+	FolderInput,
+	History,
+	Link2,
+	LoaderCircle,
+	Palette,
+	Plus,
+	RotateCcw,
+	Trash2,
+} from "lucide-react";
+import { useState } from "react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "#/components/ui/avatar";
+import { Button } from "#/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "#/components/ui/dialog";
+import type { WorkspaceHistoryEntry } from "#/features/workspaces/history/workspace-history-contract";
+import { listWorkspaceHistoryFn } from "#/features/workspaces/history/workspace-history-functions";
+import { WorkspaceHistoryVersionPreview } from "#/features/workspaces/components/WorkspaceHistoryVersionPreview";
+import { cn } from "#/lib/utils";
+
+const historyPageSize = 50;
+
+export function WorkspaceHistoryDialog({
+	open,
+	onOpenChange,
+	workspaceId,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	workspaceId: string;
+}) {
+	const [selectedVersion, setSelectedVersion] = useState<{
+		actorName: string;
+		createdAt: string;
+		entryId: string;
+		itemId: string;
+		itemName: string;
+		versionId: string;
+	} | null>(null);
+	const historyQuery = useInfiniteQuery({
+		enabled: open,
+		getNextPageParam: (lastPage: WorkspaceHistoryEntry[]) =>
+			lastPage.length === historyPageSize ? lastPage.at(-1)?.revision : undefined,
+		initialPageParam: undefined as number | undefined,
+		queryFn: ({ pageParam }: { pageParam: number | undefined }) =>
+			listWorkspaceHistoryFn({
+				data: {
+					...(pageParam ? { beforeRevision: pageParam } : {}),
+					limit: historyPageSize,
+					workspaceId,
+				},
+			}),
+		queryKey: ["workspace-history", workspaceId],
+	});
+	const entries = historyQuery.data?.pages.flat() ?? [];
+	const handleOpenChange = (nextOpen: boolean) => {
+		if (!nextOpen) setSelectedVersion(null);
+		onOpenChange(nextOpen);
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={handleOpenChange}>
+			<DialogContent className="flex h-[min(48rem,88vh)] flex-col gap-0 p-0 sm:max-w-6xl">
+				<DialogHeader className="shrink-0 border-b px-6 py-5">
+					<DialogTitle>Workspace history</DialogTitle>
+					<DialogDescription>
+						Recent changes across this workspace. Select a document version to compare or restore
+						it.
+					</DialogDescription>
+				</DialogHeader>
+				<div className="grid min-h-0 flex-1 grid-rows-[minmax(12rem,2fr)_3fr] sm:grid-cols-[20rem_minmax(0,1fr)] sm:grid-rows-1">
+					<aside className="flex min-h-0 flex-col border-b sm:border-r sm:border-b-0">
+						<div className="shrink-0 border-b px-4 py-3">
+							<p className="font-medium text-sm">Recent activity</p>
+						</div>
+						<div className="min-h-0 flex-1 overflow-y-auto p-2">
+							{historyQuery.isPending ? (
+								<div className="flex items-center justify-center gap-2 py-12 text-muted-foreground text-sm">
+									<LoaderCircle className="size-4 animate-spin" /> Loading history…
+								</div>
+							) : historyQuery.isError ? (
+								<div className="py-12 text-center text-destructive text-sm">
+									Could not load workspace history.
+								</div>
+							) : entries.length === 0 ? (
+								<div className="flex flex-col items-center gap-2 py-12 text-center text-muted-foreground text-sm">
+									<Clock3 className="size-5" />
+									Changes will appear here as you work.
+								</div>
+							) : (
+								<ul className="space-y-1">
+									{entries.map((entry) => {
+										const document = entry.items.find((item) => item.type === "document");
+										const versionId = entry.versionId;
+										const isSelectable = Boolean(
+											versionId && document && entry.type === "workspace.item.content.updated",
+										);
+										const isSelected = entry.id === selectedVersion?.entryId;
+										const content = (
+											<>
+												<div className="min-w-0 flex-1 text-left">
+													<div className="flex items-center gap-2">
+														<div className="flex size-5 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+															<HistoryActionIcon entry={entry} />
+														</div>
+														<p className="truncate text-sm">{describeHistoryEntry(entry)}</p>
+													</div>
+													<div className="mt-1 flex items-center gap-2 text-muted-foreground text-xs">
+														<Avatar size="sm" className="size-5 shadow-none">
+															<AvatarImage src={entry.actor.image ?? undefined} alt="" />
+															<AvatarFallback className="text-[9px]">
+																{getInitials(entry.actor.name)}
+															</AvatarFallback>
+														</Avatar>
+														<span className="truncate">{entry.actor.name}</span>
+														<span aria-hidden="true">·</span>
+														<span className="shrink-0">{formatHistoryDate(entry.createdAt)}</span>
+													</div>
+												</div>
+												{isSelectable ? (
+													<ChevronRight className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+												) : null}
+											</>
+										);
+										return (
+											<li key={`${entry.id}:${entry.versionId ?? "event"}`}>
+												{isSelectable && document && versionId ? (
+													<button
+														type="button"
+														className={cn(
+															"flex w-full items-start gap-2 rounded-lg px-3 py-3 transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+															isSelected && "bg-accent text-accent-foreground",
+														)}
+														onClick={() => {
+															setSelectedVersion({
+																actorName: entry.actor.name,
+																createdAt: entry.createdAt,
+																entryId: entry.id,
+																itemId: document.id,
+																itemName: document.name,
+																versionId,
+															});
+														}}
+													>
+														{content}
+													</button>
+												) : (
+													<div className="flex items-start gap-2 px-3 py-3">{content}</div>
+												)}
+											</li>
+										);
+									})}
+									{historyQuery.hasNextPage ? (
+										<li className="flex justify-center p-3">
+											<Button
+												type="button"
+												variant="outline"
+												size="sm"
+												disabled={historyQuery.isFetchingNextPage}
+												onClick={() => void historyQuery.fetchNextPage()}
+											>
+												{historyQuery.isFetchingNextPage ? (
+													<LoaderCircle className="size-4 animate-spin" />
+												) : null}
+												Load older
+											</Button>
+										</li>
+									) : null}
+								</ul>
+							)}
+						</div>
+					</aside>
+					<section className="flex min-h-0 min-w-0 flex-col bg-background/40">
+						{selectedVersion ? (
+							<WorkspaceHistoryVersionPreview
+								actorName={selectedVersion.actorName}
+								createdAt={selectedVersion.createdAt}
+								itemId={selectedVersion.itemId}
+								itemName={selectedVersion.itemName}
+								onRestored={() => setSelectedVersion(null)}
+								versionId={selectedVersion.versionId}
+								workspaceId={workspaceId}
+							/>
+						) : (
+							<div className="flex min-h-0 flex-1 flex-col items-center justify-center px-6 text-center">
+								<div className="mb-4 flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+									<History className="size-5" aria-hidden="true" />
+								</div>
+								<p className="font-medium">Select a document version</p>
+								<p className="mt-1 max-w-sm text-muted-foreground text-sm">
+									Choose an editable change from the timeline to see exactly what was added or
+									removed.
+								</p>
+							</div>
+						)}
+					</section>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function formatHistoryDate(createdAt: string) {
+	return new Date(createdAt).toLocaleString(undefined, {
+		dateStyle: "short",
+		timeStyle: "short",
+	});
+}
+
+function HistoryActionIcon({ entry }: { entry: WorkspaceHistoryEntry }) {
+	const className = "size-3";
+	if (entry.type === "workspace.item.content.updated") {
+		return entry.origin === "restore" ? (
+			<RotateCcw className={className} aria-hidden="true" />
+		) : (
+			<FilePenLine className={className} aria-hidden="true" />
+		);
+	}
+	const Icon =
+		{
+			"workspace.item.color.updated": Palette,
+			"workspace.item.created": Plus,
+			"workspace.item.deleted": Trash2,
+			"workspace.item.renamed": FilePenLine,
+			"workspace.items.moved": FolderInput,
+			"workspace.relations.updated": Link2,
+		}[entry.type] ?? Activity;
+	return <Icon className={className} aria-hidden="true" />;
+}
+
+function getInitials(name: string) {
+	return name
+		.split(/\s+/)
+		.map((part) => part[0])
+		.join("")
+		.slice(0, 2)
+		.toUpperCase();
+}
+
+function describeHistoryEntry(entry: WorkspaceHistoryEntry) {
+	const names = entry.items.map((item) => item.name);
+	const itemLabel = names.length > 0 ? names.join(", ") : "workspace";
+	const actions: Record<string, string> = {
+		"workspace.item.color.updated": "Changed the color of",
+		"workspace.item.content.updated": entry.origin === "restore" ? "Restored" : "Edited",
+		"workspace.item.created": "Created",
+		"workspace.item.deleted": "Deleted",
+		"workspace.item.renamed": "Renamed",
+		"workspace.items.moved": "Moved",
+		"workspace.relations.updated": "Updated links in",
+	};
+	return `${actions[entry.type] ?? "Updated"} ${itemLabel}`;
+}

--- a/src/features/workspaces/components/WorkspaceHistoryVersionPreview.tsx
+++ b/src/features/workspaces/components/WorkspaceHistoryVersionPreview.tsx
@@ -1,0 +1,184 @@
+import type { JSONContent } from "@tiptap/core";
+import { EditorContent, useEditor } from "@tiptap/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { LoaderCircle, RotateCcw } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "#/components/ui/alert-dialog";
+import { Button } from "#/components/ui/button";
+import { useWorkspaceMutationAccess } from "#/features/workspaces/components/workspace-mutation-access";
+import {
+	DocumentEditReviewExtension,
+	hideDocumentEditReview,
+	showDocumentEditReview,
+} from "#/features/workspaces/documents/document-edit-review-extension";
+import {
+	createInitialTiptapDocumentJson,
+	parseTiptapDocumentJson,
+	type TiptapDocumentJson,
+} from "#/features/workspaces/documents/tiptap-document";
+import { getTiptapDocumentBaseExtensions } from "#/features/workspaces/documents/tiptap-extensions";
+import {
+	getWorkspaceHistoryVersionFn,
+	restoreWorkspaceHistoryVersionFn,
+} from "#/features/workspaces/history/workspace-history-functions";
+
+export function WorkspaceHistoryVersionPreview({
+	actorName,
+	createdAt,
+	itemId,
+	itemName,
+	onRestored,
+	versionId,
+	workspaceId,
+}: {
+	actorName: string;
+	createdAt: string;
+	itemId: string;
+	itemName: string;
+	onRestored: () => void;
+	versionId: string;
+	workspaceId: string;
+}) {
+	const { capabilities } = useWorkspaceMutationAccess();
+	const queryClient = useQueryClient();
+	const [isConfirmingRestore, setIsConfirmingRestore] = useState(false);
+	const versionQuery = useQuery({
+		queryFn: () => getWorkspaceHistoryVersionFn({ data: { itemId, versionId, workspaceId } }),
+		queryKey: ["workspace-history-version", workspaceId, itemId, versionId],
+		retry: false,
+	});
+	const restoreMutation = useMutation({
+		mutationFn: () =>
+			restoreWorkspaceHistoryVersionFn({ data: { itemId, versionId, workspaceId } }),
+		onError: (error) => {
+			toast.error(error instanceof Error ? error.message : "Could not restore this version.");
+		},
+		onSuccess: async (result) => {
+			if (result.status !== "undone") {
+				toast.error("This version could not be restored.");
+				return;
+			}
+			await queryClient.invalidateQueries({ queryKey: ["workspace-history", workspaceId] });
+			toast.success("Version restored.");
+			onRestored();
+		},
+	});
+	const version = versionQuery.data && "content" in versionQuery.data ? versionQuery.data : null;
+	const canRestore = capabilities.canMutateContent && version?.canRestore === true;
+
+	return (
+		<>
+			<header className="shrink-0 border-b px-6 py-5">
+				<h3 className="truncate font-semibold text-lg">{itemName}</h3>
+				<p className="mt-1 text-muted-foreground text-sm">
+					Changed by {actorName} · {new Date(createdAt).toLocaleString()}
+				</p>
+			</header>
+			<div className="min-h-0 flex-1 overflow-y-auto px-6 py-2">
+				{versionQuery.isPending ? (
+					<div className="flex items-center justify-center gap-2 py-16 text-muted-foreground text-sm">
+						<LoaderCircle className="size-4 animate-spin" /> Loading version…
+					</div>
+				) : versionQuery.isError || !version ? (
+					<div className="py-16 text-center text-destructive text-sm">
+						This version is unavailable.
+					</div>
+				) : version.itemType !== "document" ? (
+					<div className="py-16 text-center text-muted-foreground text-sm">
+						Preview is not available for this item type yet.
+					</div>
+				) : (
+					<DocumentVersionDiff
+						afterDocument={parseTiptapDocumentJson(version.content)}
+						beforeDocument={
+							version.beforeContent
+								? parseTiptapDocumentJson(version.beforeContent)
+								: createInitialTiptapDocumentJson()
+						}
+					/>
+				)}
+			</div>
+			<footer className="flex shrink-0 items-center justify-between gap-4 border-t bg-dialog-footer px-6 py-4">
+				<p className="text-muted-foreground text-xs">
+					{version && !version.canRestore
+						? "Deleted items cannot be restored yet."
+						: "Green is added; red is removed."}
+				</p>
+				<Button
+					type="button"
+					variant="outline"
+					disabled={!canRestore || restoreMutation.isPending}
+					onClick={() => setIsConfirmingRestore(true)}
+				>
+					{restoreMutation.isPending ? (
+						<LoaderCircle className="size-4 animate-spin" />
+					) : (
+						<RotateCcw className="size-4" />
+					)}
+					Restore this version
+				</Button>
+			</footer>
+			<AlertDialog open={isConfirmingRestore} onOpenChange={setIsConfirmingRestore}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Restore this version?</AlertDialogTitle>
+						<AlertDialogDescription>
+							The current document stays in history, and this version becomes the latest one.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={() => {
+								setIsConfirmingRestore(false);
+								restoreMutation.mutate();
+							}}
+						>
+							Restore
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</>
+	);
+}
+
+function DocumentVersionDiff({
+	afterDocument,
+	beforeDocument,
+}: {
+	afterDocument: TiptapDocumentJson;
+	beforeDocument: TiptapDocumentJson;
+}) {
+	const editor = useEditor({
+		content: afterDocument as JSONContent,
+		editable: false,
+		editorProps: {
+			attributes: {
+				"aria-label": "Historical document changes",
+				class: "workspace-document-prose min-h-full py-4 outline-none",
+			},
+		},
+		extensions: [...getTiptapDocumentBaseExtensions(), DocumentEditReviewExtension],
+		immediatelyRender: false,
+	});
+
+	useEffect(() => {
+		if (!editor) return;
+		showDocumentEditReview(editor, beforeDocument);
+		return () => hideDocumentEditReview(editor);
+	}, [beforeDocument, editor]);
+
+	return <EditorContent editor={editor} />;
+}

--- a/src/features/workspaces/components/WorkspaceRootActionsMenu.tsx
+++ b/src/features/workspaces/components/WorkspaceRootActionsMenu.tsx
@@ -12,6 +12,7 @@ import { workspaceDropdownMenuRenderer } from "#/features/workspaces/components/
 import { WorkspaceExportDialog } from "#/features/workspaces/components/WorkspaceExportDialog";
 import WorkspaceSettingsDialog from "#/features/workspaces/components/WorkspaceSettingsDialog";
 import { WorkspaceShareDialog } from "#/features/workspaces/components/WorkspaceShareDialog";
+import { WorkspaceHistoryDialog } from "#/features/workspaces/components/WorkspaceHistoryDialog";
 import { WorkspaceToolbarIconButton } from "#/features/workspaces/components/WorkspaceToolbar";
 import {
 	renderWorkspaceMenuActions,
@@ -35,6 +36,7 @@ export default function WorkspaceRootActionsMenu({
 	const [settingsOpen, setSettingsOpen] = useState(false);
 	const [shareOpen, setShareOpen] = useState(false);
 	const [exportOpen, setExportOpen] = useState(false);
+	const [historyOpen, setHistoryOpen] = useState(false);
 
 	return (
 		<>
@@ -53,6 +55,7 @@ export default function WorkspaceRootActionsMenu({
 								canOpenSettings: capabilities.canMutateContent,
 								includeShare: !showShareButton,
 								onExport: () => setExportOpen(true),
+								onOpenHistory: () => setHistoryOpen(true),
 								onOpenSettings: () => setSettingsOpen(true),
 								onOpenShare: () => setShareOpen(true),
 							}),
@@ -66,6 +69,11 @@ export default function WorkspaceRootActionsMenu({
 				capabilities={capabilities}
 				open={settingsOpen}
 				onOpenChange={setSettingsOpen}
+			/>
+			<WorkspaceHistoryDialog
+				open={historyOpen}
+				onOpenChange={setHistoryOpen}
+				workspaceId={workspace.id}
 			/>
 			<WorkspaceShareDialog
 				membershipRole={workspace.membershipRole}
@@ -82,6 +90,7 @@ export default function WorkspaceRootActionsMenu({
 function getWorkspaceRootMenuActions(input: {
 	canOpenSettings: boolean;
 	includeShare: boolean;
+	onOpenHistory: () => void;
 	onExport: () => void;
 	onOpenSettings: () => void;
 	onOpenShare: () => void;
@@ -101,8 +110,7 @@ function getWorkspaceRootMenuActions(input: {
 			id: "version-history",
 			label: "Version history",
 			leading: <Clock3 className="size-4" />,
-			trailing: "Soon",
-			disabled: true,
+			onSelect: input.onOpenHistory,
 		},
 		{
 			kind: "item",

--- a/src/features/workspaces/components/document-editor/DocumentEditUndoButton.tsx
+++ b/src/features/workspaces/components/document-editor/DocumentEditUndoButton.tsx
@@ -36,7 +36,10 @@ export function DocumentEditUndoButton({
 	const [isConfirming, setIsConfirming] = useState(false);
 	const { hideReview } = useDocumentEditReview();
 	const undoMutation = useMutation({
-		mutationFn: () => undoDocumentEditReceiptFn({ data: { itemId, receiptIds, workspaceId } }),
+		mutationFn: () =>
+			undoDocumentEditReceiptFn({
+				data: { itemId, receiptIds, workspaceId },
+			}),
 		onSuccess: (result) => {
 			// Every outcome ends the review: it either just undid the changes, or
 			// told us they no longer describe the document. Leaving the marks up

--- a/src/features/workspaces/documents/document-edit-review-context.tsx
+++ b/src/features/workspaces/documents/document-edit-review-context.tsx
@@ -50,7 +50,11 @@ export function DocumentEditReviewProvider({
 			}
 
 			const review = await getDocumentEditReceiptReviewFn({
-				data: { itemId: input.itemId, receiptIds: input.receiptIds, workspaceId },
+				data: {
+					itemId: input.itemId,
+					receiptIds: input.receiptIds,
+					workspaceId,
+				},
 			}).catch(() => null);
 
 			if (!review) {

--- a/src/features/workspaces/documents/document-edit-review-functions.ts
+++ b/src/features/workspaces/documents/document-edit-review-functions.ts
@@ -42,11 +42,15 @@ export const getDocumentEditReceiptReviewFn = createServerFn({ method: "GET" })
 export const undoDocumentEditReceiptFn = createServerFn({ method: "POST" })
 	.validator(documentEditReceiptInputSchema)
 	.handler(async ({ data }): Promise<DocumentEditReceiptUndoResult> => {
-		await withWorkspaceDb(({ db, userId }) =>
-			assertCanMutateWorkspace(db, { userId, workspaceId: data.workspaceId }),
-		);
+		const userId = await withWorkspaceDb(async ({ db, userId }) => {
+			await assertCanMutateWorkspace(db, { userId, workspaceId: data.workspaceId });
+			return userId;
+		});
 		const session = await getDocumentEditSession(data);
-		return await session.undoDocumentEditReceipt({ receiptIds: data.receiptIds });
+		return await session.undoDocumentEditReceipt({
+			actorUserId: userId,
+			receiptIds: data.receiptIds,
+		});
 	});
 
 async function getDocumentEditSession(input: {
@@ -64,5 +68,8 @@ interface DocumentEditSession {
 	getDocumentEditReceiptReview(input: {
 		receiptIds: string[];
 	}): Promise<DocumentEditReceiptReviewRpcResult>;
-	undoDocumentEditReceipt(input: { receiptIds: string[] }): Promise<DocumentEditReceiptUndoResult>;
+	undoDocumentEditReceipt(input: {
+		actorUserId: string;
+		receiptIds: string[];
+	}): Promise<DocumentEditReceiptUndoResult>;
 }

--- a/src/features/workspaces/documents/document-session.ts
+++ b/src/features/workspaces/documents/document-session.ts
@@ -35,9 +35,9 @@ import {
 import type {
 	DocumentEditLineChanges,
 	DocumentEditReceiptReviewRpcResult,
-	DocumentEditReceiptStatus,
 	DocumentEditReceiptUndoResult,
 } from "#/features/workspaces/documents/document-edit-receipt";
+import type { WorkspaceMutationProvenance } from "#/features/workspaces/history/workspace-history-contract";
 import {
 	coerceTiptapDocumentJson,
 	parseTiptapDocumentJson,
@@ -55,17 +55,17 @@ import {
 import { sha256Base64Url, sha256Base64UrlText } from "#/lib/binary";
 
 const persistedYDocUpdateKey = "document-session:yjs-update";
-const latestDocumentEditReceiptKey = "document-session:ai-edit-receipt:latest";
-const documentEditReceiptIndexKey = "document-session:ai-edit-receipt:index";
+const pendingContributorIdsKey = "document-session:pending-contributors";
 const documentEditReceiptKeyPrefix = "document-session:ai-edit-receipt:";
-const maximumRetainedDocumentEditReceipts = 8;
-const maximumDocumentEditReceiptSnapshotBytes = 1_500_000;
 const checkpointDelayMs = 1_500;
 const checkpointMaxWaitMs = 8_000;
+const idleVersionDelayMs = 2 * 60 * 1_000;
 
 export interface DocumentSessionApplyEditsInput {
+	actorUserId: string;
 	edits: DocumentAiEdit[];
 	operationId: string;
+	provenance?: WorkspaceMutationProvenance;
 }
 
 export interface DocumentSessionApplyEditsResult {
@@ -87,26 +87,11 @@ export interface DocumentSessionApplyEditsResult {
 }
 
 interface StoredDocumentEditReceipt {
-	afterHash: string;
-	beforeDocument?: TiptapDocumentJson;
 	id: string;
 	inputHash: string;
-	previousReceiptId: string | null;
 	result: DocumentSessionApplyEditsResult;
 	status: "applied" | "reverted";
 }
-
-type ResolvedDocumentEditReceiptGroup =
-	| {
-			beforeDocument: TiptapDocumentJson;
-			lastReceiptId: string;
-			previousReceiptId: string | null;
-			receipts: StoredDocumentEditReceipt[];
-			status: "ready";
-	  }
-	| {
-			status: Exclude<DocumentEditReceiptStatus, "ready">;
-	  };
 
 export class DocumentSession extends YServer {
 	static override options = {
@@ -160,7 +145,7 @@ export class DocumentSession extends YServer {
 
 		const room = getDocumentSessionRoomNameParts(this.name);
 		const kernel = await this.getWorkspaceKernel(room.workspaceId);
-		const { content } = await kernel.readDocumentCheckpoint({ itemId: room.itemId });
+		const { content } = await kernel.readItemContent({ itemId: room.itemId });
 		if (this.deleted) {
 			return;
 		}
@@ -185,7 +170,36 @@ export class DocumentSession extends YServer {
 		if (this.deleted) {
 			return;
 		}
-		await this.checkpointToKernel();
+		const activeContributorIds = Array.from(
+			new Set(
+				Array.from(this.getConnections<DocumentSessionConnectionState>()).flatMap((connection) =>
+					connection.state?.userId ? [connection.state.userId] : [],
+				),
+			),
+		);
+		const pendingContributorIds = Array.from(
+			new Set([
+				...((await this.ctx.storage.get<string[]>(pendingContributorIdsKey)) ?? []),
+				...activeContributorIds,
+			]),
+		);
+		await this.ctx.storage.put(pendingContributorIdsKey, pendingContributorIds);
+		await this.checkpointToKernel({
+			actorUserId: pendingContributorIds.length === 1 ? pendingContributorIds[0] : null,
+			provenance: { origin: "human" },
+		});
+		await this.ctx.storage.setAlarm(Date.now() + idleVersionDelayMs);
+	}
+
+	override async onAlarm() {
+		if (this.deleted) return;
+		const contributors = (await this.ctx.storage.get<string[]>(pendingContributorIdsKey)) ?? [];
+		await this.checkpointToKernel({
+			actorUserId: contributors.length === 1 ? contributors[0] : null,
+			clearPendingContributors: true,
+			createVersion: true,
+			provenance: { origin: "human" },
+		});
 	}
 
 	async readDocumentSnapshot() {
@@ -210,10 +224,6 @@ export class DocumentSession extends YServer {
 				: rejectedDocumentEditResult("operation_id_conflict", input.edits.length);
 		}
 
-		const latestReceiptId = await this.ctx.storage.get<string>(latestDocumentEditReceiptKey);
-		const latestReceipt = latestReceiptId
-			? await this.getDocumentEditReceipt(latestReceiptId)
-			: undefined;
 		const referencedDocument = await this.getReferencedDocumentSnapshot();
 		const currentDocument = coerceTiptapDocumentJson(referencedDocument.document.toJSON());
 		const editResult = await applyDocumentAiEdits(currentDocument, input.edits);
@@ -228,12 +238,6 @@ export class DocumentSession extends YServer {
 		}
 
 		const beforeDocumentText = stringifyTiptapDocumentJson(currentDocument);
-		const afterDocumentText = stringifyTiptapDocumentJson(editResult.document);
-		const [beforeHash, afterHash] = await Promise.all([
-			sha256Base64UrlText(beforeDocumentText),
-			sha256Base64UrlText(afterDocumentText),
-		]);
-
 		if (stringifyTiptapDocumentJson(this.getCurrentTiptapDocument()) !== beforeDocumentText) {
 			return rejectedDocumentEditResult("content_changed", input.edits.length);
 		}
@@ -246,47 +250,28 @@ export class DocumentSession extends YServer {
 			status: editResult.status,
 		};
 		const receipt: StoredDocumentEditReceipt = {
-			afterHash,
-			...(fitsDocumentEditReceiptSnapshot(beforeDocumentText)
-				? { beforeDocument: currentDocument }
-				: {}),
 			id: input.operationId,
 			inputHash,
-			previousReceiptId:
-				latestReceipt?.status === "applied" && latestReceipt.afterHash === beforeHash
-					? latestReceipt.id
-					: null,
 			result,
 			status: "applied",
 		};
 
-		// Only the newest edit can still be undone, so older receipts are dead
-		// weight — and each one holds a whole copy of the document. Keep enough for
-		// a turn that edited this document several times, and drop the rest.
-		const recentReceiptIds = [
-			...((await this.ctx.storage.get<string[]>(documentEditReceiptIndexKey)) ?? []),
-			receipt.id,
-		];
-		const expiredReceiptIds = recentReceiptIds.splice(
-			0,
-			Math.max(0, recentReceiptIds.length - maximumRetainedDocumentEditReceipts),
-		);
-
 		this.reconcileCurrentDocument(editResult.document);
 		const persistedUpdate = Y.encodeStateAsUpdate(this.document);
-		await this.ctx.storage.transaction(async (transaction) => {
-			await Promise.all([
-				transaction.put(persistedYDocUpdateKey, persistedUpdate),
-				transaction.put(getDocumentEditReceiptKey(receipt.id), receipt),
-				transaction.put(latestDocumentEditReceiptKey, receipt.id),
-				transaction.put(documentEditReceiptIndexKey, recentReceiptIds),
-				...(expiredReceiptIds.length > 0
-					? [transaction.delete(expiredReceiptIds.map(getDocumentEditReceiptKey))]
-					: []),
-			]);
+		await this.ctx.storage.put({
+			[persistedYDocUpdateKey]: persistedUpdate,
+			[getDocumentEditReceiptKey(receipt.id)]: receipt,
 		});
 		this.assertActive();
-		if (!(await this.checkpointToKernel(input.operationId))) {
+		if (
+			!(await this.checkpointToKernel({
+				actorUserId: input.actorUserId,
+				clientMutationId: input.operationId,
+				provenance: input.provenance,
+				versionId: input.operationId,
+				createVersion: true,
+			}))
+		) {
 			return rejectedDocumentEditResult("path_not_found", input.edits.length);
 		}
 		this.assertActive();
@@ -297,51 +282,69 @@ export class DocumentSession extends YServer {
 	async getDocumentEditReceiptReview(input: {
 		receiptIds: string[];
 	}): Promise<DocumentEditReceiptReviewRpcResult> {
-		const group = await this.resolveDocumentEditReceiptGroup(input.receiptIds);
+		return await this.readVersionChange({ versionIds: input.receiptIds });
+	}
 
-		if (group.status !== "ready") {
-			return { status: group.status };
-		}
-
-		return {
-			beforeContent: stringifyTiptapDocumentJson(group.beforeDocument),
-			status: "ready",
-		};
+	async restoreDocumentVersion(input: {
+		actorUserId: string;
+		versionId: string;
+	}): Promise<DocumentEditReceiptUndoResult> {
+		const room = getDocumentSessionRoomNameParts(this.name);
+		const kernel = await this.getWorkspaceKernel(room.workspaceId);
+		const target = await kernel.readItemVersion({
+			itemId: room.itemId,
+			versionId: input.versionId,
+		});
+		if (target.status !== "ready") return target;
+		this.reconcileCurrentDocument(parseTiptapDocumentJson(target.content));
+		await this.persistYDoc();
+		if (
+			!(await this.checkpointToKernel({
+				actorUserId: input.actorUserId,
+				clientMutationId: `restore:${input.versionId}:${crypto.randomUUID()}`,
+				createVersion: true,
+				provenance: { origin: "restore" },
+			}))
+		)
+			return { status: "not_found" };
+		return { status: "undone" };
 	}
 
 	async undoDocumentEditReceipt(input: {
+		actorUserId: string;
 		receiptIds: string[];
 	}): Promise<DocumentEditReceiptUndoResult> {
-		const group = await this.resolveDocumentEditReceiptGroup(input.receiptIds);
-
-		if (group.status !== "ready") {
-			return { status: group.status };
-		}
-
-		this.reconcileCurrentDocument(group.beforeDocument);
+		const receipts = await Promise.all(
+			input.receiptIds.map((receiptId) => this.getDocumentEditReceipt(receiptId)),
+		);
+		if (receipts.some((receipt) => receipt?.status === "reverted")) return { status: "reverted" };
+		if (receipts.some((receipt) => !receipt)) return { status: "not_found" };
+		const target = await this.readVersionChange({ versionIds: input.receiptIds });
+		if (target.status !== "ready") return target;
+		const targetDocument = parseTiptapDocumentJson(target.beforeContent);
+		this.reconcileCurrentDocument(targetDocument);
 		const persistedUpdate = Y.encodeStateAsUpdate(this.document);
-
-		await this.ctx.storage.transaction(async (transaction) => {
-			await Promise.all([
-				transaction.put(persistedYDocUpdateKey, persistedUpdate),
-				...group.receipts.map((receipt) =>
-					transaction.put(getDocumentEditReceiptKey(receipt.id), {
-						...receipt,
-						status: "reverted",
-					} satisfies StoredDocumentEditReceipt),
-				),
-			]);
-
-			if (group.previousReceiptId) {
-				await transaction.put(latestDocumentEditReceiptKey, group.previousReceiptId);
-			} else {
-				await transaction.delete(latestDocumentEditReceiptKey);
-			}
-		});
-
-		if (!(await this.checkpointToKernel(`undo:${group.lastReceiptId}`))) {
+		await this.ctx.storage.put(persistedYDocUpdateKey, persistedUpdate);
+		const lastReceiptId = input.receiptIds.at(-1);
+		if (
+			!lastReceiptId ||
+			!(await this.checkpointToKernel({
+				actorUserId: input.actorUserId,
+				clientMutationId: `undo:${lastReceiptId}`,
+				createVersion: true,
+				provenance: { origin: "restore" },
+			}))
+		) {
 			return { status: "not_found" };
 		}
+		await Promise.all(
+			(receipts as StoredDocumentEditReceipt[]).map((receipt) =>
+				this.ctx.storage.put(getDocumentEditReceiptKey(receipt.id), {
+					...receipt,
+					status: "reverted",
+				}),
+			),
+		);
 
 		return { status: "undone" };
 	}
@@ -398,23 +401,39 @@ export class DocumentSession extends YServer {
 			connection.close(1008, "Document deleted");
 		}
 		this.document.destroy();
+		await this.ctx.storage.deleteAlarm();
 		await this.ctx.storage.deleteAll();
 	}
 
-	private async checkpointToKernel(clientMutationId: string | null = null) {
+	private async checkpointToKernel(
+		input: {
+			actorUserId?: string | null;
+			clearPendingContributors?: boolean;
+			clientMutationId?: string | null;
+			createVersion?: boolean;
+			provenance?: WorkspaceMutationProvenance;
+			versionId?: string;
+		} = {},
+	) {
 		const room = getDocumentSessionRoomNameParts(this.name);
 		const document = this.getCurrentTiptapDocument();
 		const kernel = await this.getWorkspaceKernel(room.workspaceId);
 
-		const outcome = await kernel.commitDocumentCheckpoint({
+		const outcome = await kernel.commitItemContent({
 			itemId: room.itemId,
 			content: stringifyTiptapDocumentJson(document),
-			actorUserId: null,
-			clientMutationId,
+			actorUserId: input.actorUserId ?? null,
+			clientMutationId: input.clientMutationId ?? null,
+			createVersion: input.createVersion,
+			provenance: input.provenance,
+			versionId: input.versionId,
 		});
-		if (outcome === "discarded") {
+		if (outcome.status === "discarded") {
 			await this.purgeForDeletion();
 			return false;
+		}
+		if ((outcome.versionId || outcome.eventId === null) && input.clearPendingContributors) {
+			await this.ctx.storage.delete(pendingContributorIdsKey);
 		}
 
 		return true;
@@ -426,59 +445,17 @@ export class DocumentSession extends YServer {
 		);
 	}
 
-	private async resolveDocumentEditReceiptGroup(
-		receiptIds: string[],
-	): Promise<ResolvedDocumentEditReceiptGroup> {
-		if (receiptIds.length === 0 || new Set(receiptIds).size !== receiptIds.length) {
-			return { status: "not_found" };
-		}
-
-		const receipts = await Promise.all(
-			receiptIds.map((receiptId) => this.getDocumentEditReceipt(receiptId)),
-		);
-		const storedReceipts = receipts.filter(
-			(receipt): receipt is StoredDocumentEditReceipt => receipt !== undefined,
-		);
-		if (storedReceipts.length !== receiptIds.length) {
-			return { status: "not_found" };
-		}
-		if (storedReceipts.some((receipt) => receipt.status === "reverted")) {
-			return { status: "reverted" };
-		}
-		for (let index = 1; index < storedReceipts.length; index += 1) {
-			if (storedReceipts[index]?.previousReceiptId !== storedReceipts[index - 1]?.id) {
-				return { status: "not_latest" };
-			}
-		}
-
-		const firstReceipt = storedReceipts[0];
-		const lastReceipt = storedReceipts.at(-1);
-		if (!firstReceipt || !lastReceipt) {
-			return { status: "not_found" };
-		}
-
-		const latestReceiptId = await this.ctx.storage.get<string>(latestDocumentEditReceiptKey);
-		if (latestReceiptId !== lastReceipt.id) {
-			return { status: "not_latest" };
-		}
-		if (!firstReceipt.beforeDocument) {
-			return { status: "review_unavailable" };
-		}
-
-		this.assertActive();
-		const currentDocumentText = stringifyTiptapDocumentJson(this.getCurrentTiptapDocument());
-		const currentHash = await sha256Base64UrlText(currentDocumentText);
-
-		return currentHash === lastReceipt.afterHash &&
-			stringifyTiptapDocumentJson(this.getCurrentTiptapDocument()) === currentDocumentText
-			? {
-					beforeDocument: firstReceipt.beforeDocument,
-					lastReceiptId: lastReceipt.id,
-					previousReceiptId: firstReceipt.previousReceiptId,
-					receipts: storedReceipts,
-					status: "ready",
-				}
-			: { status: "content_changed" };
+	private async readVersionChange(input: { versionIds: string[] }) {
+		const room = getDocumentSessionRoomNameParts(this.name);
+		const kernel = await this.getWorkspaceKernel(room.workspaceId);
+		const target = await kernel.readItemVersionChange(input);
+		if (target.status !== "ready") return target;
+		const currentText = stringifyTiptapDocumentJson(this.getCurrentTiptapDocument());
+		const currentHash = await sha256Base64UrlText(currentText);
+		return (target.expectedCurrentHash === null || currentHash === target.expectedCurrentHash) &&
+			stringifyTiptapDocumentJson(this.getCurrentTiptapDocument()) === currentText
+			? { beforeContent: target.beforeContent, status: "ready" as const }
+			: { status: "content_changed" as const };
 	}
 
 	private getCurrentTiptapDocument() {
@@ -546,12 +523,6 @@ function getDocumentSessionRoomNameParts(roomName: string): DocumentSessionRoute
 
 function getDocumentEditReceiptKey(receiptId: string) {
 	return `${documentEditReceiptKeyPrefix}${receiptId}`;
-}
-
-function fitsDocumentEditReceiptSnapshot(documentText: string) {
-	return (
-		new TextEncoder().encode(documentText).byteLength <= maximumDocumentEditReceiptSnapshotBytes
-	);
 }
 
 function rejectedDocumentEditResult(

--- a/src/features/workspaces/export/workspace-export.ts
+++ b/src/features/workspaces/export/workspace-export.ts
@@ -91,7 +91,7 @@ async function prepareWorkspaceExport(input: { workspaceId: string; userId: stri
 	// bytes are sent, an error can only abort the download and leave a partial archive.
 	for (const item of page.items) {
 		if (item.type === "document") {
-			const { content } = await kernel.readDocumentCheckpoint({ itemId: item.id });
+			const { content } = await kernel.readItemContent({ itemId: item.id });
 			estimatedBytes += textEncoder.encode(content).byteLength;
 			documents.set(item.id, parseTiptapDocumentJson(content));
 			continue;

--- a/src/features/workspaces/history/workspace-history-contract.ts
+++ b/src/features/workspaces/history/workspace-history-contract.ts
@@ -1,0 +1,33 @@
+import type { WorkspaceItemType } from "#/features/workspaces/contracts";
+
+export const workspaceHistoryOrigins = ["human", "ai", "system", "restore", "import"] as const;
+export type WorkspaceHistoryOrigin = (typeof workspaceHistoryOrigins)[number];
+
+export interface WorkspaceMutationProvenance {
+	groupId?: string | null;
+	origin: WorkspaceHistoryOrigin;
+	threadId?: string | null;
+}
+
+export interface WorkspaceHistoryItem {
+	id: string;
+	name: string;
+	type: WorkspaceItemType;
+}
+
+export interface WorkspaceHistoryEntry {
+	actor: {
+		image: string | null;
+		name: string;
+	};
+	actorUserId: string | null;
+	createdAt: string;
+	groupId: string | null;
+	id: string;
+	items: WorkspaceHistoryItem[];
+	origin: WorkspaceHistoryOrigin;
+	revision: number;
+	threadId: string | null;
+	type: string;
+	versionId: string | null;
+}

--- a/src/features/workspaces/history/workspace-history-functions.ts
+++ b/src/features/workspaces/history/workspace-history-functions.ts
@@ -1,0 +1,96 @@
+import { createServerFn } from "@tanstack/react-start";
+import { z } from "zod";
+
+import type { WorkspaceHistoryEntry } from "#/features/workspaces/history/workspace-history-contract";
+import { getDocumentSessionFromEnv } from "#/features/workspaces/document-session-access";
+import type { DocumentEditReceiptUndoResult } from "#/features/workspaces/documents/document-edit-receipt";
+import { getWorkspaceKernel } from "#/features/workspaces/kernel/workspace-kernel-access";
+import { listWorkspaceMembers } from "#/features/workspaces/members/workspace-members.server";
+import { withWorkspaceDb } from "#/features/workspaces/server/workspace-db";
+import {
+	assertCanMutateWorkspace,
+	assertCanReadWorkspace,
+} from "#/features/workspaces/server/permissions";
+
+const workspaceHistoryInputSchema = z.strictObject({
+	beforeRevision: z.number().int().positive().optional(),
+	limit: z.number().int().min(1).max(100).optional(),
+	workspaceId: z.string().trim().min(1),
+});
+
+export const listWorkspaceHistoryFn = createServerFn({ method: "GET" })
+	.validator(workspaceHistoryInputSchema)
+	.handler(async ({ data }): Promise<WorkspaceHistoryEntry[]> => {
+		const members = await withWorkspaceDb(async ({ db, userId }) => {
+			return await listWorkspaceMembers(db, { userId, workspaceId: data.workspaceId });
+		});
+		const kernel = await getWorkspaceKernel(data.workspaceId);
+		const history = await kernel.listHistory({
+			beforeRevision: data.beforeRevision,
+			limit: data.limit,
+		});
+		const membersById = new Map(members.map((member) => [member.userId, member]));
+
+		return history.map((entry) => ({
+			...entry,
+			actor: getHistoryActor(entry.actorUserId, entry.origin, membersById),
+		}));
+	});
+
+const workspaceHistoryVersionInputSchema = z.strictObject({
+	itemId: z.string().trim().min(1),
+	versionId: z.string().trim().min(1).max(512),
+	workspaceId: z.string().trim().min(1),
+});
+
+export const getWorkspaceHistoryVersionFn = createServerFn({ method: "GET" })
+	.validator(workspaceHistoryVersionInputSchema)
+	.handler(async ({ data }) => {
+		await withWorkspaceDb(({ db, userId }) =>
+			assertCanReadWorkspace(db, { userId, workspaceId: data.workspaceId }),
+		);
+		const kernel = await getWorkspaceKernel(data.workspaceId);
+		return await kernel.readItemVersion({ itemId: data.itemId, versionId: data.versionId });
+	});
+
+export const restoreWorkspaceHistoryVersionFn = createServerFn({ method: "POST" })
+	.validator(workspaceHistoryVersionInputSchema)
+	.handler(async ({ data }): Promise<DocumentEditReceiptUndoResult> => {
+		const userId = await withWorkspaceDb(async ({ db, userId }) => {
+			await assertCanMutateWorkspace(db, { userId, workspaceId: data.workspaceId });
+			return userId;
+		});
+		const kernel = await getWorkspaceKernel(data.workspaceId);
+		const version = await kernel.readItemVersion({
+			itemId: data.itemId,
+			versionId: data.versionId,
+		});
+		if (version.status !== "ready") return version;
+		if (version.itemType !== "document") return { status: "review_unavailable" };
+		if (!version.canRestore) return { status: "not_found" };
+		const { env } = await import("cloudflare:workers");
+		const session = (await getDocumentSessionFromEnv(env, {
+			itemId: data.itemId,
+			workspaceId: data.workspaceId,
+		})) as unknown as {
+			restoreDocumentVersion(input: {
+				actorUserId: string;
+				versionId: string;
+			}): Promise<DocumentEditReceiptUndoResult>;
+		};
+		return await session.restoreDocumentVersion({ actorUserId: userId, versionId: data.versionId });
+	});
+
+function getHistoryActor(
+	actorUserId: string | null,
+	origin: WorkspaceHistoryEntry["origin"],
+	membersById: Map<string, { image: string | null; name: string }>,
+): WorkspaceHistoryEntry["actor"] {
+	if (!actorUserId) {
+		return { image: null, name: origin === "system" ? "System" : "Unknown member" };
+	}
+	const member = membersById.get(actorUserId);
+	return member
+		? { image: member.image, name: member.name }
+		: { image: null, name: "Former member" };
+}

--- a/src/features/workspaces/history/workspace-kernel-history.ts
+++ b/src/features/workspaces/history/workspace-kernel-history.ts
@@ -1,0 +1,249 @@
+import { workspaceItemTypeSchema } from "#/features/workspaces/contracts";
+import type {
+	WorkspaceHistoryEntry,
+	WorkspaceHistoryItem,
+	WorkspaceHistoryOrigin,
+} from "#/features/workspaces/history/workspace-history-contract";
+import type { WorkspaceKernelSql } from "#/features/workspaces/kernel/workspace-kernel-schema";
+import type { WorkspaceRealtimeEvent } from "#/features/workspaces/realtime/messages";
+import { sha256Base64UrlText } from "#/lib/binary";
+
+interface WorkspaceItemVersionRow {
+	content_hash: string;
+	content_type: string;
+	created_at: number;
+	event_id: string;
+	id: string;
+	item_id: string;
+	item_type: string;
+	object_key: string;
+	previous_content_hash: string | null;
+	previous_object_key: string | null;
+	revision: number;
+}
+
+interface WorkspaceItemVersionStateRow extends WorkspaceItemVersionRow {
+	deleted_at: number | null;
+}
+
+interface WorkspaceEventHistoryRow {
+	actor_user_id: string | null;
+	created_at: number;
+	group_id: string | null;
+	id: string;
+	origin: WorkspaceHistoryOrigin;
+	payload_json: string;
+	revision: number;
+	thread_id: string | null;
+	type: string;
+	version_id: string | null;
+}
+
+interface PreparedWorkspaceContent {
+	contentHash: string;
+	contentType: string;
+	objectKey: string;
+}
+
+export class WorkspaceKernelHistory {
+	constructor(
+		private readonly sql: WorkspaceKernelSql,
+		private readonly r2: R2Bucket,
+		private readonly workspaceId: () => string,
+	) {}
+
+	async prepareContent(
+		itemId: string,
+		content: string,
+		contentType: string,
+		contentHash?: string,
+	): Promise<PreparedWorkspaceContent> {
+		const resolvedContentHash = contentHash ?? (await sha256Base64UrlText(content));
+		const objectKey = `workspace_history/${this.workspaceId()}/${itemId}/${resolvedContentHash}`;
+		await this.r2.put(objectKey, content, { httpMetadata: { contentType } });
+		return { contentHash: resolvedContentHash, contentType, objectKey };
+	}
+
+	private async readContent(objectKey: string) {
+		const object = await this.r2.get(objectKey);
+		if (!object?.body) {
+			throw new Error("Workspace history content is missing.");
+		}
+		return await object.text();
+	}
+
+	private getLatestVersion(itemId: string) {
+		return (
+			this.sql<WorkspaceItemVersionRow>`
+				SELECT * FROM workspace_item_versions
+				WHERE item_id = ${itemId}
+				ORDER BY revision DESC
+				LIMIT 1
+			`[0] ?? null
+		);
+	}
+
+	getLatestVersionContent(itemId: string): PreparedWorkspaceContent | null {
+		const latest = this.getLatestVersion(itemId);
+		return latest
+			? {
+					contentHash: latest.content_hash,
+					contentType: latest.content_type,
+					objectKey: latest.object_key,
+				}
+			: null;
+	}
+
+	async planVersion(input: {
+		content: string;
+		contentChanged: boolean;
+		itemId: string;
+	}): Promise<{ shouldCreate: false } | { contentHash: string; shouldCreate: true }> {
+		const latest = this.getLatestVersion(input.itemId);
+		const contentHash = await sha256Base64UrlText(input.content);
+		return !input.contentChanged && latest?.content_hash === contentHash
+			? { shouldCreate: false }
+			: { contentHash, shouldCreate: true };
+	}
+
+	insertVersion(input: {
+		content: PreparedWorkspaceContent;
+		event: WorkspaceRealtimeEvent;
+		itemId: string;
+		itemType: string;
+		previous: PreparedWorkspaceContent | null;
+		versionId: string;
+	}) {
+		this.sql`
+			INSERT INTO workspace_item_versions (
+				id, item_id, item_type, revision, event_id,
+				object_key, content_hash, content_type,
+				previous_object_key, previous_content_hash,
+				created_at
+			)
+			VALUES (
+				${input.versionId}, ${input.itemId}, ${input.itemType},
+				${input.event.revision}, ${input.event.id},
+				${input.content.objectKey}, ${input.content.contentHash}, ${input.content.contentType},
+				${input.previous?.objectKey ?? null}, ${input.previous?.contentHash ?? null},
+				${Date.parse(input.event.createdAt)}
+			)
+		`;
+	}
+
+	async readVersionChange(input: {
+		versionIds: string[];
+	}): Promise<
+		| { beforeContent: string; expectedCurrentHash: string; status: "ready" }
+		| { status: "not_found" | "not_latest" | "review_unavailable" }
+	> {
+		if (
+			input.versionIds.length === 0 ||
+			new Set(input.versionIds).size !== input.versionIds.length
+		) {
+			return { status: "not_found" };
+		}
+		const rows = input.versionIds.map((versionId) => this.getVersion(versionId));
+		if (rows.some((row) => !row)) return { status: "not_found" };
+		const versions = rows as WorkspaceItemVersionRow[];
+		for (let index = 1; index < versions.length; index += 1) {
+			if (
+				versions[index]?.item_id !== versions[0]?.item_id ||
+				versions[index]?.previous_content_hash !== versions[index - 1]?.content_hash
+			) {
+				return { status: "not_latest" };
+			}
+		}
+		const first = versions[0];
+		const last = versions.at(-1);
+		if (!first || !last) return { status: "not_found" };
+		if (first.item_type === "file") return { status: "review_unavailable" };
+		if (!first.previous_object_key) return { status: "review_unavailable" };
+		return {
+			beforeContent: await this.readContent(first.previous_object_key),
+			expectedCurrentHash: last.content_hash,
+			status: "ready",
+		};
+	}
+
+	async readVersion(input: { itemId: string; versionId: string }) {
+		const version =
+			this.sql<WorkspaceItemVersionStateRow>`
+				SELECT v.*, i.deleted_at
+				FROM workspace_item_versions v
+				LEFT JOIN kernel_items i ON i.id = v.item_id
+				WHERE v.id = ${input.versionId}
+				LIMIT 1
+			`[0] ?? null;
+		if (!version || version.item_id !== input.itemId) return { status: "not_found" as const };
+		if (version.item_type === "file") return { status: "review_unavailable" as const };
+		const [content, beforeContent] = await Promise.all([
+			this.readContent(version.object_key),
+			version.previous_object_key ? this.readContent(version.previous_object_key) : null,
+		]);
+		return {
+			beforeContent,
+			canRestore: version.deleted_at === null,
+			content,
+			itemId: version.item_id,
+			itemType: version.item_type,
+			status: "ready" as const,
+		};
+	}
+
+	list(input: { beforeRevision?: number; limit?: number } = {}) {
+		const limit = Math.min(Math.max(input.limit ?? 50, 1), 100);
+		const beforeRevision = input.beforeRevision ?? Number.MAX_SAFE_INTEGER;
+		const rows = this.sql<WorkspaceEventHistoryRow>`
+			SELECT e.*, v.id AS version_id
+			FROM kernel_events e
+			LEFT JOIN workspace_item_versions v ON v.event_id = e.id
+			WHERE e.revision < ${beforeRevision}
+				AND e.type <> 'workspace.item.projection.updated'
+			ORDER BY e.revision DESC
+			LIMIT ${limit}
+		`;
+		return rows.map(mapHistoryRow);
+	}
+
+	private getVersion(versionId: string) {
+		return (
+			this.sql<WorkspaceItemVersionRow>`
+				SELECT * FROM workspace_item_versions WHERE id = ${versionId} LIMIT 1
+			`[0] ?? null
+		);
+	}
+}
+
+function mapHistoryRow(row: WorkspaceEventHistoryRow): Omit<WorkspaceHistoryEntry, "actor"> {
+	return {
+		actorUserId: row.actor_user_id,
+		createdAt: new Date(row.created_at).toISOString(),
+		groupId: row.group_id,
+		id: row.id,
+		items: readHistoryItems(row.payload_json),
+		origin: row.origin,
+		revision: row.revision,
+		threadId: row.thread_id,
+		type: row.type,
+		versionId: row.version_id,
+	};
+}
+
+function readHistoryItems(payloadJson: string): WorkspaceHistoryItem[] {
+	let payload: Record<string, unknown>;
+	try {
+		payload = JSON.parse(payloadJson) as Record<string, unknown>;
+	} catch {
+		return [];
+	}
+	const candidates = [payload.item, ...(Array.isArray(payload.items) ? payload.items : [])];
+	return candidates.flatMap((candidate) => {
+		if (!candidate || typeof candidate !== "object") return [];
+		const item = candidate as Record<string, unknown>;
+		const parsedType = workspaceItemTypeSchema.safeParse(item.type);
+		return typeof item.id === "string" && typeof item.name === "string" && parsedType.success
+			? [{ id: item.id, name: item.name, type: parsedType.data }]
+			: [];
+	});
+}

--- a/src/features/workspaces/kernel/workspace-kernel-access.ts
+++ b/src/features/workspaces/kernel/workspace-kernel-access.ts
@@ -16,11 +16,15 @@ import {
 	type CreateWorkspaceKernelFileFromUploadArgs,
 	type CreateWorkspaceKernelItemArgs,
 	type DeleteWorkspaceKernelItemsResult,
+	type DeleteWorkspaceKernelItemsArgs,
 	type GetWorkspaceKernelItemPathsArgs,
 	type ListWorkspaceKernelItemRelationsArgs,
 	type ListWorkspaceKernelItemsArgs,
 	type LinkWorkspaceKernelItemsArgs,
+	type ListWorkspaceHistoryArgs,
+	type ListWorkspaceHistoryResult,
 	type MoveWorkspaceKernelItemsResult,
+	type MoveWorkspaceKernelItemsArgs,
 	type ReadWorkspaceKernelFilePreviewResult,
 	type ReadWorkspaceKernelFileProjectionArgs,
 	type ReadWorkspaceKernelFileProjectionResult,
@@ -28,9 +32,15 @@ import {
 	type ResolveWorkspaceKernelPathsArgs,
 	type WorkspaceKernelFileSource,
 	type WorkspaceKernelItemRelation,
-	type WorkspaceKernelNameConflictPolicy,
 	type WorkspaceKernelMutationOutcome,
 	type WorkspaceKernelPublishOutcome,
+	type WorkspaceKernelContentCommitOutcome,
+	type ReadWorkspaceItemVersionArgs,
+	type ReadWorkspaceItemVersionChangeArgs,
+	type ReadWorkspaceItemContentArgs,
+	type CommitWorkspaceItemContentArgs,
+	type RenameWorkspaceKernelItemArgs,
+	type UpdateWorkspaceKernelItemColorArgs,
 	type WorkspaceKernelItemPath,
 	type WorkspaceKernelPathResolution,
 } from "#/features/workspaces/kernel/workspace-kernel-types";
@@ -76,37 +86,21 @@ export interface WorkspaceKernelClient {
 	createFileFromUpload(
 		input: CreateWorkspaceKernelFileFromUploadArgs,
 	): Promise<WorkspaceCommandResult<WorkspaceItemSummary>>;
-	renameItem(input: {
-		itemId: string;
-		name: string;
-		onNameConflict?: WorkspaceKernelNameConflictPolicy;
-		actorUserId?: string | null;
-		clientMutationId?: string | null;
-	}): Promise<WorkspaceKernelMutationOutcome<WorkspaceItemSummary>>;
-	moveItems(input: {
-		items: Array<{
-			itemId: string;
-			sortOrder?: number;
-		}>;
-		parentId?: string | null;
-		onNameConflict?: WorkspaceKernelNameConflictPolicy;
-		actorUserId?: string | null;
-		clientMutationId?: string | null;
-	}): Promise<WorkspaceKernelMutationOutcome<MoveWorkspaceKernelItemsResult>>;
-	updateItemColor(input: {
-		itemId: string;
-		color: UpdateWorkspaceItemColorInput["color"];
-		actorUserId?: string | null;
-		clientMutationId?: string | null;
-	}): Promise<WorkspaceCommandResult<WorkspaceItemSummary>>;
-	deleteItems(input: {
-		itemIds: string[];
-		actorUserId?: string | null;
-		clientMutationId?: string | null;
-	}): Promise<WorkspaceCommandResult<DeleteWorkspaceKernelItemsResult>>;
-	readDocumentCheckpoint(input: {
-		itemId: string;
-	}): Promise<{ item: WorkspaceItemSummary; content: string }>;
+	renameItem(
+		input: RenameWorkspaceKernelItemArgs,
+	): Promise<WorkspaceKernelMutationOutcome<WorkspaceItemSummary>>;
+	moveItems(
+		input: MoveWorkspaceKernelItemsArgs,
+	): Promise<WorkspaceKernelMutationOutcome<MoveWorkspaceKernelItemsResult>>;
+	updateItemColor(
+		input: UpdateWorkspaceKernelItemColorArgs,
+	): Promise<WorkspaceCommandResult<WorkspaceItemSummary>>;
+	deleteItems(
+		input: DeleteWorkspaceKernelItemsArgs,
+	): Promise<WorkspaceCommandResult<DeleteWorkspaceKernelItemsResult>>;
+	readItemContent(
+		input: ReadWorkspaceItemContentArgs,
+	): Promise<{ item: WorkspaceItemSummary; content: string }>;
 	getFileSource(input: { itemId: string }): Promise<WorkspaceKernelFileSource>;
 	readFilePreview(input: { itemId: string }): Promise<ReadWorkspaceKernelFilePreviewResult | null>;
 	upsertFileProjection(
@@ -115,12 +109,27 @@ export interface WorkspaceKernelClient {
 	readFileProjection(
 		input: ReadWorkspaceKernelFileProjectionArgs,
 	): Promise<ReadWorkspaceKernelFileProjectionResult | null>;
-	commitDocumentCheckpoint(input: {
-		itemId: string;
-		content: string;
-		actorUserId?: string | null;
-		clientMutationId?: string | null;
-	}): Promise<WorkspaceKernelPublishOutcome>;
+	commitItemContent(
+		input: CommitWorkspaceItemContentArgs,
+	): Promise<WorkspaceKernelContentCommitOutcome>;
+	listHistory(input?: ListWorkspaceHistoryArgs): Promise<ListWorkspaceHistoryResult>;
+	readItemVersionChange(
+		input: ReadWorkspaceItemVersionChangeArgs,
+	): Promise<
+		| { beforeContent: string; expectedCurrentHash: string; status: "ready" }
+		| { status: "not_found" | "not_latest" | "review_unavailable" }
+	>;
+	readItemVersion(input: ReadWorkspaceItemVersionArgs): Promise<
+		| {
+				beforeContent: string | null;
+				canRestore: boolean;
+				content: string;
+				itemId: string;
+				itemType: string;
+				status: "ready";
+		  }
+		| { status: "not_found" | "review_unavailable" }
+	>;
 	searchWorkspace(input: WorkspaceSearchInput): Promise<{
 		failed: WorkspaceSearchFailure[];
 		results: WorkspaceSearchResult[];

--- a/src/features/workspaces/kernel/workspace-kernel-events.ts
+++ b/src/features/workspaces/kernel/workspace-kernel-events.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceKernelSql } from "#/features/workspaces/kernel/workspace-kernel-schema";
+import type { WorkspaceMutationProvenance } from "#/features/workspaces/history/workspace-history-contract";
 import type {
 	WorkspaceRealtimeEvent,
 	WorkspaceRealtimeServerMessage,
@@ -25,24 +26,42 @@ export class WorkspaceKernelEventBus {
 		this.onCommit = input.onCommit;
 	}
 
-	commit(input: Omit<WorkspaceRealtimeEvent, "id" | "revision" | "workspaceId" | "createdAt">) {
+	commit(
+		input: Omit<
+			WorkspaceRealtimeEvent,
+			"id" | "revision" | "workspaceId" | "createdAt" | "origin" | "groupId" | "threadId"
+		> & { provenance?: WorkspaceMutationProvenance },
+		options: {
+			onPersist?: (event: WorkspaceRealtimeEvent) => void;
+			persist?: boolean;
+		} = {},
+	) {
 		const createdAt = Date.now();
+		const provenance = input.provenance;
 		const event = {
 			id: crypto.randomUUID(),
 			revision: this.getNextRevision(),
 			workspaceId: this.workspaceId(),
 			createdAt: new Date(createdAt).toISOString(),
 			...input,
+			origin: provenance?.origin ?? (input.actorUserId ? "human" : "system"),
+			groupId: provenance?.groupId ?? null,
+			threadId: provenance?.threadId ?? null,
 		} as WorkspaceRealtimeEvent;
+		Reflect.deleteProperty(event, "provenance");
 
-		this.sql`
+		if (options.persist !== false) {
+			this.sql`
 			INSERT INTO kernel_events (
 				id,
 				revision,
 				type,
 				actor_user_id,
 				client_mutation_id,
-				payload_json,
+					origin,
+					group_id,
+					thread_id,
+					payload_json,
 				created_at
 			)
 			VALUES (
@@ -51,10 +70,15 @@ export class WorkspaceKernelEventBus {
 				${event.type},
 				${event.actorUserId},
 				${event.clientMutationId},
-				${JSON.stringify(event.payload)},
+					${event.origin},
+					${event.groupId},
+					${event.threadId},
+					${JSON.stringify(event.payload)},
 				${createdAt}
 			)
 		`;
+			options.onPersist?.(event);
+		}
 		this.onCommit?.(event);
 		this.broadcast({
 			type: "workspace.event",

--- a/src/features/workspaces/kernel/workspace-kernel-file-commands.ts
+++ b/src/features/workspaces/kernel/workspace-kernel-file-commands.ts
@@ -176,6 +176,7 @@ export class WorkspaceKernelFileCommands {
 			actorUserId: input.actorUserId ?? null,
 			clientMutationId: input.clientMutationId ?? null,
 			payload: { item, itemFacts },
+			provenance: input.provenance,
 		});
 
 		return { result: item, event };
@@ -285,6 +286,7 @@ export class WorkspaceKernelFileCommands {
 			actorUserId: input.actorUserId ?? null,
 			clientMutationId: input.clientMutationId ?? null,
 			payload: { itemFacts },
+			provenance: input.provenance,
 		});
 		return "applied";
 	}

--- a/src/features/workspaces/kernel/workspace-kernel-item-commands.ts
+++ b/src/features/workspaces/kernel/workspace-kernel-item-commands.ts
@@ -7,6 +7,7 @@ import {
 	persistDocumentItemContentUpdate,
 } from "#/features/workspaces/documents/document-item-content";
 import type { WorkspaceKernelEventBus } from "#/features/workspaces/kernel/workspace-kernel-events";
+import type { WorkspaceKernelHistory } from "#/features/workspaces/history/workspace-kernel-history";
 import {
 	getInitialWorkspaceKernelContent,
 	getWorkspaceKernelContentMimeType,
@@ -24,12 +25,12 @@ import type {
 	DeleteWorkspaceKernelItemsArgs,
 	MoveWorkspaceKernelItemsArgs,
 	MoveWorkspaceKernelItemsResult,
-	ReadWorkspaceDocumentCheckpointArgs,
+	ReadWorkspaceItemContentArgs,
 	RenameWorkspaceKernelItemArgs,
 	UpdateWorkspaceKernelItemColorArgs,
-	CommitWorkspaceDocumentCheckpointArgs,
+	CommitWorkspaceItemContentArgs,
 	WorkspaceKernelMutationOutcome,
-	WorkspaceKernelPublishOutcome,
+	WorkspaceKernelContentCommitOutcome,
 } from "#/features/workspaces/kernel/workspace-kernel-types";
 import {
 	resolveWorkspaceItemColorForCreate,
@@ -40,6 +41,7 @@ import { recordOperationalFailure } from "#/integrations/observability/operation
 
 export class WorkspaceKernelItemCommands {
 	private readonly events: WorkspaceKernelEventBus;
+	private readonly history: WorkspaceKernelHistory;
 	private readonly relations: WorkspaceKernelRelations;
 	private readonly sql: WorkspaceKernelSql;
 	private readonly store: WorkspaceKernelStore;
@@ -48,6 +50,7 @@ export class WorkspaceKernelItemCommands {
 
 	constructor(input: {
 		events: WorkspaceKernelEventBus;
+		history: WorkspaceKernelHistory;
 		relations: WorkspaceKernelRelations;
 		sql: WorkspaceKernelSql;
 		store: WorkspaceKernelStore;
@@ -55,6 +58,7 @@ export class WorkspaceKernelItemCommands {
 		workspaceId: () => string;
 	}) {
 		this.events = input.events;
+		this.history = input.history;
 		this.relations = input.relations;
 		this.sql = input.sql;
 		this.store = input.store;
@@ -113,6 +117,15 @@ export class WorkspaceKernelItemCommands {
 			metadataJson: input.metadataJson ?? {},
 			initialContent: input.initialContent,
 		});
+		const contentType = getWorkspaceKernelContentMimeType(type);
+		const preparedContent =
+			type === "folder"
+				? null
+				: await this.history.prepareContent(
+						id,
+						initialContent ?? getInitialWorkspaceKernelContent(type),
+						contentType,
+					);
 
 		await this.createWorkspaceFile({
 			type,
@@ -159,12 +172,29 @@ export class WorkspaceKernelItemCommands {
 		const itemFacts = this.store.getItemFacts(
 			factItemIds.map((itemId) => this.store.requireItem(itemId)),
 		);
-		const event = this.events.commit({
-			type: "workspace.item.created",
-			actorUserId: input.actorUserId ?? null,
-			clientMutationId: input.clientMutationId ?? null,
-			payload: { item, itemFacts },
-		});
+		const versionId = preparedContent ? (input.clientMutationId ?? crypto.randomUUID()) : null;
+		const event = this.events.commit(
+			{
+				type: "workspace.item.created",
+				actorUserId: input.actorUserId ?? null,
+				clientMutationId: input.clientMutationId ?? null,
+				payload: { item, itemFacts, versionId },
+				provenance: input.provenance,
+			},
+			preparedContent && versionId
+				? {
+						onPersist: (persistedEvent) =>
+							this.history.insertVersion({
+								content: preparedContent,
+								event: persistedEvent,
+								itemId: id,
+								itemType: type,
+								previous: null,
+								versionId,
+							}),
+					}
+				: {},
+		);
 
 		return { command: { result: item, event }, status: "applied" };
 	}
@@ -203,6 +233,7 @@ export class WorkspaceKernelItemCommands {
 				itemId: input.itemId,
 				actorUserId: input.actorUserId,
 				clientMutationId: input.clientMutationId,
+				provenance: input.provenance,
 			}),
 			status: "applied",
 		};
@@ -249,6 +280,7 @@ export class WorkspaceKernelItemCommands {
 			actorUserId: input.actorUserId ?? null,
 			clientMutationId: input.clientMutationId ?? null,
 			payload: { items: movedItems },
+			provenance: input.provenance,
 		});
 
 		return { command: { result: movedItems, event }, status: "applied" };
@@ -275,6 +307,7 @@ export class WorkspaceKernelItemCommands {
 			itemId: input.itemId,
 			actorUserId: input.actorUserId,
 			clientMutationId: input.clientMutationId,
+			provenance: input.provenance,
 		});
 	}
 
@@ -285,6 +318,7 @@ export class WorkspaceKernelItemCommands {
 		const rowsToRemove = deleteIds
 			.map((id) => this.store.getItemRowIncludingDeleted(id))
 			.filter((row): row is KernelItemRow => Boolean(row));
+		const deletedItems = rowsToRemove.map((row) => mapKernelItemRow(row, this.workspaceId()));
 		const relatedItemIds = this.relations.listRelatedItemIds(deleteIds);
 
 		this.store.softDeleteItems(deleteIds, Date.now());
@@ -297,7 +331,8 @@ export class WorkspaceKernelItemCommands {
 			type: "workspace.item.deleted",
 			actorUserId: input.actorUserId ?? null,
 			clientMutationId: input.clientMutationId ?? null,
-			payload: { itemIds: rootIds, deletedItemIds: deleteIds, itemFacts },
+			payload: { itemIds: rootIds, deletedItemIds: deleteIds, itemFacts, items: deletedItems },
+			provenance: input.provenance,
 		});
 
 		return {
@@ -328,10 +363,10 @@ export class WorkspaceKernelItemCommands {
 		}
 	}
 
-	async readDocumentCheckpoint(input: ReadWorkspaceDocumentCheckpointArgs) {
+	async readItemContent(input: ReadWorkspaceItemContentArgs) {
 		const item = this.store.assertActiveItem(input.itemId);
-		if (item.type !== "document") {
-			throw new Error("Only document items have document checkpoints.");
+		if (item.type === "folder" || item.type === "file") {
+			throw new Error("This workspace item does not store editable inline content.");
 		}
 		const itemSummary = mapKernelItemRow(item, this.workspaceId());
 		return {
@@ -340,47 +375,109 @@ export class WorkspaceKernelItemCommands {
 		};
 	}
 
-	async commitDocumentCheckpoint(
-		input: CommitWorkspaceDocumentCheckpointArgs,
-	): Promise<WorkspaceKernelPublishOutcome> {
+	async commitItemContent(
+		input: CommitWorkspaceItemContentArgs,
+	): Promise<WorkspaceKernelContentCommitOutcome> {
 		const item = this.store.getActiveItemRow(input.itemId);
 		if (!item) {
-			return "discarded";
+			return { status: "discarded" };
 		}
 		const type = workspaceItemTypeSchema.parse(item.type);
 
-		if (type !== "document") {
-			throw new Error("Only document checkpoints can update workspace text content.");
+		if (type === "folder" || type === "file") {
+			throw new Error("This workspace item does not store editable inline content.");
+		}
+		const contentType = getWorkspaceKernelContentMimeType(type);
+		const previousContent = await this.workspace.readFile(item.shell_path);
+		if (previousContent === null) {
+			throw new Error("Workspace item content is missing.");
+		}
+		const contentChanged = input.content !== previousContent;
+		if (!contentChanged && !input.createVersion) {
+			return { eventId: null, status: "applied", versionId: null };
+		}
+		const versionPlan = input.createVersion
+			? await this.history.planVersion({
+					content: input.content,
+					contentChanged,
+					itemId: input.itemId,
+				})
+			: { shouldCreate: false as const };
+		// Human versions summarize an editing window, not only the last shell
+		// autosave. Their before-side is therefore the previous visible version.
+		// Required AI and restore versions still use the exact live body they
+		// replaced so their receipt can be reviewed and reversed precisely.
+		const previousVisibleVersion =
+			input.provenance?.origin === "human"
+				? this.history.getLatestVersionContent(input.itemId)
+				: null;
+		const [preparedContent, previous] = versionPlan.shouldCreate
+			? await Promise.all([
+					this.history.prepareContent(
+						input.itemId,
+						input.content,
+						contentType,
+						versionPlan.contentHash,
+					),
+					previousVisibleVersion ??
+						this.history.prepareContent(input.itemId, previousContent, contentType),
+				])
+			: [null, null];
+		if (!contentChanged && !versionPlan.shouldCreate) {
+			return { eventId: null, status: "applied", versionId: null };
 		}
 
-		await this.workspace.writeFile(
-			item.shell_path,
-			input.content,
-			getWorkspaceKernelContentMimeType(type),
-		);
+		if (contentChanged) {
+			await this.workspace.writeFile(item.shell_path, input.content, contentType);
+		}
 
 		const currentItem = this.store.getActiveItemRow(input.itemId);
 		if (!currentItem) {
-			await this.workspace.rm(item.shell_path, { force: true });
-			return "discarded";
+			if (contentChanged) await this.workspace.rm(item.shell_path, { force: true });
+			return { status: "discarded" };
 		}
-		const updatedAt = Math.max(Date.now(), currentItem.updated_at + 1);
+		if (contentChanged) {
+			const updatedAt = Math.max(Date.now(), currentItem.updated_at + 1);
+			if (type === "document") {
+				persistDocumentItemContentUpdate({
+					content: input.content,
+					itemId: input.itemId,
+					metadataJson: currentItem.metadata_json,
+					sql: this.sql,
+					updatedAt,
+				});
+			} else {
+				this.sql`UPDATE kernel_items SET updated_at = ${updatedAt} WHERE id = ${input.itemId}`;
+			}
+		}
 
-		persistDocumentItemContentUpdate({
-			content: input.content,
-			itemId: input.itemId,
-			metadataJson: currentItem.metadata_json,
-			sql: this.sql,
-			updatedAt,
-		});
-
-		this.commitItemEvent({
-			type: "workspace.item.content.updated",
-			itemId: input.itemId,
-			actorUserId: input.actorUserId,
-			clientMutationId: input.clientMutationId,
-		});
-		return "applied";
+		const versionId = versionPlan.shouldCreate
+			? (input.versionId ?? input.clientMutationId ?? crypto.randomUUID())
+			: null;
+		const command = this.commitItemEvent(
+			{
+				type: "workspace.item.content.updated",
+				itemId: input.itemId,
+				actorUserId: input.actorUserId,
+				clientMutationId: input.clientMutationId,
+				provenance: input.provenance,
+				versionId,
+			},
+			versionPlan.shouldCreate && versionId && preparedContent && previous
+				? {
+						onPersist: (event) =>
+							this.history.insertVersion({
+								content: preparedContent,
+								event,
+								itemId: input.itemId,
+								itemType: type,
+								previous,
+								versionId,
+							}),
+					}
+				: { persist: false },
+		);
+		return { eventId: command.event.id, status: "applied", versionId };
 	}
 
 	private async createWorkspaceFile(input: {
@@ -400,22 +497,31 @@ export class WorkspaceKernelItemCommands {
 		);
 	}
 
-	private commitItemEvent(input: {
-		type:
-			| "workspace.item.renamed"
-			| "workspace.item.color.updated"
-			| "workspace.item.content.updated";
-		itemId: string;
-		actorUserId?: string | null;
-		clientMutationId?: string | null;
-	}) {
+	private commitItemEvent(
+		input: {
+			type:
+				| "workspace.item.renamed"
+				| "workspace.item.color.updated"
+				| "workspace.item.content.updated";
+			itemId: string;
+			actorUserId?: string | null;
+			clientMutationId?: string | null;
+			provenance?: CreateWorkspaceKernelItemArgs["provenance"];
+			versionId?: string | null;
+		},
+		options?: Parameters<WorkspaceKernelEventBus["commit"]>[1],
+	) {
 		const item = this.store.requireItem(input.itemId);
-		const event = this.events.commit({
-			type: input.type,
-			actorUserId: input.actorUserId ?? null,
-			clientMutationId: input.clientMutationId ?? null,
-			payload: { item },
-		});
+		const event = this.events.commit(
+			{
+				type: input.type,
+				actorUserId: input.actorUserId ?? null,
+				clientMutationId: input.clientMutationId ?? null,
+				payload: { item, versionId: input.versionId },
+				provenance: input.provenance,
+			},
+			options,
+		);
 
 		return { result: item, event };
 	}

--- a/src/features/workspaces/kernel/workspace-kernel-publication.worker.test.ts
+++ b/src/features/workspaces/kernel/workspace-kernel-publication.worker.test.ts
@@ -102,7 +102,7 @@ describe("workspace kernel publication", () => {
 			const delayedWrite = delayFirstCall(workspace, "writeFile");
 			Reflect.set(itemCommands, "workspace", delayedWrite.proxy);
 
-			const checkpoint = kernel.commitDocumentCheckpoint({
+			const checkpoint = kernel.commitItemContent({
 				content: '{"type":"doc","content":[]}',
 				itemId,
 			});
@@ -110,8 +110,112 @@ describe("workspace kernel publication", () => {
 			await kernel.deleteItems({ itemIds: [itemId] });
 			delayedWrite.resume();
 
-			await expect(checkpoint).resolves.toBe("discarded");
+			await expect(checkpoint).resolves.toEqual({ status: "discarded" });
 			await expect(workspace.readFile(shellPath)).resolves.toBeNull();
+		});
+	});
+
+	it("keeps exact before and after bodies for a required content version", async () => {
+		const workspaceId = crypto.randomUUID();
+		const itemId = crypto.randomUUID();
+		const versionId = crypto.randomUUID();
+		const before = '{"type":"doc","content":[]}';
+		const after = '{"type":"doc","content":[{"type":"paragraph"}]}';
+		const stub = getKernelStub(workspaceId);
+
+		await runInDurableObject(stub, async (kernel: WorkspaceKernel) => {
+			await kernel.createItem({
+				id: itemId,
+				initialContent: before,
+				name: "Draft",
+				type: "document",
+			});
+			await expect(
+				kernel.commitItemContent({
+					content: after,
+					createVersion: true,
+					itemId,
+					versionId,
+				}),
+			).resolves.toMatchObject({ status: "applied", versionId });
+
+			await expect(
+				kernel.readItemVersionChange({ versionIds: [versionId] }),
+			).resolves.toMatchObject({ beforeContent: before, status: "ready" });
+			await expect(kernel.readItemVersion({ itemId, versionId })).resolves.toMatchObject({
+				beforeContent: before,
+				content: after,
+				status: "ready",
+			});
+		});
+	});
+
+	it("promotes an already-saved document into an idle version", async () => {
+		const workspaceId = crypto.randomUUID();
+		const itemId = crypto.randomUUID();
+		const versionId = crypto.randomUUID();
+		const before = '{"type":"doc","content":[]}';
+		const after = '{"type":"doc","content":[{"type":"paragraph"}]}';
+		const stub = getKernelStub(workspaceId);
+
+		await runInDurableObject(stub, async (kernel: WorkspaceKernel) => {
+			await kernel.createItem({
+				id: itemId,
+				initialContent: before,
+				name: "Draft",
+				type: "document",
+			});
+			await expect(
+				kernel.commitItemContent({
+					content: after,
+					itemId,
+					provenance: { origin: "human" },
+				}),
+			).resolves.toMatchObject({ status: "applied", versionId: null });
+			await expect(
+				kernel.commitItemContent({
+					content: after,
+					createVersion: true,
+					itemId,
+					provenance: { origin: "human" },
+					versionId,
+				}),
+			).resolves.toMatchObject({ status: "applied", versionId });
+			await expect(kernel.readItemVersion({ itemId, versionId })).resolves.toMatchObject({
+				beforeContent: before,
+				content: after,
+				status: "ready",
+			});
+			await expect(
+				kernel.readItemVersionChange({ versionIds: [versionId] }),
+			).resolves.toMatchObject({ beforeContent: before, status: "ready" });
+		});
+	});
+
+	it("retains document versions after the item is deleted", async () => {
+		const workspaceId = crypto.randomUUID();
+		const itemId = crypto.randomUUID();
+		const versionId = crypto.randomUUID();
+		const before = '{"type":"doc","content":[]}';
+		const after = '{"type":"doc","content":[{"type":"paragraph"}]}';
+		const stub = getKernelStub(workspaceId);
+
+		await runInDurableObject(stub, async (kernel: WorkspaceKernel) => {
+			await kernel.createItem({
+				id: itemId,
+				initialContent: before,
+				name: "Draft",
+				type: "document",
+			});
+			await kernel.commitItemContent({ content: after, createVersion: true, itemId, versionId });
+			await kernel.deleteItems({ itemIds: [itemId] });
+
+			await expect(kernel.readItemVersion({ itemId, versionId })).resolves.toMatchObject({
+				beforeContent: before,
+				canRestore: false,
+				content: after,
+				status: "ready",
+			});
 		});
 	});
 });

--- a/src/features/workspaces/kernel/workspace-kernel-schema.ts
+++ b/src/features/workspaces/kernel/workspace-kernel-schema.ts
@@ -79,12 +79,44 @@ export function initializeWorkspaceKernelStorage(sql: WorkspaceKernelSql) {
 			type TEXT NOT NULL,
 			actor_user_id TEXT,
 			client_mutation_id TEXT,
-			payload_json TEXT NOT NULL,
+				origin TEXT NOT NULL DEFAULT 'system',
+				group_id TEXT,
+				thread_id TEXT,
+				payload_json TEXT NOT NULL,
 			created_at INTEGER NOT NULL
 		)
 	`;
-	sql`CREATE INDEX IF NOT EXISTS kernel_events_revision_idx
-		ON kernel_events (revision)`;
+	ensureKernelEventHistoryColumns(sql);
+	sql`DROP INDEX IF EXISTS kernel_events_revision_idx`;
+	sql`
+		CREATE TABLE IF NOT EXISTS workspace_item_versions (
+			id TEXT PRIMARY KEY,
+			item_id TEXT NOT NULL,
+			item_type TEXT NOT NULL,
+			revision INTEGER NOT NULL,
+			event_id TEXT NOT NULL,
+			object_key TEXT NOT NULL,
+			content_hash TEXT NOT NULL,
+				content_type TEXT NOT NULL,
+				previous_object_key TEXT,
+				previous_content_hash TEXT,
+				created_at INTEGER NOT NULL
+		)
+	`;
+	sql`CREATE INDEX IF NOT EXISTS workspace_item_versions_item_revision_idx
+		ON workspace_item_versions (item_id, revision DESC)`;
+	sql`CREATE INDEX IF NOT EXISTS workspace_item_versions_event_idx
+		ON workspace_item_versions (event_id)`;
+}
+
+function ensureKernelEventHistoryColumns(sql: WorkspaceKernelSql) {
+	const columns = new Set(
+		sql<{ name: string }>`PRAGMA table_info(kernel_events)`.map((row) => row.name),
+	);
+	if (!columns.has("origin"))
+		sql`ALTER TABLE kernel_events ADD COLUMN origin TEXT NOT NULL DEFAULT 'system'`;
+	if (!columns.has("group_id")) sql`ALTER TABLE kernel_events ADD COLUMN group_id TEXT`;
+	if (!columns.has("thread_id")) sql`ALTER TABLE kernel_events ADD COLUMN thread_id TEXT`;
 }
 
 function createSiblingNameIndexes(sql: WorkspaceKernelSql) {

--- a/src/features/workspaces/kernel/workspace-kernel-types.ts
+++ b/src/features/workspaces/kernel/workspace-kernel-types.ts
@@ -10,6 +10,10 @@ import type {
 	WorkspaceFileAssetKind,
 	WorkspaceUploadConversion,
 } from "#/features/workspaces/model/workspace-file";
+import type {
+	WorkspaceHistoryEntry,
+	WorkspaceMutationProvenance,
+} from "#/features/workspaces/history/workspace-history-contract";
 import type { WorkspaceCommandResult } from "#/features/workspaces/realtime/messages";
 
 export interface WorkspaceKernelPage {
@@ -26,9 +30,7 @@ export interface CreateWorkspaceKernelRelationArgs {
 	toItemId: string;
 }
 
-export interface LinkWorkspaceKernelItemsArgs {
-	actorUserId?: string | null;
-	clientMutationId?: string | null;
+export interface LinkWorkspaceKernelItemsArgs extends WorkspaceKernelMutationMetadata {
 	relations: CreateWorkspaceKernelRelationArgs[];
 }
 
@@ -103,7 +105,17 @@ export type WorkspaceKernelMutationOutcome<T> =
 			status: "conflict";
 	  };
 
+export type WorkspaceKernelContentCommitOutcome =
+	| { eventId: string | null; status: "applied"; versionId: string | null }
+	| { status: "discarded" };
+
 export type WorkspaceKernelPublishOutcome = "applied" | "discarded";
+
+interface WorkspaceKernelMutationMetadata {
+	actorUserId?: string | null;
+	clientMutationId?: string | null;
+	provenance?: WorkspaceMutationProvenance;
+}
 
 export function requireAppliedWorkspaceKernelMutation<T>(
 	outcome: WorkspaceKernelMutationOutcome<T>,
@@ -117,7 +129,7 @@ export function requireAppliedWorkspaceKernelMutation<T>(
 	return outcome.command;
 }
 
-export interface CreateWorkspaceKernelItemArgs {
+export interface CreateWorkspaceKernelItemArgs extends WorkspaceKernelMutationMetadata {
 	id: string;
 	parentId?: string | null;
 	type: WorkspaceItemType;
@@ -127,45 +139,35 @@ export interface CreateWorkspaceKernelItemArgs {
 	metadataJson?: Record<string, JsonValue>;
 	initialContent?: string;
 	initialRelations?: CreateWorkspaceKernelRelationArgs[];
-	actorUserId?: string | null;
-	clientMutationId?: string | null;
 }
 
-export interface RenameWorkspaceKernelItemArgs {
+export interface RenameWorkspaceKernelItemArgs extends WorkspaceKernelMutationMetadata {
 	itemId: string;
 	name: string;
 	onNameConflict?: WorkspaceKernelNameConflictPolicy;
-	actorUserId?: string | null;
-	clientMutationId?: string | null;
 }
 
-export interface MoveWorkspaceKernelItemsArgs {
+export interface MoveWorkspaceKernelItemsArgs extends WorkspaceKernelMutationMetadata {
 	items: Array<{
 		itemId: string;
 		sortOrder?: number;
 	}>;
 	parentId?: string | null;
 	onNameConflict?: WorkspaceKernelNameConflictPolicy;
-	actorUserId?: string | null;
-	clientMutationId?: string | null;
 }
 
 export type MoveWorkspaceKernelItemsResult = WorkspaceItemSummary[];
 
-export interface UpdateWorkspaceKernelItemColorArgs {
+export interface UpdateWorkspaceKernelItemColorArgs extends WorkspaceKernelMutationMetadata {
 	itemId: string;
 	color: WorkspaceItemColor;
-	actorUserId?: string | null;
-	clientMutationId?: string | null;
 }
 
-export interface DeleteWorkspaceKernelItemsArgs {
+export interface DeleteWorkspaceKernelItemsArgs extends WorkspaceKernelMutationMetadata {
 	itemIds: string[];
-	actorUserId?: string | null;
-	clientMutationId?: string | null;
 }
 
-export interface ReadWorkspaceDocumentCheckpointArgs {
+export interface ReadWorkspaceItemContentArgs {
 	itemId: string;
 }
 
@@ -184,11 +186,9 @@ export type WorkspaceKernelFileProjectionFormat = "pages" | "preview";
 
 export type WorkspaceKernelFileProjectionStatus = "processing" | "ready" | "failed";
 
-interface WorkspaceKernelFileProjectionMutationBase {
+interface WorkspaceKernelFileProjectionMutationBase extends WorkspaceKernelMutationMetadata {
 	itemId: string;
 	format: WorkspaceKernelFileProjectionFormat;
-	actorUserId?: string | null;
-	clientMutationId?: string | null;
 }
 
 export type UpsertWorkspaceKernelFileProjectionArgs =
@@ -249,14 +249,14 @@ export interface ReadWorkspaceKernelFileProjectionResult {
 	updatedAt: string;
 }
 
-export interface CommitWorkspaceDocumentCheckpointArgs {
+export interface CommitWorkspaceItemContentArgs extends WorkspaceKernelMutationMetadata {
 	itemId: string;
 	content: string;
-	actorUserId?: string | null;
-	clientMutationId?: string | null;
+	createVersion?: boolean;
+	versionId?: string;
 }
 
-export interface CreateWorkspaceKernelFileFromUploadArgs {
+export interface CreateWorkspaceKernelFileFromUploadArgs extends WorkspaceKernelMutationMetadata {
 	id: string;
 	parentId?: string | null;
 	fileName: string;
@@ -275,8 +275,22 @@ export interface CreateWorkspaceKernelFileFromUploadArgs {
 		mimeType: string | null;
 		sizeBytes: number;
 	};
-	actorUserId?: string | null;
-	clientMutationId?: string | null;
+}
+
+export interface ListWorkspaceHistoryArgs {
+	beforeRevision?: number;
+	limit?: number;
+}
+
+export type ListWorkspaceHistoryResult = Array<Omit<WorkspaceHistoryEntry, "actorLabel">>;
+
+export interface ReadWorkspaceItemVersionChangeArgs {
+	versionIds: string[];
+}
+
+export interface ReadWorkspaceItemVersionArgs {
+	itemId: string;
+	versionId: string;
 }
 
 export interface DeleteWorkspaceKernelItemsResult {

--- a/src/features/workspaces/kernel/workspace-kernel.ts
+++ b/src/features/workspaces/kernel/workspace-kernel.ts
@@ -3,6 +3,7 @@ import { Agent, type Connection, type ConnectionContext } from "agents";
 
 import type { WorkspaceItemSummary } from "#/features/workspaces/contracts";
 import { getDocumentSessionForDeletionFromEnv } from "#/features/workspaces/document-session-access";
+import { WorkspaceKernelHistory } from "#/features/workspaces/history/workspace-kernel-history";
 import { reconcileWorkspaceFileExtractions } from "#/features/workspaces/extraction/workspace-file-extraction-reconciler";
 import type { ResourcePurgeResult } from "#/features/workspaces/resource-purge-result";
 import { WorkspaceKernelEventBus } from "#/features/workspaces/kernel/workspace-kernel-events";
@@ -37,21 +38,24 @@ import type {
 	DeleteWorkspaceKernelItemsResult,
 	GetWorkspaceKernelItemPathsArgs,
 	ListWorkspaceKernelItemRelationsArgs,
+	ListWorkspaceHistoryArgs,
 	ListWorkspaceKernelItemsArgs,
 	LinkWorkspaceKernelItemsArgs,
 	MoveWorkspaceKernelItemsArgs,
 	MoveWorkspaceKernelItemsResult,
 	ReadWorkspaceKernelFileSourceArgs,
 	ReadWorkspaceKernelFileProjectionArgs,
-	ReadWorkspaceDocumentCheckpointArgs,
+	ReadWorkspaceItemContentArgs,
+	ReadWorkspaceItemVersionArgs,
+	ReadWorkspaceItemVersionChangeArgs,
 	ResolveWorkspaceKernelPathsArgs,
 	RenameWorkspaceKernelItemArgs,
 	UpdateWorkspaceKernelItemColorArgs,
 	UpsertWorkspaceKernelFileProjectionArgs,
 	WorkspaceKernelPage,
 	WorkspaceKernelMutationOutcome,
-	WorkspaceKernelPublishOutcome,
-	CommitWorkspaceDocumentCheckpointArgs,
+	WorkspaceKernelContentCommitOutcome,
+	CommitWorkspaceItemContentArgs,
 	WorkspaceKernelPathResolution,
 } from "#/features/workspaces/kernel/workspace-kernel-types";
 import { getChatAttachmentWorkspacePrefix } from "#/features/workspaces/ai/chat-attachment-storage";
@@ -142,8 +146,14 @@ export class WorkspaceKernel extends Agent<Cloudflare.Env> {
 		},
 	});
 	private readonly relations = new WorkspaceKernelRelations(this.kernelSql);
+	private readonly history = new WorkspaceKernelHistory(
+		this.kernelSql,
+		this.env.WORKSPACE_KERNEL_FILES,
+		() => this.name,
+	);
 	private readonly itemCommands = new WorkspaceKernelItemCommands({
 		events: this.events,
+		history: this.history,
 		relations: this.relations,
 		sql: this.kernelSql,
 		store: this.store,
@@ -267,6 +277,7 @@ export class WorkspaceKernel extends Agent<Cloudflare.Env> {
 			actorUserId: input.actorUserId ?? null,
 			clientMutationId: input.clientMutationId ?? null,
 			payload: { itemFacts },
+			provenance: input.provenance,
 		});
 		return { event, result: itemFacts };
 	}
@@ -393,16 +404,28 @@ export class WorkspaceKernel extends Agent<Cloudflare.Env> {
 		}
 	}
 
-	async readDocumentCheckpoint(input: ReadWorkspaceDocumentCheckpointArgs) {
-		return await this.itemCommands.readDocumentCheckpoint(input);
+	async readItemContent(input: ReadWorkspaceItemContentArgs) {
+		return await this.itemCommands.readItemContent(input);
 	}
 
-	async commitDocumentCheckpoint(
-		input: CommitWorkspaceDocumentCheckpointArgs,
-	): Promise<WorkspaceKernelPublishOutcome> {
-		return this.runMutation("commit_document_checkpoint", input, 1, () =>
-			this.itemCommands.commitDocumentCheckpoint(input),
+	async commitItemContent(
+		input: CommitWorkspaceItemContentArgs,
+	): Promise<WorkspaceKernelContentCommitOutcome> {
+		return this.runMutation("commit_item_content", input, 1, () =>
+			this.itemCommands.commitItemContent(input),
 		);
+	}
+
+	async listHistory(input: ListWorkspaceHistoryArgs = {}) {
+		return this.history.list(input);
+	}
+
+	async readItemVersionChange(input: ReadWorkspaceItemVersionChangeArgs) {
+		return await this.history.readVersionChange(input);
+	}
+
+	async readItemVersion(input: ReadWorkspaceItemVersionArgs) {
+		return await this.history.readVersion(input);
 	}
 
 	async searchWorkspace(input: WorkspaceSearchInput) {
@@ -496,6 +519,7 @@ export class WorkspaceKernel extends Agent<Cloudflare.Env> {
 			deleteR2Prefix(this.env.WORKSPACE_KERNEL_FILES, `workspace_kernel_files/${workspaceId}/`),
 			deleteR2Prefix(this.env.WORKSPACE_KERNEL_FILES, `workspace_file_objects/${workspaceId}/`),
 			deleteR2Prefix(this.env.WORKSPACE_KERNEL_FILES, `workspace_file_uploads/${workspaceId}/`),
+			deleteR2Prefix(this.env.WORKSPACE_KERNEL_FILES, `workspace_history/${workspaceId}/`),
 		]);
 		const r2Failures = r2PurgeResults.filter((result) => result.status === "rejected");
 		if (r2Failures.length > 0) {

--- a/src/features/workspaces/model/workspace-page.test.ts
+++ b/src/features/workspaces/model/workspace-page.test.ts
@@ -24,6 +24,9 @@ describe("applyWorkspaceEventToPage", () => {
 				createdAt: "2026-01-01T00:00:00.000Z",
 				actorUserId: null,
 				clientMutationId: null,
+				origin: "system",
+				groupId: null,
+				threadId: null,
 				type,
 				payload: {
 					itemFacts: [{ itemId: "item-1", pageCount: 12, relationshipCount: 2 }],

--- a/src/features/workspaces/operations/create-items.ts
+++ b/src/features/workspaces/operations/create-items.ts
@@ -158,6 +158,7 @@ export async function createWorkspaceItemsOperation(
 			initialRelations: relations.relations,
 			actorUserId: accessContext.actor.userId,
 			clientMutationId: `${accessContext.operationId}:${index}`,
+			provenance: accessContext.provenance,
 		});
 
 		if (outcome.status === "conflict") {

--- a/src/features/workspaces/operations/delete-items.ts
+++ b/src/features/workspaces/operations/delete-items.ts
@@ -74,6 +74,7 @@ export async function deleteWorkspaceItemsOperation(
 		itemIds: resolvedItems.map((resolved) => resolved.item.id),
 		actorUserId: accessContext.actor.userId,
 		clientMutationId: accessContext.operationId,
+		provenance: accessContext.provenance,
 	});
 	const resolvedItemsById = new Map<string, (typeof resolvedItems)[number]>();
 

--- a/src/features/workspaces/operations/edit-item.ts
+++ b/src/features/workspaces/operations/edit-item.ts
@@ -83,6 +83,8 @@ export async function editWorkspaceItemOperation(
 			),
 		),
 		operationId: accessContext.operationId,
+		actorUserId: accessContext.actor.userId,
+		provenance: accessContext.provenance,
 	});
 
 	return {

--- a/src/features/workspaces/operations/link-items.ts
+++ b/src/features/workspaces/operations/link-items.ts
@@ -82,6 +82,7 @@ export async function linkWorkspaceItemsOperation(
 		relations: relations.relations,
 		actorUserId: accessContext.actor.userId,
 		clientMutationId: accessContext.operationId,
+		provenance: accessContext.provenance,
 	});
 
 	return {

--- a/src/features/workspaces/operations/move-items.ts
+++ b/src/features/workspaces/operations/move-items.ts
@@ -139,6 +139,7 @@ export async function moveWorkspaceItemsOperation(
 			onNameConflict: "error",
 			actorUserId: accessContext.actor.userId,
 			clientMutationId: accessContext.operationId,
+			provenance: accessContext.provenance,
 		});
 
 		if (outcome.status === "conflict") {

--- a/src/features/workspaces/operations/rename-item.ts
+++ b/src/features/workspaces/operations/rename-item.ts
@@ -66,6 +66,7 @@ export async function renameWorkspaceItemOperation(
 		onNameConflict: "error",
 		actorUserId: accessContext.actor.userId,
 		clientMutationId: accessContext.operationId,
+		provenance: accessContext.provenance,
 	});
 
 	if (outcome.status === "conflict") {

--- a/src/features/workspaces/operations/workspace-access-context.ts
+++ b/src/features/workspaces/operations/workspace-access-context.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceReferenceRecord } from "#/features/workspaces/locations/workspace-location";
+import type { WorkspaceMutationProvenance } from "#/features/workspaces/history/workspace-history-contract";
 import {
 	assertAccessScope,
 	createAccessActor,
@@ -11,6 +12,7 @@ export type WorkspaceAccessScope = (typeof workspaceAccessScopes)[number];
 
 export interface WorkspaceAccessContext extends ScopedAccessContext<WorkspaceAccessScope> {
 	operationId: string;
+	provenance?: WorkspaceMutationProvenance;
 	/**
 	 * Resolves the short refs a read handed the assistant, so a document can cite
 	 * with the same `wr_` ref it cites with in chat. Absent outside a chat turn.
@@ -22,6 +24,7 @@ export interface WorkspaceAccessContext extends ScopedAccessContext<WorkspaceAcc
 export function createWorkspaceAccessContext(input: {
 	scopes: readonly WorkspaceAccessScope[];
 	operationId: string;
+	provenance?: WorkspaceMutationProvenance;
 	resolveWorkspaceReferences?: (refs: readonly string[]) => Promise<WorkspaceReferenceRecord[]>;
 	userId: string;
 	workspaceId: string;
@@ -29,6 +32,7 @@ export function createWorkspaceAccessContext(input: {
 	return {
 		actor: createAccessActor(input),
 		operationId: input.operationId,
+		...(input.provenance ? { provenance: input.provenance } : {}),
 		...(input.resolveWorkspaceReferences
 			? { resolveWorkspaceReferences: input.resolveWorkspaceReferences }
 			: {}),

--- a/src/features/workspaces/realtime/messages.ts
+++ b/src/features/workspaces/realtime/messages.ts
@@ -3,6 +3,7 @@ import {
 	workspaceItemFactsSchema,
 	workspaceItemSummarySchema,
 } from "#/features/workspaces/contracts";
+import { workspaceHistoryOrigins } from "#/features/workspaces/history/workspace-history-contract";
 
 const workspacePresenceUserSchema = z.object({
 	id: z.string(),
@@ -18,6 +19,9 @@ const workspaceRealtimeEventBase = {
 	createdAt: z.string(),
 	actorUserId: z.string().nullable(),
 	clientMutationId: z.string().nullable(),
+	origin: z.enum(workspaceHistoryOrigins),
+	groupId: z.string().nullable(),
+	threadId: z.string().nullable(),
 };
 
 const workspaceRealtimeEventSchema = z.discriminatedUnion("type", [
@@ -27,6 +31,7 @@ const workspaceRealtimeEventSchema = z.discriminatedUnion("type", [
 		payload: z.object({
 			item: workspaceItemSummarySchema,
 			itemFacts: z.array(workspaceItemFactsSchema),
+			versionId: z.string().nullable().optional(),
 		}),
 	}),
 	z.object({
@@ -37,12 +42,17 @@ const workspaceRealtimeEventSchema = z.discriminatedUnion("type", [
 			"workspace.item.color.updated",
 			"workspace.item.content.updated",
 		]),
-		payload: z.object({ item: workspaceItemSummarySchema }),
+		payload: z.object({
+			item: workspaceItemSummarySchema,
+			versionId: z.string().nullable().optional(),
+		}),
 	}),
 	z.object({
 		...workspaceRealtimeEventBase,
 		type: z.literal("workspace.items.moved"),
-		payload: z.object({ items: z.array(workspaceItemSummarySchema) }),
+		payload: z.object({
+			items: z.array(workspaceItemSummarySchema),
+		}),
 	}),
 	z.object({
 		...workspaceRealtimeEventBase,
@@ -51,6 +61,7 @@ const workspaceRealtimeEventSchema = z.discriminatedUnion("type", [
 			itemIds: z.array(z.string()),
 			deletedItemIds: z.array(z.string()),
 			itemFacts: z.array(workspaceItemFactsSchema),
+			items: z.array(workspaceItemSummarySchema).optional(),
 		}),
 	}),
 	z.object({


### PR DESCRIPTION
## What changed

- add workspace-wide activity backed by kernel events and immutable item versions stored in R2
- checkpoint AI edits, restores, undo operations, and settled human editing sessions
- add a two-pane history dialog with actor identity, exact document diffs, pagination, and restore
- keep live AI undo separate from historical review and preserve deleted-item history
- adapt the generic item-content path to the latest workspace export flow

## Why

ThinkEx previously had activity metadata but no durable content bodies, so overwritten document states could not be compared or restored. This adds the minimal immutable history layer needed for reliable review and recovery without replacing Yjs/Tiptap or versioning every keystroke.

## User impact

Workspace members can inspect recent changes across the workspace, see who made them, compare document versions, and restore an older version without erasing later history.

## Validation

- `pnpm check`
- 82 unit test files / 358 tests
- 16 worker test files / 54 tests
- production build
- browser-verified empty, selected, diff, pagination, and restore states on localhost

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788978376&installation_model_id=425282&pr_number=756&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F756&signature=35396f610272565bf0c31f6bba26180e24aa3f7d8c46378b176642165c90f389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added workspace Version history, accessible from the workspace actions menu.
  - Browse activity with pagination, loading, error, and empty states.
  - Preview historical document versions with highlighted changes.
  - Restore eligible document versions with confirmation and success or error notifications.
  - Improved tracking of mutation source and conversation context in workspace activity.
- **Bug Fixes**
  - Improved reliability of document undo, restore, export, and deletion scenarios.
  - Added safeguards to prevent inconsistent version history after failed or conflicting updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->