### PR TITLE
Add AI image search and web fetch

### DIFF
--- a/src/features/workspaces/ai/ai-tool-registry.test.ts
+++ b/src/features/workspaces/ai/ai-tool-registry.test.ts
@@ -12,6 +12,10 @@ describe("AI tool registry", () => {
 			model: { access: "read", codemode: true },
 			ui: { icon: "code", visibility: "visible" },
 		});
+		expect(AI_TOOL_REGISTRY.web_fetch).toMatchObject({
+			model: { access: "read", codemode: false },
+			ui: { icon: "web", visibility: "visible" },
+		});
 	});
 
 	it("exposes mutations to Code Mode so replays resolve against the durable log", () => {

--- a/src/features/workspaces/ai/ai-tool-registry.ts
+++ b/src/features/workspaces/ai/ai-tool-registry.ts
@@ -49,7 +49,6 @@ export const AI_TOOL_REGISTRY = defineAiToolRegistry({
 	compute: readTool({ icon: "code", title: "Run Python" }),
 	web_search: readTool({ icon: "search", title: "Search web" }),
 	web_fetch: readTool({ icon: "web", title: "Read URL" }, false),
-	web_links: readTool({ icon: "web", title: "Find links" }),
 	research_discover: readTool({
 		icon: "search",
 		title: "Discover research",

--- a/src/features/workspaces/ai/ai-tool-registry.ts
+++ b/src/features/workspaces/ai/ai-tool-registry.ts
@@ -48,7 +48,7 @@ export const AI_TOOL_REGISTRY = defineAiToolRegistry({
 	browser_handoff: readTool({ icon: "web", title: "Browser handoff", visibility: "hidden" }),
 	compute: readTool({ icon: "code", title: "Run Python" }),
 	web_search: readTool({ icon: "search", title: "Search web" }),
-	web_markdown: readTool({ icon: "web", title: "Read webpage" }),
+	web_fetch: readTool({ icon: "web", title: "Read URL" }, false),
 	web_links: readTool({ icon: "web", title: "Find links" }),
 	research_discover: readTool({
 		icon: "search",

--- a/src/features/workspaces/ai/web-access-policy.test.ts
+++ b/src/features/workspaces/ai/web-access-policy.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { assertPublicHttpUrl } from "#/features/workspaces/ai/web-access-policy";
+import {
+	assertPublicHttpUrl,
+	parsePublicHttpUrl,
+} from "#/features/workspaces/ai/web-access-policy";
 
 describe("web access policy", () => {
 	it("accepts public HTTP URLs and strips fragments", () => {
@@ -22,5 +25,15 @@ describe("web access policy", () => {
 		expect(() => assertPublicHttpUrl("https://127.0.0.1")).toThrow(
 			"Only public domain-name URLs are supported.",
 		);
+	});
+
+	it("parses untrusted public URLs without throwing", () => {
+		expect(parsePublicHttpUrl(" https://Example.com/image.png#fragment ")?.toString()).toBe(
+			"https://example.com/image.png",
+		);
+		expect(parsePublicHttpUrl("data:image/png;base64,abc")).toBeNull();
+		expect(parsePublicHttpUrl("http://127.0.0.1/image.png")).toBeNull();
+		expect(parsePublicHttpUrl("not a URL")).toBeNull();
+		expect(parsePublicHttpUrl(null)).toBeNull();
 	});
 });

--- a/src/features/workspaces/ai/web-access-policy.ts
+++ b/src/features/workspaces/ai/web-access-policy.ts
@@ -26,6 +26,16 @@ export function assertPublicHttpUrl(input: string) {
 	return url;
 }
 
+export function parsePublicHttpUrl(input: unknown) {
+	if (typeof input !== "string" || !input.trim()) return null;
+
+	try {
+		return assertPublicHttpUrl(input.trim());
+	} catch {
+		return null;
+	}
+}
+
 function normalizeHostname(hostname: string) {
 	return hostname.toLowerCase().replace(/^\[/, "").replace(/\]$/, "").replace(/\.$/, "");
 }

--- a/src/features/workspaces/ai/web-fetch.ts
+++ b/src/features/workspaces/ai/web-fetch.ts
@@ -18,19 +18,19 @@ const supportedImageMediaTypes: ReadonlySet<string> = new Set(
 export const webFetchOutputSchema = z.discriminatedUnion("kind", [
 	z.object({
 		kind: z.literal("page"),
-		url: z.string().url(),
+		url: z.url(),
 		content: z.string(),
 		truncated: z.boolean(),
 	}),
 	z.object({
 		kind: z.literal("image"),
-		url: z.string().url(),
+		url: z.url(),
 		mediaType: z.literal("image/jpeg"),
 		sizeBytes: z.number().int().positive(),
 	}),
 	z.object({
 		kind: z.literal("unsupported"),
-		url: z.string().url(),
+		url: z.url(),
 		mediaType: z.string().nullable(),
 		reason: z.enum(["pdf", "media_type"]),
 		message: z.string(),
@@ -48,14 +48,21 @@ export async function fetchPublicWebResource(input: {
 	abortSignal?: AbortSignal;
 	browser: QuickActionBinding;
 	env: Cloudflare.Env;
+	kind: "page" | "image";
 	url: string;
 }): Promise<{ image?: FreshWebImage; output: WebFetchOutput }> {
-	const { response, url } = await fetchFollowingPublicRedirects(input.url, input.abortSignal);
-	const mediaType = normalizeMediaType(response.headers.get("content-type"));
+	const requestedUrl = assertPublicHttpUrl(input.url);
+	if (input.kind === "page") {
+		if (requestedUrl.pathname.toLowerCase().endsWith(".pdf")) {
+			return unsupportedPdf(requestedUrl.toString());
+		}
 
-	if (mediaType === "text/html" || mediaType === "application/xhtml+xml") {
-		await response.body?.cancel();
-		const content = await browserMarkdown(input.browser, { url });
+		input.abortSignal?.throwIfAborted();
+		const url = requestedUrl.toString();
+		const content = await browserMarkdown(input.browser, {
+			url,
+			gotoOptions: { timeout: WEB_FETCH_TIMEOUT_MS },
+		});
 		return {
 			output: {
 				kind: "page",
@@ -66,18 +73,15 @@ export async function fetchPublicWebResource(input: {
 		};
 	}
 
+	const { response, url } = await fetchImageFollowingPublicRedirects(
+		requestedUrl,
+		input.abortSignal,
+	);
+	const mediaType = normalizeMediaType(response.headers.get("content-type"));
+
 	if (mediaType === "application/pdf") {
 		await response.body?.cancel();
-		return {
-			output: {
-				kind: "unsupported",
-				url,
-				mediaType,
-				reason: "pdf",
-				message:
-					"Public PDFs are not supported here. Ask the user to upload the PDF to the workspace, then read it with workspace_read_items.",
-			},
-		};
+		return unsupportedPdf(url, mediaType);
 	}
 
 	if (!mediaType || !supportedImageMediaTypes.has(mediaType)) {
@@ -98,10 +102,7 @@ export async function fetchPublicWebResource(input: {
 	if (!response.body) {
 		throw new Error("The image response did not include a body.");
 	}
-	assertContentLengthWithinLimit(
-		response.headers.get("content-length"),
-		WORKSPACE_AI_CHAT_ATTACHMENT_POLICY.maxFileSize,
-	);
+	await assertContentLengthWithinLimit(response, WORKSPACE_AI_CHAT_ATTACHMENT_POLICY.maxFileSize);
 	const normalized = await normalizeChatImageToJpeg(
 		input.env,
 		limitReadableStream(response.body, WORKSPACE_AI_CHAT_ATTACHMENT_POLICY.maxFileSize),
@@ -119,15 +120,15 @@ export async function fetchPublicWebResource(input: {
 	};
 }
 
-async function fetchFollowingPublicRedirects(input: string, abortSignal?: AbortSignal) {
-	let url = assertPublicHttpUrl(input);
+async function fetchImageFollowingPublicRedirects(input: URL, abortSignal?: AbortSignal) {
+	let url = input;
 	const signal = abortSignal
 		? AbortSignal.any([abortSignal, AbortSignal.timeout(WEB_FETCH_TIMEOUT_MS)])
 		: AbortSignal.timeout(WEB_FETCH_TIMEOUT_MS);
 
 	for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects += 1) {
 		const response = await fetch(url, {
-			headers: { Accept: "text/html,image/*;q=0.9,*/*;q=0.1" },
+			headers: { Accept: "image/*,*/*;q=0.1" },
 			redirect: "manual",
 			signal,
 		});
@@ -154,12 +155,27 @@ function normalizeMediaType(value: string | null) {
 	return value?.split(";", 1)[0]?.trim().toLowerCase() || null;
 }
 
-function assertContentLengthWithinLimit(value: string | null, maxBytes: number) {
+async function assertContentLengthWithinLimit(response: Response, maxBytes: number) {
+	const value = response.headers.get("content-length");
 	if (value === null) return;
 	const size = Number(value);
 	if (Number.isSafeInteger(size) && size > maxBytes) {
+		await response.body?.cancel();
 		throw new Error(`The image exceeds the ${maxBytes}-byte input limit.`);
 	}
+}
+
+function unsupportedPdf(url: string, mediaType: string | null = "application/pdf") {
+	return {
+		output: {
+			kind: "unsupported" as const,
+			url,
+			mediaType,
+			reason: "pdf" as const,
+			message:
+				"Public PDFs are not supported here. Ask the user to upload the PDF to the workspace, then read it with workspace_read_items.",
+		},
+	};
 }
 
 function limitReadableStream(body: ReadableStream<Uint8Array>, maxBytes: number) {

--- a/src/features/workspaces/ai/web-fetch.ts
+++ b/src/features/workspaces/ai/web-fetch.ts
@@ -1,10 +1,10 @@
-import { browserMarkdown, type QuickActionBinding } from "@cloudflare/think/tools/browser";
 import { z } from "zod";
 
 import { WORKSPACE_AI_CHAT_ATTACHMENT_POLICY } from "#/features/workspaces/ai/chat-attachment-policy";
 import { assertPublicHttpUrl } from "#/features/workspaces/ai/web-access-policy";
 import { normalizeChatImageToJpeg } from "#/features/workspaces/conversion/image-normalizer";
 import { workspaceFileUploadFormats } from "#/features/workspaces/model/workspace-file/policy";
+import { scrapePublicWebPage } from "#/integrations/firecrawl/scrape";
 
 const MAX_PAGE_CHARACTERS = 100_000;
 const MAX_REDIRECTS = 5;
@@ -46,7 +46,6 @@ export interface FreshWebImage {
 
 export async function fetchPublicWebResource(input: {
 	abortSignal?: AbortSignal;
-	browser: QuickActionBinding;
 	env: Cloudflare.Env;
 	kind: "page" | "image";
 	url: string;
@@ -57,11 +56,11 @@ export async function fetchPublicWebResource(input: {
 			return unsupportedPdf(requestedUrl.toString());
 		}
 
-		input.abortSignal?.throwIfAborted();
 		const url = requestedUrl.toString();
-		const content = await browserMarkdown(input.browser, {
+		const content = await scrapePublicWebPage({
+			abortSignal: input.abortSignal,
+			env: input.env,
 			url,
-			gotoOptions: { timeout: WEB_FETCH_TIMEOUT_MS },
 		});
 		return {
 			output: {

--- a/src/features/workspaces/ai/web-fetch.ts
+++ b/src/features/workspaces/ai/web-fetch.ts
@@ -1,0 +1,188 @@
+import { browserMarkdown, type QuickActionBinding } from "@cloudflare/think/tools/browser";
+import { z } from "zod";
+
+import { WORKSPACE_AI_CHAT_ATTACHMENT_POLICY } from "#/features/workspaces/ai/chat-attachment-policy";
+import { assertPublicHttpUrl } from "#/features/workspaces/ai/web-access-policy";
+import { normalizeChatImageToJpeg } from "#/features/workspaces/conversion/image-normalizer";
+import { workspaceFileUploadFormats } from "#/features/workspaces/model/workspace-file/policy";
+
+const MAX_PAGE_CHARACTERS = 100_000;
+const MAX_REDIRECTS = 5;
+const WEB_FETCH_TIMEOUT_MS = 20_000;
+const supportedImageMediaTypes: ReadonlySet<string> = new Set(
+	workspaceFileUploadFormats
+		.filter((format) => format.assetKind === "image")
+		.map((format) => format.mime),
+);
+
+export const webFetchOutputSchema = z.discriminatedUnion("kind", [
+	z.object({
+		kind: z.literal("page"),
+		url: z.string().url(),
+		content: z.string(),
+		truncated: z.boolean(),
+	}),
+	z.object({
+		kind: z.literal("image"),
+		url: z.string().url(),
+		mediaType: z.literal("image/jpeg"),
+		sizeBytes: z.number().int().positive(),
+	}),
+	z.object({
+		kind: z.literal("unsupported"),
+		url: z.string().url(),
+		mediaType: z.string().nullable(),
+		reason: z.enum(["pdf", "media_type"]),
+		message: z.string(),
+	}),
+]);
+
+export type WebFetchOutput = z.output<typeof webFetchOutputSchema>;
+
+export interface FreshWebImage {
+	bytes: ArrayBuffer;
+	mediaType: "image/jpeg";
+}
+
+export async function fetchPublicWebResource(input: {
+	abortSignal?: AbortSignal;
+	browser: QuickActionBinding;
+	env: Cloudflare.Env;
+	url: string;
+}): Promise<{ image?: FreshWebImage; output: WebFetchOutput }> {
+	const { response, url } = await fetchFollowingPublicRedirects(input.url, input.abortSignal);
+	const mediaType = normalizeMediaType(response.headers.get("content-type"));
+
+	if (mediaType === "text/html" || mediaType === "application/xhtml+xml") {
+		await response.body?.cancel();
+		const content = await browserMarkdown(input.browser, { url });
+		return {
+			output: {
+				kind: "page",
+				url,
+				content: content.slice(0, MAX_PAGE_CHARACTERS),
+				truncated: content.length > MAX_PAGE_CHARACTERS,
+			},
+		};
+	}
+
+	if (mediaType === "application/pdf") {
+		await response.body?.cancel();
+		return {
+			output: {
+				kind: "unsupported",
+				url,
+				mediaType,
+				reason: "pdf",
+				message:
+					"Public PDFs are not supported here. Ask the user to upload the PDF to the workspace, then read it with workspace_read_items.",
+			},
+		};
+	}
+
+	if (!mediaType || !supportedImageMediaTypes.has(mediaType)) {
+		await response.body?.cancel();
+		return {
+			output: {
+				kind: "unsupported",
+				url,
+				mediaType,
+				reason: "media_type",
+				message: mediaType
+					? `This URL returned unsupported content type ${mediaType}.`
+					: "This URL did not return a supported content type.",
+			},
+		};
+	}
+
+	if (!response.body) {
+		throw new Error("The image response did not include a body.");
+	}
+	assertContentLengthWithinLimit(
+		response.headers.get("content-length"),
+		WORKSPACE_AI_CHAT_ATTACHMENT_POLICY.maxFileSize,
+	);
+	const normalized = await normalizeChatImageToJpeg(
+		input.env,
+		limitReadableStream(response.body, WORKSPACE_AI_CHAT_ATTACHMENT_POLICY.maxFileSize),
+		WORKSPACE_AI_CHAT_ATTACHMENT_POLICY.maxNormalizedFileSize,
+	);
+
+	return {
+		image: { bytes: normalized.bytes, mediaType: normalized.contentType },
+		output: {
+			kind: "image",
+			url,
+			mediaType: normalized.contentType,
+			sizeBytes: normalized.sizeBytes,
+		},
+	};
+}
+
+async function fetchFollowingPublicRedirects(input: string, abortSignal?: AbortSignal) {
+	let url = assertPublicHttpUrl(input);
+	const signal = abortSignal
+		? AbortSignal.any([abortSignal, AbortSignal.timeout(WEB_FETCH_TIMEOUT_MS)])
+		: AbortSignal.timeout(WEB_FETCH_TIMEOUT_MS);
+
+	for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects += 1) {
+		const response = await fetch(url, {
+			headers: { Accept: "text/html,image/*;q=0.9,*/*;q=0.1" },
+			redirect: "manual",
+			signal,
+		});
+		if (response.status >= 300 && response.status < 400) {
+			const location = response.headers.get("location");
+			await response.body?.cancel();
+			if (!location) throw new Error("The URL redirected without a destination.");
+			if (redirects === MAX_REDIRECTS) throw new Error("The URL redirected too many times.");
+			url = assertPublicHttpUrl(new URL(location, url).toString());
+			continue;
+		}
+		if (!response.ok) {
+			await response.body?.cancel();
+			throw new Error(`The URL returned HTTP ${response.status}.`);
+		}
+
+		return { response, url: url.toString() };
+	}
+
+	throw new Error("The URL redirected too many times.");
+}
+
+function normalizeMediaType(value: string | null) {
+	return value?.split(";", 1)[0]?.trim().toLowerCase() || null;
+}
+
+function assertContentLengthWithinLimit(value: string | null, maxBytes: number) {
+	if (value === null) return;
+	const size = Number(value);
+	if (Number.isSafeInteger(size) && size > maxBytes) {
+		throw new Error(`The image exceeds the ${maxBytes}-byte input limit.`);
+	}
+}
+
+function limitReadableStream(body: ReadableStream<Uint8Array>, maxBytes: number) {
+	const reader = body.getReader();
+	let totalBytes = 0;
+
+	return new ReadableStream<Uint8Array>({
+		async pull(controller) {
+			const { done, value } = await reader.read();
+			if (done) {
+				controller.close();
+				return;
+			}
+			totalBytes += value.byteLength;
+			if (totalBytes > maxBytes) {
+				await reader.cancel("Image input exceeds the byte limit.");
+				controller.error(new Error(`The image exceeds the ${maxBytes}-byte input limit.`));
+				return;
+			}
+			controller.enqueue(value);
+		},
+		cancel(reason) {
+			return reader.cancel(reason);
+		},
+	});
+}

--- a/src/features/workspaces/ai/web-tools.ts
+++ b/src/features/workspaces/ai/web-tools.ts
@@ -43,6 +43,11 @@ const webSearchInputSchema = z.object({
 const publicUrlInputSchema = z.object({
 	url: z.string().trim().min(1).describe("Public HTTP(S) webpage or image URL to fetch."),
 });
+const webFetchInputSchema = publicUrlInputSchema.extend({
+	kind: z
+		.enum(["page", "image"])
+		.describe("Use page for rendered webpage text or image to inspect the image pixels."),
+});
 const webLinksOutputSchema = z.object({
 	items: z.array(z.string()),
 	truncated: z.boolean(),
@@ -94,6 +99,11 @@ const browserPageInputExamples = [
 	},
 ];
 
+const webFetchInputExamples = [
+	{ input: { kind: "page" as const, url: "https://example.com" } },
+	{ input: { kind: "image" as const, url: "https://example.com/image.png" } },
+];
+
 export function createAIThreadWebTools(env: Cloudflare.Env): ToolSet {
 	const browser: QuickActionBinding = env.BROWSER;
 	const freshImages = new Map<string, FreshWebImage>();
@@ -117,9 +127,9 @@ export function createAIThreadWebTools(env: Cloudflare.Env): ToolSet {
 		}),
 		web_fetch: defineAIThreadTool({
 			description:
-				"Fetch a public webpage or image URL. Webpages return rendered Markdown. Images are attached temporarily for this model step so you can inspect them. Public PDFs are unsupported; ask the user to upload those to the workspace.",
-			inputSchema: publicUrlInputSchema,
-			inputExamples: browserPageInputExamples,
+				"Fetch a public webpage or image URL. Set kind to page for rendered Markdown or image to attach its pixels temporarily for this model step. Public PDFs are unsupported; ask the user to upload those to the workspace.",
+			inputSchema: webFetchInputSchema,
+			inputExamples: webFetchInputExamples,
 			outputSchema: webFetchOutputSchema,
 			toModelOutput: ({ output, toolCallId }) => {
 				const image = freshImages.get(toolCallId);
@@ -140,11 +150,12 @@ export function createAIThreadWebTools(env: Cloudflare.Env): ToolSet {
 					],
 				};
 			},
-			execute: async ({ url }, context) => {
+			execute: async ({ kind, url }, context) => {
 				const result = await fetchPublicWebResource({
 					abortSignal: context.abortSignal,
 					browser,
 					env,
+					kind,
 					url,
 				});
 				if (context.source === "direct" && result.image) {

--- a/src/features/workspaces/ai/web-tools.ts
+++ b/src/features/workspaces/ai/web-tools.ts
@@ -1,11 +1,12 @@
-import {
-	browserLinks,
-	browserMarkdown,
-	type QuickActionBinding,
-} from "@cloudflare/think/tools/browser";
-import type { ToolSet } from "ai";
+import { browserLinks, type QuickActionBinding } from "@cloudflare/think/tools/browser";
+import type { JSONValue, ToolSet } from "ai";
 import { z } from "zod";
 import { defineAIThreadTool } from "#/features/workspaces/ai/ai-thread-tool";
+import {
+	fetchPublicWebResource,
+	type FreshWebImage,
+	webFetchOutputSchema,
+} from "#/features/workspaces/ai/web-fetch";
 import {
 	publicWebSearchResultSchema,
 	searchPublicWeb,
@@ -30,21 +31,17 @@ const webSearchInputSchema = z.object({
 	source: z
 		.enum(webSearchSourceValues)
 		.optional()
-		.describe("Use news for current events. Defaults to web."),
+		.describe("Use news for current events or images for an image gallery. Defaults to web."),
 	category: z
 		.enum(webSearchCategoryValues)
 		.optional()
 		.describe(
-			"Restrict to PDFs, GitHub, academic sites, or developer docs and issues. Use research_discover for papers.",
+			"Restrict to PDFs, GitHub, academic sites, or developer docs and issues. Cannot be combined with source images. Use research_discover for papers.",
 		),
 });
 
-const browserPageInputSchema = z.object({
-	url: z.string().trim().min(1).describe("Public HTTP(S) URL to load in Cloudflare Browser Run."),
-});
-const webMarkdownOutputSchema = z.object({
-	content: z.string(),
-	truncated: z.boolean(),
+const publicUrlInputSchema = z.object({
+	url: z.string().trim().min(1).describe("Public HTTP(S) webpage or image URL to fetch."),
 });
 const webLinksOutputSchema = z.object({
 	items: z.array(z.string()),
@@ -71,6 +68,12 @@ const webSearchInputExamples: Array<{ input: z.infer<typeof webSearchInputSchema
 	},
 	{
 		input: {
+			query: "labeled mitochondrion diagram",
+			source: "images",
+		},
+	},
+	{
+		input: {
 			query: "transformer architecture survey",
 			category: "pdf",
 		},
@@ -93,11 +96,12 @@ const browserPageInputExamples = [
 
 export function createAIThreadWebTools(env: Cloudflare.Env): ToolSet {
 	const browser: QuickActionBinding = env.BROWSER;
+	const freshImages = new Map<string, FreshWebImage>();
 
 	return {
 		web_search: defineAIThreadTool({
 			description:
-				"Find relevant public web pages for a topic or question. Snippets are query-relevant passages.",
+				"Find relevant public webpages, news, or images for a topic or question. Image searches render a gallery; call web_fetch with an imageUrl only when you need to inspect its pixels.",
 			inputSchema: webSearchInputSchema,
 			inputExamples: webSearchInputExamples,
 			outputSchema: publicWebSearchResultSchema,
@@ -111,23 +115,48 @@ export function createAIThreadWebTools(env: Cloudflare.Env): ToolSet {
 					category,
 				}),
 		}),
-		web_markdown: defineAIThreadTool({
-			description: "Load a public webpage and return its rendered content as Markdown.",
-			inputSchema: browserPageInputSchema,
+		web_fetch: defineAIThreadTool({
+			description:
+				"Fetch a public webpage or image URL. Webpages return rendered Markdown. Images are attached temporarily for this model step so you can inspect them. Public PDFs are unsupported; ask the user to upload those to the workspace.",
+			inputSchema: publicUrlInputSchema,
 			inputExamples: browserPageInputExamples,
-			outputSchema: webMarkdownOutputSchema,
-			execute: async ({ url }) => {
-				const safeUrl = assertPublicHttpUrl(url);
-				return truncateMarkdown(
-					await browserMarkdown(browser, {
-						url: safeUrl.toString(),
-					}),
-				);
+			outputSchema: webFetchOutputSchema,
+			toModelOutput: ({ output, toolCallId }) => {
+				const image = freshImages.get(toolCallId);
+				freshImages.delete(toolCallId);
+				if (!image) {
+					return { type: "json" as const, value: output as JSONValue };
+				}
+
+				return {
+					type: "content" as const,
+					value: [
+						{ type: "text" as const, text: JSON.stringify(output) },
+						{
+							type: "file" as const,
+							mediaType: image.mediaType,
+							data: { type: "data" as const, data: new Uint8Array(image.bytes) },
+						},
+					],
+				};
+			},
+			execute: async ({ url }, context) => {
+				const result = await fetchPublicWebResource({
+					abortSignal: context.abortSignal,
+					browser,
+					env,
+					url,
+				});
+				if (context.source === "direct" && result.image) {
+					freshImages.set(context.invocationId, result.image);
+				}
+
+				return result.output;
 			},
 		}),
 		web_links: defineAIThreadTool({
 			description: "Load a public webpage and return its rendered links.",
-			inputSchema: browserPageInputSchema,
+			inputSchema: publicUrlInputSchema,
 			inputExamples: browserPageInputExamples,
 			outputSchema: webLinksOutputSchema,
 			execute: async ({ url }) => {
@@ -139,20 +168,6 @@ export function createAIThreadWebTools(env: Cloudflare.Env): ToolSet {
 				);
 			},
 		}),
-	};
-}
-
-function truncateMarkdown(content: string) {
-	if (content.length <= MAX_BROWSER_RESULT_CHARS) {
-		return {
-			content,
-			truncated: false,
-		};
-	}
-
-	return {
-		content: content.slice(0, MAX_BROWSER_RESULT_CHARS),
-		truncated: true,
 	};
 }
 

--- a/src/features/workspaces/ai/web-tools.ts
+++ b/src/features/workspaces/ai/web-tools.ts
@@ -1,4 +1,3 @@
-import { browserLinks, type QuickActionBinding } from "@cloudflare/think/tools/browser";
 import type { JSONValue, ToolSet } from "ai";
 import { z } from "zod";
 import { defineAIThreadTool } from "#/features/workspaces/ai/ai-thread-tool";
@@ -14,9 +13,6 @@ import {
 	webSearchFreshnessValues,
 	webSearchSourceValues,
 } from "#/integrations/firecrawl/search";
-import { assertPublicHttpUrl } from "#/features/workspaces/ai/web-access-policy";
-
-const MAX_BROWSER_RESULT_CHARS = 100_000;
 const webSearchInputSchema = z.object({
 	query: z.string().trim().min(1).describe("Topic or question to search for."),
 	include_domains: z
@@ -48,11 +44,6 @@ const webFetchInputSchema = publicUrlInputSchema.extend({
 		.enum(["page", "image"])
 		.describe("Use page for rendered webpage text or image to inspect the image pixels."),
 });
-const webLinksOutputSchema = z.object({
-	items: z.array(z.string()),
-	truncated: z.boolean(),
-});
-
 const webSearchInputExamples: Array<{ input: z.infer<typeof webSearchInputSchema> }> = [
 	{
 		input: {
@@ -91,21 +82,12 @@ const webSearchInputExamples: Array<{ input: z.infer<typeof webSearchInputSchema
 	},
 ];
 
-const browserPageInputExamples = [
-	{
-		input: {
-			url: "https://example.com",
-		},
-	},
-];
-
 const webFetchInputExamples = [
 	{ input: { kind: "page" as const, url: "https://example.com" } },
 	{ input: { kind: "image" as const, url: "https://example.com/image.png" } },
 ];
 
 export function createAIThreadWebTools(env: Cloudflare.Env): ToolSet {
-	const browser: QuickActionBinding = env.BROWSER;
 	const freshImages = new Map<string, FreshWebImage>();
 
 	return {
@@ -153,7 +135,6 @@ export function createAIThreadWebTools(env: Cloudflare.Env): ToolSet {
 			execute: async ({ kind, url }, context) => {
 				const result = await fetchPublicWebResource({
 					abortSignal: context.abortSignal,
-					browser,
 					env,
 					kind,
 					url,
@@ -165,42 +146,5 @@ export function createAIThreadWebTools(env: Cloudflare.Env): ToolSet {
 				return result.output;
 			},
 		}),
-		web_links: defineAIThreadTool({
-			description: "Load a public webpage and return its rendered links.",
-			inputSchema: publicUrlInputSchema,
-			inputExamples: browserPageInputExamples,
-			outputSchema: webLinksOutputSchema,
-			execute: async ({ url }) => {
-				const safeUrl = assertPublicHttpUrl(url);
-				return truncateLinks(
-					await browserLinks(browser, {
-						url: safeUrl.toString(),
-					}),
-				);
-			},
-		}),
-	};
-}
-
-function truncateLinks(items: string[]) {
-	const result: string[] = [];
-	let size = 2;
-	let truncated = false;
-
-	for (const item of items) {
-		const itemSize = JSON.stringify(item).length + (result.length === 0 ? 0 : 1);
-
-		if (size + itemSize > MAX_BROWSER_RESULT_CHARS) {
-			truncated = true;
-			break;
-		}
-
-		result.push(item);
-		size += itemSize;
-	}
-
-	return {
-		items: truncated ? result : items,
-		truncated,
 	};
 }

--- a/src/features/workspaces/ai/web-tools.worker.test.ts
+++ b/src/features/workspaces/ai/web-tools.worker.test.ts
@@ -79,13 +79,10 @@ describe("web_fetch", () => {
 		});
 	});
 
-	it("renders pages without probing them through fetch first", async () => {
-		const fetchSpy = vi.fn();
+	it("scrapes pages once through Firecrawl", async () => {
+		const fetchSpy = vi.fn(async () => Response.json({ data: { markdown: "# Rendered page" } }));
 		vi.stubGlobal("fetch", fetchSpy);
-		const quickAction = vi.fn(async () => Response.json({ result: "# Rendered page" }));
-		const tool = createAIThreadWebTools(
-			createEnv(createImagesBinding().binding, { quickAction }),
-		).web_fetch;
+		const tool = createAIThreadWebTools(createEnv(createImagesBinding().binding)).web_fetch;
 		if (!tool?.execute) throw new Error("Expected executable web_fetch");
 
 		await expect(
@@ -96,11 +93,18 @@ describe("web_fetch", () => {
 			content: "# Rendered page",
 			truncated: false,
 		});
-		expect(quickAction).toHaveBeenCalledWith("markdown", {
-			url: "https://example.com/",
-			gotoOptions: { timeout: 20_000 },
+		expect(fetchSpy).toHaveBeenCalledOnce();
+		expect(fetchSpy).toHaveBeenCalledWith(new URL("https://api.firecrawl.dev/v2/scrape"), {
+			method: "POST",
+			headers: expect.any(Headers),
+			body: JSON.stringify({
+				url: "https://example.com/",
+				formats: ["markdown"],
+				onlyMainContent: true,
+				timeout: 20_000,
+			}),
+			signal: expect.any(AbortSignal),
 		});
-		expect(fetchSpy).not.toHaveBeenCalled();
 	});
 
 	it("cancels an image response rejected by its content length", async () => {
@@ -154,9 +158,9 @@ function createImagesBinding(output = new Uint8Array([1])) {
 	};
 }
 
-function createEnv(images: ImagesBinding, browser: Partial<Cloudflare.Env["BROWSER"]> = {}) {
+function createEnv(images: ImagesBinding) {
 	return {
-		BROWSER: browser as Cloudflare.Env["BROWSER"],
+		BROWSER: {} as Cloudflare.Env["BROWSER"],
 		IMAGES: images,
 	} as Cloudflare.Env;
 }

--- a/src/features/workspaces/ai/web-tools.worker.test.ts
+++ b/src/features/workspaces/ai/web-tools.worker.test.ts
@@ -1,0 +1,103 @@
+import type { ToolExecutionOptions } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createAIThreadWebTools } from "#/features/workspaces/ai/web-tools";
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("web_fetch", () => {
+	it("sends fetched image bytes to the model once without persisting them in output", async () => {
+		const images = createImagesBinding(new Uint8Array([9, 8, 7]));
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(new Uint8Array([1, 2, 3]), {
+						headers: { "content-length": "3", "content-type": "image/png" },
+					}),
+			),
+		);
+		const tool = createAIThreadWebTools(createEnv(images.binding)).web_fetch;
+		if (!tool?.execute || !tool.toModelOutput) throw new Error("Expected executable web_fetch");
+		const options = directOptions("image-call");
+
+		const output = await tool.execute({ url: "https://cdn.example/image.png" }, options);
+		expect(output).toEqual({
+			kind: "image",
+			url: "https://cdn.example/image.png",
+			mediaType: "image/jpeg",
+			sizeBytes: 3,
+		});
+		expect(JSON.stringify(output)).not.toContain("9,8,7");
+
+		const freshModelOutput = await tool.toModelOutput({
+			input: { url: "https://cdn.example/image.png" },
+			output,
+			toolCallId: "image-call",
+		});
+		expect(freshModelOutput).toMatchObject({
+			type: "content",
+			value: [{ type: "text" }, { type: "file", mediaType: "image/jpeg", data: { type: "data" } }],
+		});
+
+		expect(
+			tool.toModelOutput({
+				input: { url: "https://cdn.example/image.png" },
+				output,
+				toolCallId: "image-call",
+			}),
+		).toEqual({ type: "json", value: output });
+	});
+
+	it("directs public PDFs to the existing workspace upload flow", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(new Uint8Array([1]), {
+						headers: { "content-type": "application/pdf" },
+					}),
+			),
+		);
+		const tool = createAIThreadWebTools(createEnv(createImagesBinding().binding)).web_fetch;
+		if (!tool?.execute) throw new Error("Expected executable web_fetch");
+
+		await expect(
+			tool.execute({ url: "https://example.com/paper.pdf" }, directOptions("pdf-call")),
+		).resolves.toMatchObject({
+			kind: "unsupported",
+			reason: "pdf",
+			message: expect.stringContaining("upload the PDF to the workspace"),
+		});
+	});
+});
+
+function directOptions(toolCallId: string): ToolExecutionOptions<unknown> {
+	return {
+		abortSignal: new AbortController().signal,
+		context: {},
+		messages: [],
+		toolCallId,
+	};
+}
+
+function createImagesBinding(output = new Uint8Array([1])) {
+	const image = vi.fn(() => new Response(output).body!);
+	const transformOutput = vi.fn(async () => ({ image }));
+	const transform = vi.fn(() => ({ output: transformOutput }));
+	const input = vi.fn(() => ({ output: transformOutput, transform }));
+
+	return {
+		binding: { input } as unknown as ImagesBinding,
+		input,
+	};
+}
+
+function createEnv(images: ImagesBinding) {
+	return {
+		BROWSER: {} as Cloudflare.Env["BROWSER"],
+		IMAGES: images,
+	} as Cloudflare.Env;
+}

--- a/src/features/workspaces/ai/web-tools.worker.test.ts
+++ b/src/features/workspaces/ai/web-tools.worker.test.ts
@@ -80,7 +80,7 @@ describe("web_fetch", () => {
 	});
 
 	it("scrapes pages once through Firecrawl", async () => {
-		const fetchSpy = vi.fn(async () => Response.json({ data: { markdown: "" } }));
+		const fetchSpy = vi.fn(async () => Response.json({ data: { markdown: "# Rendered page" } }));
 		vi.stubGlobal("fetch", fetchSpy);
 		const tool = createAIThreadWebTools(createEnv(createImagesBinding().binding)).web_fetch;
 		if (!tool?.execute) throw new Error("Expected executable web_fetch");
@@ -90,7 +90,7 @@ describe("web_fetch", () => {
 		).resolves.toEqual({
 			kind: "page",
 			url: "https://example.com/",
-			content: "",
+			content: "# Rendered page",
 			truncated: false,
 		});
 		expect(fetchSpy).toHaveBeenCalledOnce();
@@ -105,6 +105,19 @@ describe("web_fetch", () => {
 			}),
 			signal: expect.any(AbortSignal),
 		});
+	});
+
+	it("accepts a successful page scrape with empty Markdown", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => Response.json({ data: { markdown: "" } })),
+		);
+		const tool = createAIThreadWebTools(createEnv(createImagesBinding().binding)).web_fetch;
+		if (!tool?.execute) throw new Error("Expected executable web_fetch");
+
+		await expect(
+			tool.execute({ kind: "page", url: "https://example.com" }, directOptions("empty-page-call")),
+		).resolves.toMatchObject({ kind: "page", content: "" });
 	});
 
 	it("cancels an image response rejected by its content length", async () => {

--- a/src/features/workspaces/ai/web-tools.worker.test.ts
+++ b/src/features/workspaces/ai/web-tools.worker.test.ts
@@ -80,7 +80,7 @@ describe("web_fetch", () => {
 	});
 
 	it("scrapes pages once through Firecrawl", async () => {
-		const fetchSpy = vi.fn(async () => Response.json({ data: { markdown: "# Rendered page" } }));
+		const fetchSpy = vi.fn(async () => Response.json({ data: { markdown: "" } }));
 		vi.stubGlobal("fetch", fetchSpy);
 		const tool = createAIThreadWebTools(createEnv(createImagesBinding().binding)).web_fetch;
 		if (!tool?.execute) throw new Error("Expected executable web_fetch");
@@ -90,7 +90,7 @@ describe("web_fetch", () => {
 		).resolves.toEqual({
 			kind: "page",
 			url: "https://example.com/",
-			content: "# Rendered page",
+			content: "",
 			truncated: false,
 		});
 		expect(fetchSpy).toHaveBeenCalledOnce();

--- a/src/features/workspaces/ai/web-tools.worker.test.ts
+++ b/src/features/workspaces/ai/web-tools.worker.test.ts
@@ -23,7 +23,10 @@ describe("web_fetch", () => {
 		if (!tool?.execute || !tool.toModelOutput) throw new Error("Expected executable web_fetch");
 		const options = directOptions("image-call");
 
-		const output = await tool.execute({ url: "https://cdn.example/image.png" }, options);
+		const output = await tool.execute(
+			{ kind: "image", url: "https://cdn.example/image.png" },
+			options,
+		);
 		expect(output).toEqual({
 			kind: "image",
 			url: "https://cdn.example/image.png",
@@ -33,7 +36,7 @@ describe("web_fetch", () => {
 		expect(JSON.stringify(output)).not.toContain("9,8,7");
 
 		const freshModelOutput = await tool.toModelOutput({
-			input: { url: "https://cdn.example/image.png" },
+			input: { kind: "image", url: "https://cdn.example/image.png" },
 			output,
 			toolCallId: "image-call",
 		});
@@ -44,7 +47,7 @@ describe("web_fetch", () => {
 
 		expect(
 			tool.toModelOutput({
-				input: { url: "https://cdn.example/image.png" },
+				input: { kind: "image", url: "https://cdn.example/image.png" },
 				output,
 				toolCallId: "image-call",
 			}),
@@ -65,12 +68,68 @@ describe("web_fetch", () => {
 		if (!tool?.execute) throw new Error("Expected executable web_fetch");
 
 		await expect(
-			tool.execute({ url: "https://example.com/paper.pdf" }, directOptions("pdf-call")),
+			tool.execute(
+				{ kind: "image", url: "https://example.com/paper.pdf" },
+				directOptions("pdf-call"),
+			),
 		).resolves.toMatchObject({
 			kind: "unsupported",
 			reason: "pdf",
 			message: expect.stringContaining("upload the PDF to the workspace"),
 		});
+	});
+
+	it("renders pages without probing them through fetch first", async () => {
+		const fetchSpy = vi.fn();
+		vi.stubGlobal("fetch", fetchSpy);
+		const quickAction = vi.fn(async () => Response.json({ result: "# Rendered page" }));
+		const tool = createAIThreadWebTools(
+			createEnv(createImagesBinding().binding, { quickAction }),
+		).web_fetch;
+		if (!tool?.execute) throw new Error("Expected executable web_fetch");
+
+		await expect(
+			tool.execute({ kind: "page", url: "https://example.com" }, directOptions("page-call")),
+		).resolves.toEqual({
+			kind: "page",
+			url: "https://example.com/",
+			content: "# Rendered page",
+			truncated: false,
+		});
+		expect(quickAction).toHaveBeenCalledWith("markdown", {
+			url: "https://example.com/",
+			gotoOptions: { timeout: 20_000 },
+		});
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("cancels an image response rejected by its content length", async () => {
+		const cancel = vi.fn();
+		const body = new ReadableStream<Uint8Array>({ cancel });
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(body, {
+						headers: {
+							"content-length": String(50 * 1024 * 1024),
+							"content-type": "image/png",
+						},
+					}),
+			),
+		);
+		const images = createImagesBinding();
+		const tool = createAIThreadWebTools(createEnv(images.binding)).web_fetch;
+		if (!tool?.execute) throw new Error("Expected executable web_fetch");
+
+		await expect(
+			tool.execute(
+				{ kind: "image", url: "https://cdn.example/huge.png" },
+				directOptions("large-image-call"),
+			),
+		).rejects.toThrow("image exceeds");
+		expect(cancel).toHaveBeenCalledOnce();
+		expect(images.input).not.toHaveBeenCalled();
 	});
 });
 
@@ -95,9 +154,9 @@ function createImagesBinding(output = new Uint8Array([1])) {
 	};
 }
 
-function createEnv(images: ImagesBinding) {
+function createEnv(images: ImagesBinding, browser: Partial<Cloudflare.Env["BROWSER"]> = {}) {
 	return {
-		BROWSER: {} as Cloudflare.Env["BROWSER"],
+		BROWSER: browser as Cloudflare.Env["BROWSER"],
 		IMAGES: images,
 	} as Cloudflare.Env;
 }

--- a/src/features/workspaces/components/ai-chat/AiChatImageSearchResults.test.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatImageSearchResults.test.tsx
@@ -35,4 +35,27 @@ describe("AI chat image search results", () => {
 		expect(html).not.toContain("1600 × 900");
 		expect(html).not.toContain("Ignored webpage");
 	});
+
+	it("does not render unsafe image or source URLs", () => {
+		const html = renderToStaticMarkup(
+			<AiChatImageSearchResults
+				output={{
+					results: [
+						{
+							type: "image",
+							url: "https://example.com/source",
+							imageUrl: "data:image/png;base64,abc",
+						},
+						{
+							type: "image",
+							url: "http://127.0.0.1/private",
+							imageUrl: "https://cdn.example/image.png",
+						},
+					],
+				}}
+			/>,
+		);
+
+		expect(html).toBe("");
+	});
 });

--- a/src/features/workspaces/components/ai-chat/AiChatImageSearchResults.test.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatImageSearchResults.test.tsx
@@ -1,0 +1,38 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { AiChatImageSearchResults } from "#/features/workspaces/components/ai-chat/AiChatImageSearchResults";
+
+describe("AI chat image search results", () => {
+	it("renders image results as linked gallery cards", () => {
+		const html = renderToStaticMarkup(
+			<AiChatImageSearchResults
+				output={{
+					results: [
+						{
+							type: "image",
+							title: "Mitochondrion diagram",
+							url: "https://example.com/biology",
+							imageUrl: "https://cdn.example/mitochondrion.png",
+							imageWidth: 1600,
+							imageHeight: 900,
+						},
+						{
+							type: "page",
+							title: "Ignored webpage",
+							url: "https://example.com/page",
+						},
+					],
+				}}
+			/>,
+		);
+
+		expect(html).toContain('href="https://example.com/biology"');
+		expect(html).toContain('src="https://cdn.example/mitochondrion.png"');
+		expect(html).toContain('aria-label="Mitochondrion diagram"');
+		expect(html).toContain('alt=""');
+		expect(html).not.toContain("line-clamp-1");
+		expect(html).not.toContain("1600 × 900");
+		expect(html).not.toContain("Ignored webpage");
+	});
+});

--- a/src/features/workspaces/components/ai-chat/AiChatImageSearchResults.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatImageSearchResults.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+
+import { asRecord } from "#/lib/record";
+
+const MAX_VISIBLE_IMAGES = 8;
+
+export function AiChatImageSearchResults({ output }: { output: unknown }) {
+	const images = getImageResults(output).slice(0, MAX_VISIBLE_IMAGES);
+	if (images.length === 0) return null;
+
+	return (
+		<div className="grid max-w-2xl grid-cols-2 gap-2 sm:grid-cols-3">
+			{images.map((image) => (
+				<ImageResultCard key={`${image.imageUrl}:${image.sourceUrl}`} image={image} />
+			))}
+		</div>
+	);
+}
+
+function ImageResultCard({ image }: { image: ReturnType<typeof getImageResults>[number] }) {
+	const [failed, setFailed] = useState(false);
+	if (failed) return null;
+
+	return (
+		<a
+			href={image.sourceUrl}
+			target="_blank"
+			rel="noreferrer"
+			aria-label={image.title ?? `Image from ${getHostname(image.sourceUrl)}`}
+			className="group/image aspect-[4/3] overflow-hidden rounded-lg border bg-muted outline-none transition-colors hover:border-foreground/25 focus-visible:ring-2 focus-visible:ring-ring"
+		>
+			<img
+				src={image.imageUrl}
+				alt=""
+				className="size-full object-cover transition-transform duration-200 group-hover/image:scale-[1.02]"
+				loading="lazy"
+				referrerPolicy="no-referrer"
+				onError={() => setFailed(true)}
+			/>
+		</a>
+	);
+}
+
+function getImageResults(output: unknown) {
+	const results = asRecord(output).results;
+	if (!Array.isArray(results)) return [];
+
+	return results.flatMap((item) => {
+		const record = asRecord(item);
+		const imageUrl = getString(record.imageUrl);
+		const sourceUrl = getString(record.url);
+		if (record.type !== "image" || !imageUrl || !sourceUrl) return [];
+
+		return [
+			{
+				imageUrl,
+				sourceUrl,
+				title: getString(record.title),
+			},
+		];
+	});
+}
+
+function getString(value: unknown) {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function getHostname(url: string) {
+	try {
+		return new URL(url).hostname.replace(/^www\./, "");
+	} catch {
+		return "Image";
+	}
+}

--- a/src/features/workspaces/components/ai-chat/AiChatImageSearchResults.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatImageSearchResults.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { parsePublicHttpUrl } from "#/features/workspaces/ai/web-access-policy";
 import { asRecord } from "#/lib/record";
 
 const MAX_VISIBLE_IMAGES = 8;
@@ -47,14 +48,14 @@ function getImageResults(output: unknown) {
 
 	return results.flatMap((item) => {
 		const record = asRecord(item);
-		const imageUrl = getString(record.imageUrl);
-		const sourceUrl = getString(record.url);
+		const imageUrl = parsePublicHttpUrl(record.imageUrl);
+		const sourceUrl = parsePublicHttpUrl(record.url);
 		if (record.type !== "image" || !imageUrl || !sourceUrl) return [];
 
 		return [
 			{
-				imageUrl,
-				sourceUrl,
+				imageUrl: imageUrl.toString(),
+				sourceUrl: sourceUrl.toString(),
 				title: getString(record.title),
 			},
 		];

--- a/src/features/workspaces/components/ai-chat/AiChatMessageRow.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatMessageRow.tsx
@@ -218,15 +218,19 @@ function AssistantMessageBody({
 	workspaceCitationLocations: ReturnType<typeof getWorkspaceCitationLocations>;
 }) {
 	if (display.kind === "content") {
-		return display.parts.map((part, index) => (
-			<AiChatMessagePartView
-				key={getMessagePartKey(message.id, part, index)}
-				interruptUnfinishedTools={display.interruptUnfinishedTools}
-				isStreaming={isStreaming}
-				part={part}
-				workspaceCitationLocations={workspaceCitationLocations}
-			/>
-		));
+		return (
+			<div data-slot="assistant-parts" className="flex flex-col gap-3">
+				{display.parts.map((part, index) => (
+					<AiChatMessagePartView
+						key={getMessagePartKey(message.id, part, index)}
+						interruptUnfinishedTools={display.interruptUnfinishedTools}
+						isStreaming={isStreaming}
+						part={part}
+						workspaceCitationLocations={workspaceCitationLocations}
+					/>
+				))}
+			</div>
+		);
 	}
 
 	if (display.kind === "empty-terminal") {

--- a/src/features/workspaces/components/ai-chat/AiChatMessageRow.worker.test.ts
+++ b/src/features/workspaces/components/ai-chat/AiChatMessageRow.worker.test.ts
@@ -1,0 +1,50 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import AiChatMessageRow from "#/features/workspaces/components/ai-chat/AiChatMessageRow";
+import type { AssistantRowDisplay } from "#/features/workspaces/components/ai-chat/ai-chat-display-state";
+import type { AiChatMessage } from "#/features/workspaces/components/ai-chat/types";
+
+describe("AI chat assistant part spacing", () => {
+	it("separates a completed tool result from the following response", () => {
+		const parts = [
+			{
+				type: "tool-web_search",
+				toolCallId: "search-1",
+				state: "output-available",
+				input: { query: "mountain landscape", source: "images" },
+				output: {
+					results: [
+						{
+							type: "image",
+							title: "Mountain landscape",
+							url: "https://example.com/mountain",
+							imageUrl: "https://cdn.example.com/mountain.jpg",
+						},
+					],
+				},
+			},
+			{ type: "text", text: "The image search tool works.", state: "done" },
+		] as AiChatMessage["parts"];
+		const message = { id: "assistant-1", role: "assistant", parts } as AiChatMessage;
+		const display: AssistantRowDisplay = {
+			kind: "content",
+			parts,
+			interruptUnfinishedTools: false,
+		};
+
+		const html = renderToStaticMarkup(
+			createElement(AiChatMessageRow, {
+				display,
+				isLatestAssistant: true,
+				isRegenerable: false,
+				isStreaming: false,
+				message,
+			}),
+		);
+
+		expect(html).toContain('data-slot="assistant-parts"');
+		expect(html).toContain('class="flex flex-col gap-3"');
+	});
+});

--- a/src/features/workspaces/components/ai-chat/AiChatMessageRow.worker.test.ts
+++ b/src/features/workspaces/components/ai-chat/AiChatMessageRow.worker.test.ts
@@ -46,5 +46,9 @@ describe("AI chat assistant part spacing", () => {
 
 		expect(html).toContain('data-slot="assistant-parts"');
 		expect(html).toContain('class="flex flex-col gap-3"');
+		const imageResultIndex = html.indexOf('aria-label="Mountain landscape"');
+		const responseIndex = html.indexOf("The image search tool works.");
+		expect(imageResultIndex).toBeGreaterThan(-1);
+		expect(responseIndex).toBeGreaterThan(imageResultIndex);
 	});
 });

--- a/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
@@ -20,6 +20,7 @@ import {
 	AiChatComputeDetails,
 	AiChatComputeImages,
 } from "#/features/workspaces/components/ai-chat/AiChatComputeResult";
+import { AiChatImageSearchResults } from "#/features/workspaces/components/ai-chat/AiChatImageSearchResults";
 import {
 	getToolActivityForPart,
 	type AiChatToolActivity,
@@ -120,15 +121,18 @@ function ToolActivityMotion({
 }
 
 function getInlineActivityContent(activity: AiChatToolActivity) {
-	if (
-		activity.toolName !== "compute" ||
-		activity.status === "running" ||
-		activity.status === "interrupted"
-	) {
+	if (activity.status === "running" || activity.status === "interrupted") {
 		return null;
 	}
 
-	return <AiChatComputeImages output={activity.detail.output} />;
+	if (activity.toolName === "compute") {
+		return <AiChatComputeImages output={activity.detail.output} />;
+	}
+	if (activity.toolName === "web_search") {
+		return <AiChatImageSearchResults output={activity.detail.output} />;
+	}
+
+	return null;
 }
 
 function getActivityDetails(activity: AiChatToolActivity) {

--- a/src/features/workspaces/components/ai-chat/ai-chat-tool-receipts.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-tool-receipts.ts
@@ -130,7 +130,7 @@ export function getRunningToolReceipt(input: {
 		}
 		case "web_links":
 			return receipt.running("Finding links on ", { name: formatUrl(getString(toolInput.url)) });
-		case "web_markdown":
+		case "web_fetch":
 			return receipt.running("Reading ", {
 				name: formatUrlWithPath(getString(toolInput.url)),
 			});
@@ -190,10 +190,8 @@ export function getFinishedToolReceipt(input: {
 			return summarizeWorkspaceRead(input.output);
 		case "web_search":
 			return summarizeWebSearch(input.output, input.toolInput);
-		case "web_markdown":
-			return receipt.completed("Read ", {
-				name: formatUrlWithPath(getString(asRecord(input.toolInput).url)),
-			});
+		case "web_fetch":
+			return summarizeWebFetch(input.output, input.toolInput);
 		case "web_links":
 			return summarizeWebLinks(input.output, input.toolInput);
 		case "research_discover":
@@ -400,11 +398,20 @@ function formatPageRange(range: string | undefined) {
 
 function summarizeWebSearch(output: unknown, toolInput: unknown): AiChatToolReceipt {
 	const results = getArray(asRecord(output).results);
-	const subject = getString(asRecord(toolInput).query);
-	const base: ReceiptPart[] = [`Found ${formatCount(results.length, "source")}`];
+	const input = asRecord(toolInput);
+	const subject = getString(input.query);
+	const noun = getString(input.source) === "images" ? "image" : "source";
+	const base: ReceiptPart[] = [`Found ${formatCount(results.length, noun)}`];
 	return subject
 		? receipt.completed(...base, " for ", ...name(subject))
 		: receipt.completed(...base);
+}
+
+function summarizeWebFetch(output: unknown, toolInput: unknown): AiChatToolReceipt {
+	const kind = getString(asRecord(output).kind);
+	const target = { name: formatUrlWithPath(getString(asRecord(toolInput).url)) };
+	if (kind === "unsupported") return receipt.completed("Couldn’t read ", target);
+	return receipt.completed(kind === "image" ? "Inspected " : "Read ", target);
 }
 
 function summarizeWebLinks(output: unknown, toolInput: unknown): AiChatToolReceipt {

--- a/src/features/workspaces/components/ai-chat/ai-chat-tool-receipts.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-tool-receipts.ts
@@ -128,8 +128,6 @@ export function getRunningToolReceipt(input: {
 				? receipt.running("Renaming ", ...name(oldName), " → ", ...name(newName))
 				: receipt.running("Renaming ", ...name(oldName));
 		}
-		case "web_links":
-			return receipt.running("Finding links on ", { name: formatUrl(getString(toolInput.url)) });
 		case "web_fetch":
 			return receipt.running("Reading ", {
 				name: formatUrlWithPath(getString(toolInput.url)),
@@ -192,8 +190,6 @@ export function getFinishedToolReceipt(input: {
 			return summarizeWebSearch(input.output, input.toolInput);
 		case "web_fetch":
 			return summarizeWebFetch(input.output, input.toolInput);
-		case "web_links":
-			return summarizeWebLinks(input.output, input.toolInput);
 		case "research_discover":
 			return summarizeResearchDiscover(input.output, input.toolInput);
 		case "research_deepen":
@@ -414,13 +410,6 @@ function summarizeWebFetch(output: unknown, toolInput: unknown): AiChatToolRecei
 	return receipt.completed(kind === "image" ? "Inspected " : "Read ", target);
 }
 
-function summarizeWebLinks(output: unknown, toolInput: unknown): AiChatToolReceipt {
-	const items = getArray(asRecord(output).items);
-	return receipt.completed(`Found ${formatCount(items.length, "link")} on `, {
-		name: formatUrl(getString(asRecord(toolInput).url)),
-	});
-}
-
 function summarizeResearchDiscover(output: unknown, toolInput: unknown): AiChatToolReceipt {
 	const record = asRecord(output);
 	const total = getArray(record.papers).length + getArray(record.github).length;
@@ -582,15 +571,6 @@ function getBaseName(path: string | undefined) {
 
 function getPathFromToolInput(input: unknown) {
 	return getString(asRecord(input).path);
-}
-
-function formatUrl(url: string | undefined) {
-	if (!url) return "page";
-	try {
-		return new URL(url).hostname.replace(/^www\./, "");
-	} catch {
-		return url;
-	}
 }
 
 function formatUrlWithPath(url: string | undefined) {

--- a/src/features/workspaces/components/ai-chat/ai-chat-tool-source-previews.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-tool-source-previews.ts
@@ -23,16 +23,6 @@ export function getToolSourcePreviews(activity: AiChatToolActivity): ToolSourceP
 					urlKeys: ["url"],
 				});
 			});
-		case "web_links":
-			return getArray(output.items).map((item) =>
-				typeof item === "string"
-					? sourcePreviewFromUrl(item, "Link")
-					: sourcePreviewFromRecord(asRecord(item), {
-							kind: "Link",
-							titleKeys: ["title", "text", "label"],
-							urlKeys: ["url", "href"],
-						}),
-			);
 		case "web_fetch": {
 			const url = getString(input.url);
 			let label = "Page";

--- a/src/features/workspaces/components/ai-chat/ai-chat-tool-source-previews.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-tool-source-previews.ts
@@ -14,14 +14,15 @@ export function getToolSourcePreviews(activity: AiChatToolActivity): ToolSourceP
 
 	switch (activity.toolName) {
 		case "web_search":
-			return getArray(output.results).map((item) =>
-				sourcePreviewFromRecord(asRecord(item), {
+			return getArray(output.results).map((item) => {
+				const record = asRecord(item);
+				return sourcePreviewFromRecord(record, {
 					descriptionKeys: ["snippet", "description"],
-					kind: "Web",
+					kind: getString(record.type) === "image" ? "Image" : "Web",
 					titleKeys: ["title"],
 					urlKeys: ["url"],
-				}),
-			);
+				});
+			});
 		case "web_links":
 			return getArray(output.items).map((item) =>
 				typeof item === "string"
@@ -32,9 +33,14 @@ export function getToolSourcePreviews(activity: AiChatToolActivity): ToolSourceP
 							urlKeys: ["url", "href"],
 						}),
 			);
-		case "web_markdown": {
+		case "web_fetch": {
 			const url = getString(input.url);
-			return url ? [sourcePreviewFromUrl(url, "Page")] : [];
+			let label = "Page";
+			if (output.kind === "image") label = "Image";
+			if (output.kind === "unsupported") {
+				label = output.reason === "pdf" ? "PDF" : "Unsupported";
+			}
+			return url ? [sourcePreviewFromUrl(url, label)] : [];
 		}
 		case "research_discover":
 			return [

--- a/src/features/workspaces/components/ai-chat/ai-chat-web-fetch-presentation.test.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-web-fetch-presentation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import type { AiChatToolActivity } from "#/features/workspaces/components/ai-chat/ai-chat-display-state";
+import { getFinishedToolReceipt } from "#/features/workspaces/components/ai-chat/ai-chat-tool-receipts";
+import { getToolSourcePreviews } from "#/features/workspaces/components/ai-chat/ai-chat-tool-source-previews";
+
+describe("web_fetch presentation", () => {
+	it.each([
+		["page", undefined, "Read example.com/article", "Page"],
+		["image", undefined, "Inspected example.com/article", "Image"],
+		["unsupported", "pdf", "Couldn’t read example.com/article", "PDF"],
+		["unsupported", "media_type", "Couldn’t read example.com/article", "Unsupported"],
+	])("presents %s output honestly", (kind, reason, summary, sourceKind) => {
+		const output = { kind, reason };
+		const toolInput = { url: "https://example.com/article" };
+
+		expect(
+			getFinishedToolReceipt({
+				baseStatus: "completed",
+				output,
+				toolInput,
+				toolName: "web_fetch",
+			}),
+		).toMatchObject({ status: "completed", summary });
+		expect(
+			getToolSourcePreviews({
+				detail: { input: toolInput, output } as AiChatToolActivity["detail"],
+				presentation: {} as AiChatToolActivity["presentation"],
+				status: "completed",
+				summary,
+				toolName: "web_fetch",
+			}),
+		).toEqual([
+			{
+				kind: sourceKind,
+				title: "example.com",
+				url: "https://example.com/article",
+			},
+		]);
+	});
+});

--- a/src/integrations/firecrawl/client.ts
+++ b/src/integrations/firecrawl/client.ts
@@ -7,6 +7,7 @@ export async function firecrawlJsonRequest(input: {
 	env: Cloudflare.Env;
 	path: string;
 	operation: string;
+	abortSignal?: AbortSignal;
 	method?: string;
 	body?: BodyInit | null;
 	headers?: HeadersInit;
@@ -23,6 +24,7 @@ export async function firecrawlJsonRequest(input: {
 			method: input.method ?? "GET",
 			headers,
 			body: input.body,
+			signal: input.abortSignal,
 		});
 		const responseJson = (await response.json().catch(() => null)) as unknown;
 

--- a/src/integrations/firecrawl/scrape.ts
+++ b/src/integrations/firecrawl/scrape.ts
@@ -1,0 +1,37 @@
+import {
+	firecrawlJsonRequest,
+	getRecordValue,
+	getStringValue,
+} from "#/integrations/firecrawl/client";
+
+const FIRECRAWL_SCRAPE_TIMEOUT_MS = 20_000;
+
+export async function scrapePublicWebPage(input: {
+	abortSignal?: AbortSignal;
+	env: Cloudflare.Env;
+	url: string;
+}) {
+	const timeoutSignal = AbortSignal.timeout(FIRECRAWL_SCRAPE_TIMEOUT_MS);
+	const response = await firecrawlJsonRequest({
+		abortSignal: input.abortSignal
+			? AbortSignal.any([input.abortSignal, timeoutSignal])
+			: timeoutSignal,
+		env: input.env,
+		path: "/v2/scrape",
+		operation: "Web page scrape",
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			url: input.url,
+			formats: ["markdown"],
+			onlyMainContent: true,
+			timeout: FIRECRAWL_SCRAPE_TIMEOUT_MS,
+		}),
+	});
+	const markdown = getStringValue(getRecordValue(response, "data"), "markdown");
+	if (markdown === null) {
+		throw new Error("Web page scrape did not return Markdown.");
+	}
+
+	return markdown;
+}

--- a/src/integrations/firecrawl/scrape.ts
+++ b/src/integrations/firecrawl/scrape.ts
@@ -1,8 +1,4 @@
-import {
-	firecrawlJsonRequest,
-	getRecordValue,
-	getStringValue,
-} from "#/integrations/firecrawl/client";
+import { firecrawlJsonRequest, getRecordValue } from "#/integrations/firecrawl/client";
 
 const FIRECRAWL_SCRAPE_TIMEOUT_MS = 20_000;
 
@@ -28,8 +24,8 @@ export async function scrapePublicWebPage(input: {
 			timeout: FIRECRAWL_SCRAPE_TIMEOUT_MS,
 		}),
 	});
-	const markdown = getStringValue(getRecordValue(response, "data"), "markdown");
-	if (markdown === null) {
+	const markdown = getRecordValue(getRecordValue(response, "data"), "markdown");
+	if (typeof markdown !== "string") {
 		throw new Error("Web page scrape did not return Markdown.");
 	}
 

--- a/src/integrations/firecrawl/search.test.ts
+++ b/src/integrations/firecrawl/search.test.ts
@@ -66,8 +66,75 @@ describe("searchPublicWeb", () => {
 			categories: [{ type: "developer" }],
 		});
 		expect(result.results).toEqual([
-			{ title: "News", url: "https://news.example", snippet: "Today" },
-			{ title: "Issue", url: "https://github.com/acme/repo/issues/1", snippet: null },
+			{ type: "page", title: "News", url: "https://news.example", snippet: "Today" },
+			{
+				type: "page",
+				title: "Issue",
+				url: "https://github.com/acme/repo/issues/1",
+				snippet: null,
+			},
 		]);
+	});
+
+	it("returns image metadata without scraping or downloading the images", async () => {
+		let body: Record<string, unknown> | undefined;
+		vi.stubGlobal("fetch", async (_url: string, init?: RequestInit) => {
+			if (typeof init?.body === "string") {
+				body = JSON.parse(init.body) as Record<string, unknown>;
+			}
+			return new Response(
+				JSON.stringify({
+					data: {
+						images: [
+							{
+								title: "Mitochondrion diagram",
+								imageUrl: "https://cdn.example/mitochondrion.png",
+								imageWidth: 1600,
+								imageHeight: 900,
+								url: "https://example.com/biology",
+								position: 1,
+							},
+						],
+					},
+				}),
+			);
+		});
+
+		const result = await searchPublicWeb({
+			env: { FIRECRAWL_API_KEY: "fc-test" } as Cloudflare.Env,
+			query: "mitochondria",
+			source: "images",
+		});
+
+		expect(body).toMatchObject({
+			query: "mitochondria",
+			sources: [{ type: "images" }],
+		});
+		expect(result.results).toEqual([
+			{
+				type: "image",
+				title: "Mitochondrion diagram",
+				url: "https://example.com/biology",
+				imageUrl: "https://cdn.example/mitochondrion.png",
+				imageWidth: 1600,
+				imageHeight: 900,
+				position: 1,
+			},
+		]);
+	});
+
+	it("rejects categories for image searches instead of silently broadening them", async () => {
+		const fetchSpy = vi.fn();
+		vi.stubGlobal("fetch", fetchSpy);
+
+		await expect(
+			searchPublicWeb({
+				env: { FIRECRAWL_API_KEY: "fc-test" } as Cloudflare.Env,
+				query: "mitochondria",
+				source: "images",
+				category: "research",
+			}),
+		).rejects.toThrow("Image search cannot be combined with a search category.");
+		expect(fetchSpy).not.toHaveBeenCalled();
 	});
 });

--- a/src/integrations/firecrawl/search.test.ts
+++ b/src/integrations/firecrawl/search.test.ts
@@ -66,7 +66,7 @@ describe("searchPublicWeb", () => {
 			categories: [{ type: "developer" }],
 		});
 		expect(result.results).toEqual([
-			{ type: "page", title: "News", url: "https://news.example", snippet: "Today" },
+			{ type: "page", title: "News", url: "https://news.example/", snippet: "Today" },
 			{
 				type: "page",
 				title: "Issue",
@@ -121,6 +121,39 @@ describe("searchPublicWeb", () => {
 				position: 1,
 			},
 		]);
+	});
+
+	it("drops unsafe result URLs returned by Firecrawl", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							data: {
+								images: [
+									{
+										imageUrl: "data:image/png;base64,abc",
+										url: "https://example.com/source",
+									},
+									{
+										imageUrl: "https://cdn.example/image.png",
+										url: "http://127.0.0.1/private",
+									},
+								],
+							},
+						}),
+					),
+			),
+		);
+
+		await expect(
+			searchPublicWeb({
+				env: { FIRECRAWL_API_KEY: "fc-test" } as Cloudflare.Env,
+				query: "unsafe images",
+				source: "images",
+			}),
+		).resolves.toEqual({ results: [] });
 	});
 
 	it("rejects categories for image searches instead of silently broadening them", async () => {

--- a/src/integrations/firecrawl/search.ts
+++ b/src/integrations/firecrawl/search.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { parsePublicHttpUrl } from "#/features/workspaces/ai/web-access-policy";
+
 import {
 	firecrawlJsonRequest,
 	getRecordArrayValue,
@@ -76,16 +78,16 @@ export async function searchPublicWeb(input: {
 	if (input.source === "images") {
 		return {
 			results: getRecordArrayValue(data, "images").flatMap((item) => {
-				const imageUrl = getStringValue(item, "imageUrl");
-				const sourceUrl = getStringValue(item, "url");
+				const imageUrl = parsePublicHttpUrl(getStringValue(item, "imageUrl"));
+				const sourceUrl = parsePublicHttpUrl(getStringValue(item, "url"));
 				if (!imageUrl || !sourceUrl) return [];
 
 				return [
 					{
 						type: "image" as const,
 						title: getStringValue(item, "title"),
-						url: sourceUrl,
-						imageUrl,
+						url: sourceUrl.toString(),
+						imageUrl: imageUrl.toString(),
 						imageWidth: positiveIntegerOrNull(getNumberValue(item, "imageWidth")),
 						imageHeight: positiveIntegerOrNull(getNumberValue(item, "imageHeight")),
 						position: positiveIntegerOrNull(getNumberValue(item, "position")),
@@ -103,10 +105,11 @@ export async function searchPublicWeb(input: {
 
 	return {
 		results: hits.flatMap((item) => {
-			const url =
+			const url = parsePublicHttpUrl(
 				getStringValue(item, "url") ??
-				getStringValue(getRecordValue(item, "metadata"), "sourceURL") ??
-				getStringValue(getRecordValue(item, "metadata"), "url");
+					getStringValue(getRecordValue(item, "metadata"), "sourceURL") ??
+					getStringValue(getRecordValue(item, "metadata"), "url"),
+			);
 			if (!url) return [];
 
 			return [
@@ -115,7 +118,7 @@ export async function searchPublicWeb(input: {
 					title:
 						getStringValue(item, "title") ??
 						getStringValue(getRecordValue(item, "metadata"), "title"),
-					url,
+					url: url.toString(),
 					snippet: truncateFirecrawlText(
 						getStringValue(item, "description") ??
 							getStringValue(item, "snippet") ??

--- a/src/integrations/firecrawl/search.ts
+++ b/src/integrations/firecrawl/search.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import {
 	firecrawlJsonRequest,
 	getRecordArrayValue,
+	getNumberValue,
 	getRecordValue,
 	getStringValue,
 	truncateFirecrawlText,
@@ -11,7 +12,7 @@ import {
 const MAX_WEB_SEARCH_SNIPPET_CHARS = 600;
 const WEB_SEARCH_RESULT_LIMIT = 8;
 export const webSearchFreshnessValues = ["day", "week", "month"] as const;
-export const webSearchSourceValues = ["web", "news"] as const;
+export const webSearchSourceValues = ["web", "news", "images"] as const;
 export const webSearchCategoryValues = ["pdf", "github", "research", "developer"] as const;
 const webSearchFreshnessTbs = {
 	day: "qdr:d",
@@ -21,11 +22,23 @@ const webSearchFreshnessTbs = {
 
 export const publicWebSearchResultSchema = z.object({
 	results: z.array(
-		z.object({
-			title: z.string().nullable(),
-			url: z.string().nullable(),
-			snippet: z.string().nullable(),
-		}),
+		z.discriminatedUnion("type", [
+			z.object({
+				type: z.literal("page"),
+				title: z.string().nullable(),
+				url: z.string(),
+				snippet: z.string().nullable(),
+			}),
+			z.object({
+				type: z.literal("image"),
+				title: z.string().nullable(),
+				url: z.string(),
+				imageUrl: z.string(),
+				imageWidth: z.number().int().positive().nullable(),
+				imageHeight: z.number().int().positive().nullable(),
+				position: z.number().int().positive().nullable(),
+			}),
+		]),
 	),
 });
 
@@ -37,6 +50,10 @@ export async function searchPublicWeb(input: {
 	source?: (typeof webSearchSourceValues)[number];
 	category?: (typeof webSearchCategoryValues)[number];
 }): Promise<z.output<typeof publicWebSearchResultSchema>> {
+	if (input.source === "images" && input.category) {
+		throw new Error("Image search cannot be combined with a search category.");
+	}
+
 	const response = await firecrawlJsonRequest({
 		env: input.env,
 		path: "/v2/search",
@@ -56,6 +73,28 @@ export async function searchPublicWeb(input: {
 		}),
 	});
 	const data = getRecordValue(response, "data");
+	if (input.source === "images") {
+		return {
+			results: getRecordArrayValue(data, "images").flatMap((item) => {
+				const imageUrl = getStringValue(item, "imageUrl");
+				const sourceUrl = getStringValue(item, "url");
+				if (!imageUrl || !sourceUrl) return [];
+
+				return [
+					{
+						type: "image" as const,
+						title: getStringValue(item, "title"),
+						url: sourceUrl,
+						imageUrl,
+						imageWidth: positiveIntegerOrNull(getNumberValue(item, "imageWidth")),
+						imageHeight: positiveIntegerOrNull(getNumberValue(item, "imageHeight")),
+						position: positiveIntegerOrNull(getNumberValue(item, "position")),
+					},
+				];
+			}),
+		};
+	}
+
 	const hits = [
 		...getRecordArrayValue(data, "web"),
 		...getRecordArrayValue(data, "news"),
@@ -63,24 +102,34 @@ export async function searchPublicWeb(input: {
 	];
 
 	return {
-		results: hits
-			.map((item) => ({
-				title:
-					getStringValue(item, "title") ??
-					getStringValue(getRecordValue(item, "metadata"), "title"),
-				url:
-					getStringValue(item, "url") ??
-					getStringValue(getRecordValue(item, "metadata"), "sourceURL") ??
-					getStringValue(getRecordValue(item, "metadata"), "url"),
-				snippet: truncateFirecrawlText(
-					getStringValue(item, "description") ??
-						getStringValue(item, "snippet") ??
-						getStringValue(getRecordValue(item, "metadata"), "description"),
-					MAX_WEB_SEARCH_SNIPPET_CHARS,
-				),
-			}))
-			.filter((item) => item.title && item.url),
+		results: hits.flatMap((item) => {
+			const url =
+				getStringValue(item, "url") ??
+				getStringValue(getRecordValue(item, "metadata"), "sourceURL") ??
+				getStringValue(getRecordValue(item, "metadata"), "url");
+			if (!url) return [];
+
+			return [
+				{
+					type: "page" as const,
+					title:
+						getStringValue(item, "title") ??
+						getStringValue(getRecordValue(item, "metadata"), "title"),
+					url,
+					snippet: truncateFirecrawlText(
+						getStringValue(item, "description") ??
+							getStringValue(item, "snippet") ??
+							getStringValue(getRecordValue(item, "metadata"), "description"),
+						MAX_WEB_SEARCH_SNIPPET_CHARS,
+					),
+				},
+			];
+		}),
 	};
+}
+
+function positiveIntegerOrNull(value: number | null) {
+	return value !== null && Number.isInteger(value) && value > 0 ? value : null;
 }
 
 function normalizeHostnameList(value: string[] | undefined) {


### PR DESCRIPTION
## Summary

- extend `web_search` with Firecrawl image results and render an eight-image, image-only gallery in chat
- replace `web_markdown` with `web_fetch` for Firecrawl-scraped webpages and one-shot multimodal image inspection
- keep fetched image bytes ephemeral and out of the persisted tool output
- reject image searches combined with categories instead of silently broadening the query
- present webpage, image, PDF, and unsupported fetch outcomes honestly in tool receipts and source previews
- add shared spacing between completed tool output and the following assistant response

## Behavior

Public PDFs remain intentionally unsupported and direct users to the existing workspace upload flow. Failed external thumbnails disappear cleanly instead of exposing broken-image text.

## Validation

- `pnpm exec vitest run src/integrations/firecrawl/search.test.ts src/features/workspaces/ai/ai-tool-registry.test.ts src/features/workspaces/components/ai-chat/AiChatImageSearchResults.test.tsx src/features/workspaces/components/ai-chat/ai-chat-web-fetch-presentation.test.ts`
- `pnpm exec vitest run --project=workers src/features/workspaces/ai/web-tools.worker.test.ts src/features/workspaces/components/ai-chat/AiChatMessageRow.worker.test.ts`
- `pnpm check`
- `pnpm build:app`

The Firecrawl integration is covered with mocked API responses; no live Firecrawl request was made locally.

## Follow-up

An aggregate outstanding-byte budget across multiple simultaneous `web_fetch` image calls is intentionally outside this PR's requested scope; existing per-image source and normalized-output limits remain enforced.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789321135&installation_model_id=425282&pr_number=783&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F783&signature=d03528ba341f5325613cdf27d14a1149486ebf8084abfaf1ab531dfd2af81f4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for fetching public webpages, PDFs, images, and unsupported content from URLs.
  * Added image search with linked, lazily loaded image cards in AI chat.
  * Improved AI chat previews and labels for pages, images, PDFs, and unsupported content.
  * Added clearer spacing between assistant response sections.

* **Bug Fixes**
  * Prevented invalid or unsupported web content from being presented misleadingly.
  * Added validation for public URLs, image metadata, redirects, and search filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->