### PR TITLE
fix(migrations): scope every legacy workspace id

### DIFF
--- a/src/features/workspaces/migration/legacy-workspace-data.ts
+++ b/src/features/workspaces/migration/legacy-workspace-data.ts
@@ -514,7 +514,9 @@ function getString(value: JsonValue | undefined) {
 }
 
 function getLegacyDestinationId(workspaceId: string, legacyId: string) {
-	return legacyId.startsWith("sample-") ? `${workspaceId}:${legacyId}` : legacyId;
+	// Legacy IDs were only unique inside one WorkspaceKernel Durable Object.
+	// Postgres IDs are global, so retain the old identity while adding its scope.
+	return `${workspaceId}:${legacyId}`;
 }
 
 function getDestinationItemId(itemIds: Map<string, string>, legacyId: string) {


### PR DESCRIPTION
## Summary
- namespace every legacy item and relation ID by its WorkspaceKernel ID
- keep the reference rewriting introduced in #765 for parents, relations, citations, files, extractions, and pages

## Why
Production showed that legacy Durable Object IDs—including timestamp-style seeded IDs—were only workspace-local. The Postgres model uses global IDs, so the migration must make the legacy scope explicit.

## Verification
- `pnpm check`
- exact production collision workspace will be retried after merge and manual deployment

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789077920&installation_model_id=425282&pr_number=766&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F766&signature=571002a7d57d90e77100b2889942f4406709fd8116ce63996d083258de8baae7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

