### PR TITLE
fix(migrations): resolve legacy sibling name collisions

### DIFF
--- a/src/features/workspaces/migration/legacy-workspace-data.ts
+++ b/src/features/workspaces/migration/legacy-workspace-data.ts
@@ -15,7 +15,10 @@ import {
 import { createDbContext } from "#/db/server";
 import type { JsonValue } from "#/features/workspaces/contracts";
 import { workspaceItemTypeSchema } from "#/features/workspaces/contracts";
-import { getWorkspaceItemNameKey } from "#/features/workspaces/defaults";
+import {
+	getAvailableWorkspaceItemName,
+	getWorkspaceItemNameKey,
+} from "#/features/workspaces/defaults";
 import {
 	createWorkspaceFilePreview,
 	WORKSPACE_FILE_PREVIEW_CONTENT_TYPE,
@@ -154,9 +157,18 @@ export async function migrateLegacyWorkspaceData(input: {
 				throw new Error("Workspace already has Postgres items without a migration marker.");
 			}
 
+			const siblingNames = new Map<string | null, string[]>();
 			for (const item of orderParentsBeforeChildren(items)) {
 				const type = workspaceItemTypeSchema.parse(item.type);
 				const itemId = getDestinationItemId(destinationItemIds, item.id);
+				const existingNames = siblingNames.get(item.parent_id) ?? [];
+				const name = getAvailableWorkspaceItemName({
+					type,
+					requestedName: item.name,
+					existingNames,
+				});
+				existingNames.push(name);
+				siblingNames.set(item.parent_id, existingNames);
 				await transaction.insert(workspaceItems).values({
 					id: itemId,
 					workspaceId: input.workspaceId,
@@ -164,8 +176,8 @@ export async function migrateLegacyWorkspaceData(input: {
 						? getDestinationItemId(destinationItemIds, item.parent_id)
 						: null,
 					type,
-					name: item.name,
-					nameKey: getWorkspaceItemNameKey(item.name),
+					name,
+					nameKey: getWorkspaceItemNameKey(name),
 					color: item.color,
 					metadata: parseJsonRecord(item.metadata_json),
 					sortOrder: item.sort_order,


### PR DESCRIPTION
## Summary
- normalize legacy item names through the live workspace naming policy
- deterministically suffix duplicate sibling names during the one-time import

## Verification
- `pnpm check`
- `pnpm test` (325 tests)
- production failure isolated to the root sibling-name uniqueness constraint; each workspace remains transactional

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789081007&installation_model_id=425282&pr_number=769&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F769&signature=aab71d869b58e65fd27d74478f2a8a836d53f06bc9211a61328153f9a3913b2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace migration now assigns unique names to imported items when sibling items share the same name.
  * Generated item identifiers consistently reflect the resolved display names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->