### PR TITLE
fix(migrations): preserve legacy workspace references

### DIFF
--- a/src/features/workspaces/components/ai-chat/AiChatMessageResponse.test.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatMessageResponse.test.tsx
@@ -85,6 +85,32 @@ describe("AI chat message response citations", () => {
 		expect(html).toContain("Research Notes");
 	});
 
+	it("resolves citations written before legacy item IDs were globally scoped", () => {
+		const ref = "wr_CCCCCCCC" as WorkspaceReference;
+		const migratedItem: WorkspaceItem = {
+			...documentItem,
+			id: "workspace-1:document-1",
+			metadataJson: { legacyItemId: "document-1" },
+		};
+		const html = renderToStaticMarkup(
+			<WorkspaceLocationProvider
+				itemsById={new Map([[migratedItem.id, migratedItem]])}
+				navigate={() => "tab-1"}
+			>
+				<AiChatMessageResponse
+					workspaceCitationLocations={
+						new Map([[ref, { itemId: "document-1", kind: "item", version: 1 }]])
+					}
+				>
+					{`Claim <citation ref="${ref}"></citation>`}
+				</AiChatMessageResponse>
+			</WorkspaceLocationProvider>,
+		);
+
+		expect(html).toContain("Research Notes");
+		expect(html).not.toContain("Source unavailable");
+	});
+
 	it("does not expose an incomplete streamed citation tag", () => {
 		const html = renderToStaticMarkup(
 			<WorkspaceLocationProvider itemsById={new Map()} navigate={() => undefined}>

--- a/src/features/workspaces/locations/workspace-location-context.tsx
+++ b/src/features/workspaces/locations/workspace-location-context.tsx
@@ -1,5 +1,5 @@
 import { FileQuestion, type LucideIcon } from "lucide-react";
-import { createContext, type ReactNode, use, useCallback, useState } from "react";
+import { createContext, type ReactNode, use, useCallback, useMemo, useState } from "react";
 
 import type { WorkspaceLocation } from "#/features/workspaces/locations/workspace-location";
 import { getWorkspaceItemDisplay } from "#/features/workspaces/model/item-display";
@@ -42,13 +42,25 @@ export function WorkspaceLocationProvider({
 	readonly navigate: (location: WorkspaceLocation) => string | undefined;
 }) {
 	const [revealRequest, setRevealRequest] = useState<WorkspacePdfPageRevealRequest | null>(null);
+	const legacyItemsById = useMemo(() => {
+		const aliases = new Map<string, WorkspaceItem>();
+		for (const item of itemsById.values()) {
+			const legacyItemId = item.metadataJson.legacyItemId;
+			if (typeof legacyItemId === "string") aliases.set(legacyItemId, item);
+		}
+		return aliases;
+	}, [itemsById]);
+	const resolveItem = useCallback(
+		(itemId: string) => itemsById.get(itemId) ?? legacyItemsById.get(itemId),
+		[itemsById, legacyItemsById],
+	);
 	const consumeRevealRequest = useCallback((request: WorkspacePdfPageRevealRequest) => {
 		setRevealRequest((current) => (current === request ? null : current));
 	}, []);
 	const value: WorkspaceLocationContextValue = {
 		consumeRevealRequest,
 		getPresentation(location) {
-			const item = itemsById.get(location.itemId);
+			const item = resolveItem(location.itemId);
 			const itemName = item?.name ?? "Source unavailable";
 			const locatorLabel = location.kind === "pdf-page" ? `p. ${location.pageNumber}` : undefined;
 
@@ -65,13 +77,17 @@ export function WorkspaceLocationProvider({
 			return { Icon, iconClassName, label: itemName, locatorLabel };
 		},
 		hasItem(itemId) {
-			return itemsById.has(itemId);
+			return Boolean(resolveItem(itemId));
 		},
 		reveal(location) {
-			const viewInstanceId = navigate(location);
+			const item = resolveItem(location.itemId);
+			const resolvedLocation = item ? { ...location, itemId: item.id } : location;
+			const viewInstanceId = navigate(resolvedLocation);
 
 			setRevealRequest(
-				viewInstanceId && location.kind === "pdf-page" ? { location, viewInstanceId } : null,
+				viewInstanceId && resolvedLocation.kind === "pdf-page"
+					? { location: resolvedLocation, viewInstanceId }
+					: null,
 			);
 			return Boolean(viewInstanceId);
 		},

--- a/src/features/workspaces/migration/legacy-workspace-data.ts
+++ b/src/features/workspaces/migration/legacy-workspace-data.ts
@@ -166,7 +166,10 @@ export async function migrateLegacyWorkspaceData(input: {
 					name: item.name,
 					nameKey: getWorkspaceItemNameKey(item.name),
 					color: item.color,
-					metadata: parseJsonRecord(item.metadata_json),
+					metadata: {
+						...parseJsonRecord(item.metadata_json),
+						legacyItemId: item.id,
+					},
 					sortOrder: item.sort_order,
 					createdAt: new Date(item.created_at),
 					updatedAt: new Date(item.updated_at),

--- a/src/features/workspaces/persistence/workspace-postgres-documents.ts
+++ b/src/features/workspaces/persistence/workspace-postgres-documents.ts
@@ -32,7 +32,7 @@ export class PostgresWorkspaceDocuments {
 			const [checkpoint] = await db
 				.select({ content: workspaceDocumentCheckpoints.content })
 				.from(workspaceDocumentCheckpoints)
-				.where(eq(workspaceDocumentCheckpoints.itemId, input.itemId))
+				.where(eq(workspaceDocumentCheckpoints.itemId, item.id))
 				.limit(1);
 			if (!checkpoint) {
 				throw new Error("Workspace document checkpoint is missing.");
@@ -60,7 +60,7 @@ export class PostgresWorkspaceDocuments {
 			const now = new Date();
 			await transaction
 				.insert(workspaceDocumentCheckpoints)
-				.values({ itemId: input.itemId, content: input.content })
+				.values({ itemId: row.id, content: input.content })
 				.onConflictDoUpdate({
 					target: workspaceDocumentCheckpoints.itemId,
 					set: { content: input.content },
@@ -68,7 +68,7 @@ export class PostgresWorkspaceDocuments {
 			await transaction
 				.update(workspaceItems)
 				.set({ metadata, updatedAt: now })
-				.where(eq(workspaceItems.id, input.itemId));
+				.where(eq(workspaceItems.id, row.id));
 			const revision = await nextWorkspaceRevision(transaction, this.workspaceId);
 			return { outcome: "applied" as const, revision };
 		});

--- a/src/features/workspaces/persistence/workspace-postgres-support.ts
+++ b/src/features/workspaces/persistence/workspace-postgres-support.ts
@@ -95,7 +95,19 @@ export async function getActiveWorkspaceItemRow(
 		.from(workspaceItems)
 		.where(and(eq(workspaceItems.workspaceId, workspaceId), eq(workspaceItems.id, itemId)))
 		.limit(1);
-	return row ?? null;
+	if (row) return row;
+
+	const [legacyRow] = await db
+		.select()
+		.from(workspaceItems)
+		.where(
+			and(
+				eq(workspaceItems.workspaceId, workspaceId),
+				sql`${workspaceItems.metadata}->>'legacyItemId' = ${itemId}`,
+			),
+		)
+		.limit(1);
+	return legacyRow ?? null;
 }
 
 export async function requireActiveWorkspaceItemRow(


### PR DESCRIPTION
## Summary
- preserve each pre-Postgres workspace item ID as migration metadata
- resolve historical AI citations and edit actions through that alias
- write legacy DocumentSession checkpoints to the canonical Postgres item

## Verification
- `pnpm check`
- `pnpm test` (77 files, 326 tests)
- `pnpm build`
- `pnpm doctor` (only existing findings outside this diff)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789078513&installation_model_id=425282&pr_number=767&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F767&signature=565ce24b1d222396d192646e02ed661a7dff3ed8bea47a911c1bc2dfa6577685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

