### PR TITLE
fix(migrations): preserve incomplete legacy extractions

### DIFF
--- a/src/features/workspaces/migration/legacy-workspace-data.ts
+++ b/src/features/workspaces/migration/legacy-workspace-data.ts
@@ -328,17 +328,27 @@ async function importExtraction(input: {
 	transaction: Transaction;
 	workspaceId: string;
 }) {
-	const status = parseExtractionStatus(input.projection.status);
+	let status: "failed" | "processing" | "ready" = parseExtractionStatus(input.projection.status);
+	let errorMessage = input.projection.error_message;
 	const metadata = parseJsonRecord(input.projection.metadata_json);
 	let pages = 0;
 	let markdownLength = 0;
 	let tier: "enhanced" | "fast" | null = null;
+	const readyProjection =
+		input.projection.object_key && input.projection.source_hash
+			? {
+					expectedSourceHash: input.projection.source_hash,
+					manifestObjectKey: input.projection.object_key,
+				}
+			: null;
 
-	if (status === "ready") {
-		if (!input.projection.object_key || !input.projection.source_hash) {
-			throw new Error(`Ready extraction ${input.projection.item_id} is incomplete.`);
-		}
-		tier = parseExtractionTier(input.projection.object_key);
+	if (status === "ready" && !readyProjection) {
+		status = "failed";
+		errorMessage = "Legacy extraction was incomplete and must be regenerated.";
+	}
+
+	if (status === "ready" && readyProjection) {
+		tier = parseExtractionTier(readyProjection.manifestObjectKey);
 		let batch: Array<{
 			itemId: string;
 			pageNumber: number;
@@ -347,8 +357,7 @@ async function importExtraction(input: {
 		}> = [];
 		for await (const page of iterateLegacyProjectionPages({
 			bucket: input.bucket,
-			expectedSourceHash: input.projection.source_hash,
-			manifestObjectKey: input.projection.object_key,
+			...readyProjection,
 		})) {
 			batch.push({
 				itemId: input.projection.item_id,
@@ -373,7 +382,7 @@ async function importExtraction(input: {
 		provider: input.projection.provider,
 		providerMode: input.projection.provider_mode,
 		tier,
-		errorMessage: input.projection.error_message,
+		errorMessage,
 		sourceHash: input.projection.source_hash,
 		metadata: status === "ready" ? { ...metadata, markdownLength, pageCount: pages } : metadata,
 		updatedAt: new Date(input.projection.updated_at),


### PR DESCRIPTION
## What changed

- Preserve a legacy `ready` extraction with missing manifest data as an explicit failed extraction that can be regenerated.
- Continue migrating the canonical file, preview, metadata, and all valid extracted pages.

## Why

The production importer found a legacy projection marked `ready` without the manifest key or source hash required to read any pages. The former extraction healer already classified this shape as unreadable. Blocking the entire workspace cannot recover nonexistent derived data; recording an honest failed projection preserves the canonical file and makes the recovery requirement visible.

## Validation

- `pnpm exec vitest run src/features/workspaces/extraction/workspace-projection-readiness.test.ts`
- `pnpm check`
- Production verification will repeat the exact failing workspace migration before the importer resumes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789076223&installation_model_id=425282&pr_number=762&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F762&signature=3d941beac9b73af6a9ae7cfbf89aa27a34697302e5a3ea66e6dfb2bc63edc466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

