### PR TITLE
fix(migrations): rebuild stale legacy previews

### DIFF
--- a/src/features/workspaces/migration/legacy-workspace-data.ts
+++ b/src/features/workspaces/migration/legacy-workspace-data.ts
@@ -16,7 +16,12 @@ import { createDbContext } from "#/db/server";
 import type { JsonValue } from "#/features/workspaces/contracts";
 import { workspaceItemTypeSchema } from "#/features/workspaces/contracts";
 import { getWorkspaceItemNameKey } from "#/features/workspaces/defaults";
+import {
+	createWorkspaceFilePreview,
+	WORKSPACE_FILE_PREVIEW_CONTENT_TYPE,
+} from "#/features/workspaces/files/workspace-file-preview";
 import { workspaceFileAssetKindSchema } from "#/features/workspaces/model/workspace-file";
+import { putFixedLengthR2Object } from "#/lib/r2";
 
 const migrationScopePrefix = "workspace:";
 const legacyShellInlineThresholdBytes = 1_500_000;
@@ -178,6 +183,7 @@ export async function migrateLegacyWorkspaceData(input: {
 			for (const item of items.filter((candidate) => candidate.type === "file")) {
 				await importFileAsset({
 					bucket: input.env.WORKSPACE_KERNEL_FILES,
+					env: input.env,
 					item,
 					projections,
 					transaction,
@@ -260,11 +266,13 @@ function orderParentsBeforeChildren(items: LegacyItemRow[]) {
 
 async function importFileAsset(input: {
 	bucket: R2Bucket;
+	env: Cloudflare.Env;
 	item: LegacyItemRow;
 	projections: LegacyProjectionRow[];
 	transaction: Transaction;
 }) {
 	const metadata = parseJsonRecord(input.item.metadata_json);
+	const assetKind = workspaceFileAssetKindSchema.parse(metadata.assetKind);
 	const preview = input.projections.find(
 		(projection) => projection.item_id === input.item.id && projection.format === "preview",
 	);
@@ -278,10 +286,29 @@ async function importFileAsset(input: {
 	if (!sourceObject || !previewObject) {
 		throw new Error(`Legacy file ${input.item.id} references missing R2 objects.`);
 	}
+	let previewSizeBytes = previewObject.size;
 	if (preview.source_hash && preview.source_hash !== sourceObject.etag) {
-		throw new Error(`Legacy file ${input.item.id} preview does not match its source.`);
+		const source = await input.bucket.get(input.item.object_key);
+		if (!source) {
+			throw new Error(`Legacy file ${input.item.id} source disappeared during preview repair.`);
+		}
+		const generatedPreview = await createWorkspaceFilePreview(input.env, {
+			assetKind,
+			body: source.body,
+			contentType: getString(metadata.mimeType) ?? "application/octet-stream",
+			sizeBytes: source.size,
+		});
+		const storedPreview = await putFixedLengthR2Object(
+			input.bucket,
+			preview.object_key,
+			generatedPreview,
+			{ httpMetadata: { contentType: WORKSPACE_FILE_PREVIEW_CONTENT_TYPE } },
+		);
+		if (!storedPreview) {
+			throw new Error(`Legacy file ${input.item.id} preview could not be repaired.`);
+		}
+		previewSizeBytes = storedPreview.size;
 	}
-	workspaceFileAssetKindSchema.parse(metadata.assetKind);
 
 	await input.transaction.insert(workspaceFileAssets).values({
 		itemId: input.item.id,
@@ -291,7 +318,7 @@ async function importFileAsset(input: {
 		mimeType: getString(metadata.mimeType) ?? "application/octet-stream",
 		sizeBytes: sourceObject.size,
 		previewObjectKey: preview.object_key,
-		previewSizeBytes: previewObject.size,
+		previewSizeBytes,
 	});
 }
 


### PR DESCRIPTION
## What changed

- Rebuild a legacy file preview from its canonical R2 source when the stored preview source hash is stale.
- Store the repaired preview size and current source hash in Postgres.

## Why

The production cutover rehearsal found one workspace whose legacy preview referenced an older source hash. The migration previously aborted the entire workspace, even though the canonical source file remained intact and readable. Rebuilding the derived preview preserves the source and avoids carrying a visibly stale preview into Postgres.

## Validation

- `pnpm exec vitest run src/features/workspaces/files/workspace-file-preview.test.ts`
- `pnpm check`
- Production verification will repeat the exact failing migration request before the full importer resumes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789075538&installation_model_id=425282&pr_number=761&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F761&signature=0c2605896e4ff841090dcbafae9da086a3e20cc550df2a753646799e4ca1de68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

