### PR TITLE
fix(search): match names across spaces and punctuation

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -9,6 +9,7 @@ import {
 	DialogTitle,
 } from "#/components/ui/dialog.tsx";
 import { InputGroup, InputGroupAddon } from "#/components/ui/input-group.tsx";
+import { scoreNameSearch } from "#/lib/name-search";
 import { cn } from "#/lib/utils.ts";
 
 type CommandContextValue = {
@@ -179,7 +180,7 @@ function CommandGroup({ className, ...props }: React.ComponentProps<"div">) {
 	return (
 		<AutocompletePrimitive.Group
 			data-slot="command-group"
-			className={cn("overflow-hidden p-1 text-foreground", className)}
+			className={cn("flex flex-col overflow-hidden p-1 text-foreground", className)}
 			{...props}
 		/>
 	);
@@ -208,19 +209,24 @@ function CommandSeparator({ className, ...props }: React.ComponentProps<"div">) 
 function CommandItem({
 	className,
 	children,
+	keywords,
 	onClick,
 	onKeyDown,
 	onSelect,
+	style,
 	value,
 	...props
 }: Omit<React.ComponentProps<"div">, "onSelect"> & {
+	keywords?: readonly string[];
 	onSelect?: (value: string) => void;
 	value?: string;
 }) {
 	const id = React.useId();
 	const { dispatchItem, search } = useCommandContext();
 	const itemValue = value ?? (typeof children === "string" ? children : "");
-	const visible = !search || itemValue.toLowerCase().includes(search.trim().toLowerCase());
+	const query = search.trim();
+	const score = query ? scoreNameSearch(query, [itemValue, ...(keywords ?? [])]) : 0;
+	const visible = !query || score > 0;
 
 	React.useEffect(() => {
 		dispatchItem({ id, type: "register", visible });
@@ -242,6 +248,9 @@ function CommandItem({
 				"group/command-item relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none in-data-[slot=dialog-content]:rounded-lg! data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-checked:bg-muted data-checked:text-foreground hover:bg-accent hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground data-highlighted:bg-accent data-highlighted:text-foreground data-selected:bg-accent data-selected:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
+			value={itemValue}
+			{...props}
+			style={{ ...style, order: query ? Math.round((8 - score) * 1000) : style?.order }}
 			onClick={(event) => {
 				selectItem();
 				onClick?.(event);
@@ -249,8 +258,6 @@ function CommandItem({
 			onKeyDown={(event) => {
 				onKeyDown?.(event);
 			}}
-			value={itemValue}
-			{...props}
 		>
 			{children}
 			<CheckIcon className="ml-auto opacity-0 group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:opacity-100" />

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -9,7 +9,7 @@ import {
 	DialogTitle,
 } from "#/components/ui/dialog.tsx";
 import { InputGroup, InputGroupAddon } from "#/components/ui/input-group.tsx";
-import { scoreNameSearch } from "#/lib/name-search";
+import { hasNameSearchQuery, scoreNameSearch } from "#/lib/name-search";
 import { cn } from "#/lib/utils.ts";
 
 type CommandContextValue = {
@@ -180,7 +180,7 @@ function CommandGroup({ className, ...props }: React.ComponentProps<"div">) {
 	return (
 		<AutocompletePrimitive.Group
 			data-slot="command-group"
-			className={cn("flex flex-col overflow-hidden p-1 text-foreground", className)}
+			className={cn("overflow-hidden p-1 text-foreground", className)}
 			{...props}
 		/>
 	);
@@ -213,7 +213,6 @@ function CommandItem({
 	onClick,
 	onKeyDown,
 	onSelect,
-	style,
 	value,
 	...props
 }: Omit<React.ComponentProps<"div">, "onSelect"> & {
@@ -224,9 +223,8 @@ function CommandItem({
 	const id = React.useId();
 	const { dispatchItem, search } = useCommandContext();
 	const itemValue = value ?? (typeof children === "string" ? children : "");
-	const query = search.trim();
-	const score = query ? scoreNameSearch(query, [itemValue, ...(keywords ?? [])]) : 0;
-	const visible = !query || score > 0;
+	const searching = hasNameSearchQuery(search);
+	const visible = !searching || scoreNameSearch(search, [itemValue, ...(keywords ?? [])]) > 0;
 
 	React.useEffect(() => {
 		dispatchItem({ id, type: "register", visible });
@@ -250,7 +248,6 @@ function CommandItem({
 			)}
 			value={itemValue}
 			{...props}
-			style={{ ...style, order: query ? Math.round((8 - score) * 1000) : style?.order }}
 			onClick={(event) => {
 				selectItem();
 				onClick?.(event);

--- a/src/features/workspaces/components/WorkspaceHomePage.tsx
+++ b/src/features/workspaces/components/WorkspaceHomePage.tsx
@@ -31,6 +31,7 @@ import { useWorkspaceTabsStore } from "#/features/workspaces/state/workspace-tab
 import { useCreateWorkspaceMutation } from "#/features/workspaces/use-create-workspace";
 import { useCopyToClipboard } from "#/hooks/use-copy-to-clipboard";
 import { useTypeToFocusTextInput } from "#/hooks/use-type-to-focus-text-input";
+import { rankNameSearch } from "#/lib/name-search";
 
 const workspaceHomeCommunityLinkOrder = ["Discord", "Twitter / X", "GitHub"];
 
@@ -218,10 +219,5 @@ function filterWorkspaces<TWorkspace extends { name: string }>(
 	workspaces: TWorkspace[],
 	search: string,
 ) {
-	const query = search.trim().toLocaleLowerCase();
-	if (!query) {
-		return workspaces;
-	}
-
-	return workspaces.filter((workspace) => workspace.name.toLocaleLowerCase().includes(query));
+	return rankNameSearch(search, workspaces, (workspace) => [workspace.name]);
 }

--- a/src/features/workspaces/components/WorkspaceSearchDialog.tsx
+++ b/src/features/workspaces/components/WorkspaceSearchDialog.tsx
@@ -75,7 +75,13 @@ function WorkspaceSearchResult({
 	const Icon = itemDisplay.Icon;
 
 	return (
-		<CommandItem value={item.name} data-checked={active} className="gap-2 py-2" onSelect={onSelect}>
+		<CommandItem
+			value={item.name}
+			keywords={[itemDisplay.label, item.type]}
+			data-checked={active}
+			className="gap-2 py-2"
+			onSelect={onSelect}
+		>
 			<Icon className={cn("size-4 shrink-0", itemDisplay.iconClassName)} aria-hidden="true" />
 			<span className="min-w-0 flex-1 truncate font-medium">{item.name}</span>
 		</CommandItem>

--- a/src/features/workspaces/model/workspace-themes.test.ts
+++ b/src/features/workspaces/model/workspace-themes.test.ts
@@ -43,6 +43,11 @@ describe("theme search", () => {
 		expect(labels("chem")).toContain("Chemistry");
 	});
 
+	it("treats spaces and hyphens as the same in names", () => {
+		expect(labels("todo")).toContain("To-Do");
+		expect(labels("to do")).toContain("To-Do");
+	});
+
 	it("requires every token to match", () => {
 		expect(labels("chemistry zzzz")).toHaveLength(0);
 	});

--- a/src/features/workspaces/model/workspace-themes.ts
+++ b/src/features/workspaces/model/workspace-themes.ts
@@ -19,11 +19,11 @@ import {
 	DEFAULT_WORKSPACE_THEME,
 } from "#/features/workspaces/defaults";
 import {
-	getSearchTermScore,
 	normalizeIconSearch,
 	normalizeIconSearchTerm,
 	workspaceIconOptions,
 } from "#/features/workspaces/model/workspace-icons";
+import { hasNameSearchQuery, scoreNameSearch, type NameSearchField } from "#/lib/name-search";
 
 const art = import.meta.glob("../themes/*.webp", {
 	eager: true,
@@ -766,29 +766,21 @@ const themeIcons = new Map(workspaceIconOptions.map((option) => [option.value, o
 // without weights that alias ties with Chemistry's actual label.
 const TERM_WEIGHTS = { name: 1, group: 0.75, borrowed: 0.5 } as const;
 
-const themeSearchTerms = new Map<string, ReadonlyArray<{ term: string; weight: number }>>(
+const themeSearchFields = new Map<string, readonly NameSearchField[]>(
 	workspaceThemeOptions.map((theme) => {
 		const icon = themeIcons.get(theme.icon);
-		const buckets: ReadonlyArray<readonly [number, string]> = [
-			[TERM_WEIGHTS.name, theme.label],
-			[TERM_WEIGHTS.name, theme.value],
-			[TERM_WEIGHTS.group, theme.group],
-			[TERM_WEIGHTS.borrowed, themeKeywords[theme.value] ?? ""],
-			[TERM_WEIGHTS.borrowed, icon?.label ?? ""],
-			[TERM_WEIGHTS.borrowed, (icon?.aliases ?? []).join(" ")],
+
+		return [
+			theme.value,
+			[
+				{ text: theme.label, weight: TERM_WEIGHTS.name },
+				{ text: theme.value, weight: TERM_WEIGHTS.name },
+				{ text: theme.group, weight: TERM_WEIGHTS.group },
+				{ text: themeKeywords[theme.value] ?? "", weight: TERM_WEIGHTS.borrowed },
+				{ text: icon?.label ?? "", weight: TERM_WEIGHTS.borrowed },
+				{ text: (icon?.aliases ?? []).join(" "), weight: TERM_WEIGHTS.borrowed },
+			],
 		];
-
-		const terms: Array<{ term: string; weight: number }> = [];
-
-		for (const [weight, text] of buckets) {
-			for (const term of normalizeIconSearchTerm(text).split(" ")) {
-				if (term) {
-					terms.push({ term, weight });
-				}
-			}
-		}
-
-		return [theme.value, terms];
 	}),
 );
 
@@ -796,9 +788,8 @@ export function filterWorkspaceThemeOptions(query: string, group: string | null)
 	const scoped = workspaceThemeOptions.filter(
 		(theme) => theme.group !== "Default" && (!group || theme.group === group),
 	);
-	const tokens = normalizeIconSearch(query);
 
-	if (tokens.length === 0) {
+	if (!hasNameSearchQuery(query)) {
 		return scoped;
 	}
 
@@ -807,44 +798,41 @@ export function filterWorkspaceThemeOptions(query: string, group: string | null)
 	// Mathematics first, because the direct label match scores higher.
 	return scoped
 		.map((theme, index) => {
-			const terms = themeSearchTerms.get(theme.value) ?? [];
-			let score = 0;
-
-			for (const token of tokens) {
-				const direct = Math.max(
-					...terms.map(({ term, weight }) => getSearchTermScore(term, token) * weight),
-				);
-
-				// An expansion match must never outrank a direct one: "math" hits
-				// "Statistics" exactly through expansion (12) but only prefixes
-				// "Mathematics" (8), which would put the family above the subject.
-				// Capping expansions below the weakest direct score fixes the order.
-				let expanded = 0;
-
-				if (!direct) {
-					for (const candidate of expansionTokens.get(token) ?? []) {
-						for (const { term, weight } of terms) {
-							expanded = Math.max(expanded, getSearchTermScore(term, candidate) * weight);
-						}
-					}
-
-					expanded = Math.min(3, expanded);
-				}
-
-				const best = direct || expanded;
-
-				if (best === 0) {
-					return null;
-				}
-
-				score += best;
-			}
-
-			return { theme, index, score };
+			const fields = themeSearchFields.get(theme.value) ?? [];
+			const score = scoreThemeQuery(query, fields);
+			return score > 0 ? { index, score, theme } : null;
 		})
 		.filter((result) => result !== null)
 		.sort((left, right) => right.score - left.score || left.index - right.index)
 		.map((result) => result.theme);
+}
+
+function scoreThemeQuery(query: string, fields: readonly NameSearchField[]) {
+	const direct = scoreNameSearch(query, fields);
+	if (direct > 0) {
+		return direct;
+	}
+
+	const tokens = normalizeIconSearch(query);
+	let total = 0;
+
+	for (const token of tokens) {
+		let best = scoreNameSearch(token, fields);
+
+		if (best === 0) {
+			for (const candidate of expansionTokens.get(token) ?? []) {
+				best = Math.max(best, Math.min(3, scoreNameSearch(candidate, fields)));
+			}
+		}
+
+		if (best === 0) {
+			return 0;
+		}
+
+		total += best;
+	}
+
+	return tokens.length > 0 ? total / tokens.length : 0;
 }
 
 export const getWorkspaceThemeArtByValue = (value: string) => art[`../themes/${value}.webp`];

--- a/src/lib/name-search.test.ts
+++ b/src/lib/name-search.test.ts
@@ -17,6 +17,10 @@ describe("name search", () => {
 		expect(byName).toBeGreaterThan(byType);
 	});
 
+	it("ranks an exact name ahead of a longer name that contains it", () => {
+		expect(scoreNameSearch("foo", ["foo"])).toBeGreaterThan(scoreNameSearch("foo", ["foo bar"]));
+	});
+
 	it("keeps token order free and ranks closer names first", () => {
 		const ranked = rankNameSearch("notes meet", ["Meeting Notes", "Notes", "Unrelated"], (name) => [
 			name,

--- a/src/lib/name-search.test.ts
+++ b/src/lib/name-search.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { rankNameSearch, scoreNameSearch } from "#/lib/name-search";
+
+describe("name search", () => {
+	it("treats spaces and punctuation as optional in names", () => {
+		expect(scoreNameSearch("to do", ["todo"])).toBeGreaterThan(0);
+		expect(scoreNameSearch("to-do", ["todo"])).toBeGreaterThan(0);
+		expect(scoreNameSearch("todo", ["To Do"])).toBeGreaterThan(0);
+		expect(scoreNameSearch("td", ["To Do"])).toBeGreaterThan(0);
+	});
+
+	it("matches type aliases and ranks the name higher", () => {
+		const byType = scoreNameSearch("pdf", ["report", "PDF"]);
+		const byName = scoreNameSearch("pdf", ["Q4 PDF"]);
+		expect(byType).toBeGreaterThan(0);
+		expect(byName).toBeGreaterThan(byType);
+	});
+
+	it("keeps token order free and ranks closer names first", () => {
+		const ranked = rankNameSearch("notes meet", ["Meeting Notes", "Notes", "Unrelated"], (name) => [
+			name,
+		]);
+		expect(ranked[0]).toBe("Meeting Notes");
+		expect(ranked).not.toContain("Unrelated");
+	});
+});

--- a/src/lib/name-search.ts
+++ b/src/lib/name-search.ts
@@ -1,0 +1,150 @@
+/**
+ * In-memory name search for palettes and pickers.
+ *
+ * Compact form follows VS Code `prepareQuery` (spaces and punctuation do not
+ * have to appear in the target). Spaces are AND-tokens like fzf. Ranking tiers
+ * follow match-sorter: equal > prefix > contains > acronym > subsequence.
+ *
+ * The first field is the primary name (weight 1). Later string fields are
+ * aliases (weight 0.6). Pass `{ text, weight }` to override.
+ */
+
+const equalRank = 7;
+const prefixRank = 6;
+const containsRank = 4;
+const acronymRank = 3;
+const fuzzyRank = 1;
+const aliasWeight = 0.6;
+
+export type NameSearchField = string | { text: string; weight?: number };
+
+interface PreparedName {
+	acronym: string;
+	compact: string;
+	tokens: string[];
+}
+
+export function hasNameSearchQuery(query: string) {
+	return prepareName(query).compact.length > 0;
+}
+
+export function scoreNameSearch(query: string, fields: readonly NameSearchField[]): number {
+	const needle = prepareName(query);
+	if (needle.compact.length === 0) {
+		return 0;
+	}
+
+	const haystacks = fields.flatMap((field, index) => {
+		const { text, weight } = resolveField(field, index);
+		const haystack = prepareName(text);
+		return haystack.compact.length > 0 ? [{ haystack, weight }] : [];
+	});
+	if (haystacks.length === 0) {
+		return 0;
+	}
+
+	let best = 0;
+	for (const { haystack, weight } of haystacks) {
+		best = Math.max(best, rankString(haystack.compact, needle.compact) * weight);
+	}
+
+	let tokenTotal = 0;
+	for (const token of needle.tokens) {
+		let tokenBest = 0;
+		for (const { haystack, weight } of haystacks) {
+			tokenBest = Math.max(tokenBest, scoreToken(haystack, token) * weight);
+		}
+		if (tokenBest === 0) {
+			return best;
+		}
+		tokenTotal += tokenBest;
+	}
+
+	return Math.max(best, tokenTotal / needle.tokens.length);
+}
+
+export function rankNameSearch<T>(
+	query: string,
+	items: readonly T[],
+	fieldsOf: (item: T) => readonly NameSearchField[],
+): T[] {
+	if (!hasNameSearchQuery(query)) {
+		return items as T[];
+	}
+
+	return items
+		.map((item, index) => ({
+			index,
+			item,
+			score: scoreNameSearch(query, fieldsOf(item)),
+		}))
+		.filter((entry) => entry.score > 0)
+		.sort((left, right) => right.score - left.score || left.index - right.index)
+		.map((entry) => entry.item);
+}
+
+function scoreToken(haystack: PreparedName, token: string) {
+	let best = rankString(haystack.compact, token);
+	for (const hayToken of haystack.tokens) {
+		best = Math.max(best, rankString(hayToken, token));
+	}
+	if (token.length >= 2 && haystack.acronym.startsWith(token)) {
+		best = Math.max(best, acronymRank);
+	}
+	return best;
+}
+
+function rankString(haystack: string, needle: string) {
+	if (needle.length === 0 || needle.length > haystack.length) {
+		return 0;
+	}
+	if (haystack === needle) {
+		return equalRank;
+	}
+	if (haystack.startsWith(needle)) {
+		return prefixRank;
+	}
+	if (haystack.includes(needle)) {
+		return containsRank;
+	}
+	return rankSubsequence(haystack, needle);
+}
+
+function rankSubsequence(haystack: string, needle: string) {
+	let from = 0;
+	const first = haystack.indexOf(needle[0]!);
+	if (first === -1) {
+		return 0;
+	}
+	from = first + 1;
+	for (let index = 1; index < needle.length; index += 1) {
+		const at = haystack.indexOf(needle[index]!, from);
+		if (at === -1) {
+			return 0;
+		}
+		from = at + 1;
+	}
+	return fuzzyRank + needle.length / (from - first);
+}
+
+function prepareName(value: string): PreparedName {
+	const tokens =
+		foldName(value.replace(/([\p{Ll}\p{N}])(\p{Lu})/gu, "$1 $2")).match(/[\p{L}\p{N}]+/gu) ?? [];
+	return {
+		acronym: tokens.map((token) => token[0]).join(""),
+		compact: tokens.join(""),
+		tokens,
+	};
+}
+
+function foldName(value: string) {
+	return value.normalize("NFKD").replace(/\p{M}/gu, "").toLowerCase();
+}
+
+function resolveField(field: NameSearchField, index: number) {
+	if (typeof field === "string") {
+		return { text: field, weight: index === 0 ? 1 : aliasWeight };
+	}
+
+	return { text: field.text, weight: field.weight ?? (index === 0 ? 1 : aliasWeight) };
+}

--- a/src/lib/name-search.ts
+++ b/src/lib/name-search.ts
@@ -86,7 +86,8 @@ export function rankNameSearch<T>(
 function scoreToken(haystack: PreparedName, token: string) {
 	let best = rankString(haystack.compact, token);
 	for (const hayToken of haystack.tokens) {
-		best = Math.max(best, rankString(hayToken, token));
+		const rank = rankString(hayToken, token);
+		best = Math.max(best, rank === equalRank ? prefixRank : rank);
 	}
 	if (token.length >= 2 && haystack.acronym.startsWith(token)) {
 		best = Math.max(best, acronymRank);


### PR DESCRIPTION
## Summary
- Cmd+K, workspace home search, and the theme picker now share one name matcher that ignores spacing/punctuation differences (`to do` / `todo` / `To-Do`).
- Queries are token-AND with compact-form matching (VS Code / fzf style); theme family expansions like `math` → Geometry are unchanged.
- Cmd+K also matches item type labels (`pdf`, `folder`) and ranks closer name hits first.

## Test plan
- [ ] In a workspace, create an item named `todo`. Open Cmd+K and search `to do` — it should appear.
- [ ] Search `pdf` in Cmd+K and confirm PDF files show even when the filename does not contain `pdf`.
- [ ] On the home page, search a workspace whose name has a hyphen/space mismatch (e.g. `To Do` vs `todo`).
- [ ] In workspace settings, open the theme picker and search `todo` and `to do` — both should find **To-Do**.
- [ ] Confirm `math` still ranks **Mathematics** first and still includes Geometry and Statistics.


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789161492&installation_model_id=425282&pr_number=778&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F778&signature=f1343e54335cb79a9d3579b1703b8bf6b224d41ed8e25a18a28c9d4b970e0f23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved search across commands, workspaces, and themes with relevance-based ranking.
  - Search now supports aliases, keywords, initials, punctuation, spacing, and flexible matching.
  - Workspace search results include additional searchable labels and types.

- **Bug Fixes**
  - Improved matching for theme names such as “To-Do” and searches like “todo” or “to do.”
  - Preserved stable ordering when results have similar relevance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->