### PR TITLE
fix(migrations): infer legacy extraction tiers

### DIFF
--- a/src/features/workspaces/migration/legacy-workspace-data.ts
+++ b/src/features/workspaces/migration/legacy-workspace-data.ts
@@ -348,7 +348,11 @@ async function importExtraction(input: {
 	}
 
 	if (status === "ready" && readyProjection) {
-		tier = parseExtractionTier(readyProjection.manifestObjectKey);
+		tier = resolveExtractionTier({
+			manifestObjectKey: readyProjection.manifestObjectKey,
+			metadata,
+			providerMode: input.projection.provider_mode,
+		});
 		let batch: Array<{
 			itemId: string;
 			pageNumber: number;
@@ -509,10 +513,19 @@ function parseExtractionStatus(value: string) {
 	throw new Error(`Unsupported legacy extraction status: ${value}`);
 }
 
-function parseExtractionTier(objectKey: string) {
+function resolveExtractionTier(input: {
+	manifestObjectKey: string;
+	metadata: Record<string, JsonValue>;
+	providerMode: string | null;
+}) {
+	// Newer projections encode the tier in their R2 key. Early projections did
+	// not always do so, but the fast pass has always identified itself as either
+	// provisional or provider mode `fast`; every other published projection is
+	// the final enhanced pass.
+	const objectKey = input.manifestObjectKey;
 	const match = objectKey.match(/\/(fast|enhanced)\/manifest\.json$/);
-	if (!match) throw new Error("Legacy extraction tier could not be determined.");
-	return match[1] as "enhanced" | "fast";
+	if (match) return match[1] as "enhanced" | "fast";
+	return input.metadata.provisional === true || input.providerMode === "fast" ? "fast" : "enhanced";
 }
 
 function getManifestPrefix(objectKey: string) {


### PR DESCRIPTION
## Summary
- preserve explicit extraction tiers encoded in R2 keys
- infer early fast projections from their existing provisional/provider-mode metadata
- treat other published legacy projections as the final enhanced pass

## Verification
- `pnpm check`
- exact production workspace will be retried after merge and manual deployment

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789076853&installation_model_id=425282&pr_number=764&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F764&signature=690f5e306790db814d908effb375cc1fdbac4ba6ae0f73ceec503cf2f4b936df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction tier detection when manifest information is incomplete.
  * Added fallback classification using projection metadata and provider mode.
  * Unrecognized manifest tiers are now handled gracefully instead of producing an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->