### PR TITLE
fix(migrations): retry only pending workspaces

### DIFF
--- a/scripts/import-legacy-d1.mjs
+++ b/scripts/import-legacy-d1.mjs
@@ -88,6 +88,8 @@ const workspaceIds = (source.get("workspaces") ?? []).map((row) => String(row.id
 try {
 	await withPostgresClient((client) => importD1Rows(client, source));
 	if (!options.d1Only) {
+		const completedWorkspaceIds = await withPostgresClient(readCompletedWorkspaceIds);
+		const pendingWorkspaceIds = workspaceIds.filter((id) => !completedWorkspaceIds.has(id));
 		const summary = {
 			workspaces: 0,
 			statuses: {},
@@ -97,9 +99,13 @@ try {
 			relations: 0,
 			pages: 0,
 		};
-		for (let index = 0; index < workspaceIds.length; index += workspaceMigrationConcurrency) {
+		for (
+			let index = 0;
+			index < pendingWorkspaceIds.length;
+			index += workspaceMigrationConcurrency
+		) {
 			const reports = await Promise.all(
-				workspaceIds
+				pendingWorkspaceIds
 					.slice(index, index + workspaceMigrationConcurrency)
 					.map((workspaceId) => migrateWorkspace(options.appUrl, migrationToken, workspaceId)),
 			);
@@ -122,20 +128,39 @@ async function withPostgresClient(run) {
 	}
 }
 
-async function migrateWorkspace(appUrl, migrationToken, workspaceId) {
-	const response = await fetch(
-		`${appUrl}/api/internal/migrations/postgres/workspaces/${encodeURIComponent(workspaceId)}`,
-		{
-			method: "POST",
-			headers: { authorization: `Bearer ${migrationToken}` },
-		},
+async function readCompletedWorkspaceIds(client) {
+	const result = await client.query(
+		"SELECT scope FROM legacy_data_migrations WHERE scope LIKE 'workspace:%'",
 	);
-	if (!response.ok) {
-		throw new Error(
-			`Workspace ${workspaceId} migration failed (${response.status}): ${await response.text()}`,
-		);
+	return new Set(result.rows.map((row) => row.scope.slice("workspace:".length)));
+}
+
+async function migrateWorkspace(appUrl, migrationToken, workspaceId) {
+	const url = `${appUrl}/api/internal/migrations/postgres/workspaces/${encodeURIComponent(workspaceId)}`;
+	for (let attempt = 1; attempt <= 4; attempt += 1) {
+		let response;
+		try {
+			response = await fetch(url, {
+				method: "POST",
+				headers: { authorization: `Bearer ${migrationToken}` },
+			});
+		} catch (error) {
+			if (attempt === 4) throw error;
+			await retryDelay(attempt);
+			continue;
+		}
+		if (response.ok) return await response.json();
+		const body = await response.text();
+		if (response.status < 500 || attempt === 4) {
+			throw new Error(`Workspace ${workspaceId} migration failed (${response.status}): ${body}`);
+		}
+		await retryDelay(attempt);
 	}
-	return await response.json();
+	throw new Error(`Workspace ${workspaceId} migration failed after retries.`);
+}
+
+async function retryDelay(attempt) {
+	await new Promise((resolve) => setTimeout(resolve, 5_000 * 2 ** (attempt - 1)));
 }
 
 function addWorkspaceReport(summary, report) {


### PR DESCRIPTION
## Summary
- skip workspace RPCs whose Postgres migration markers already exist
- retry transient Worker and Durable Object failures with bounded exponential backoff

## Production evidence
The importer recovered Cloudflare DO reset/wake failures and final verification passed for all 13 D1 tables and 1,018 workspaces.

## Verification
- `pnpm check`
- final production importer verification completed successfully

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789086210&installation_model_id=425282&pr_number=771&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F771&signature=074f519a46e369e81c008f6b9798e88edf2e52cfd73720985822c30b0f93931a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legacy workspace migrations by skipping workspaces that have already completed migration.
  * Added automatic retries for temporary network and server errors.
  * Migration failures now provide clearer error details when retries are exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->