### PR TITLE
perf(dev): default local dev to a lite profile

### DIFF
--- a/docs/configuration/local-development.mdx
+++ b/docs/configuration/local-development.mdx
@@ -9,7 +9,7 @@ ThinkEx is a Cloudflare Worker app managed by Vite+. The repo pins Node 24 and e
 
 - Node.js 24 (`>=24.11.0 <25`) through Vite+ managed mode
 - pnpm 11
-- Docker, because local startup declares Cloudflare Container bindings
+- Docker, only for the full dev profile (see [Dev server profiles](#dev-server-profiles))
 - Infisical access for core team members, or a local `.dev.vars` file for contributors
 
 If `node`, `pnpm`, or Corepack resolve to unexpected versions, run:
@@ -52,15 +52,38 @@ BETTER_AUTH_URL=http://localhost:3000
 
 The auth page shows **Continue as guest** in local development, so Google OAuth credentials are not required for normal UI testing.
 
-## Force Local Cloudflare Bindings
+## Dev server profiles
 
-Some bindings are remote by default. If you do not have Cloudflare credentials, run:
+`pnpm dev` and `pnpm serve:dev` run a **lite** profile by default:
+
+- Every Cloudflare binding is emulated locally. Nothing is proxied to the real account, so a normal session incurs no Workers AI, Browser Rendering, R2, or Email charges — and no invite email is delivered to a real inbox.
+- Containers are off, so Docker is never invoked and the three container images are neither built nor started.
+- Miniflare's local trace store is off, which is otherwise the largest thing in `.wrangler/`.
+
+Remote-only features are unavailable in this profile: browser rendering, PDF export, image-to-text extraction, and email invite delivery. Core workspace, document, and auth flows all run locally.
+
+<Warning>
+	**The lite profile is not "free" — it removes the charges you did not ask for, not the ones you trigger.**
+
+	Only Cloudflare *bindings* are forced local. Three paid services are reached over plain HTTPS with an API key rather than through a binding, so no dev profile affects them:
+
+	- **AI chat, thread titles, and compaction** — Vercel AI Gateway, billed per turn whenever `AI_GATEWAY_API_KEY` is set
+	- **`web_search` and research tools** — Firecrawl
+	- **PDF text extraction** — LlamaParse
+
+	Under `pnpm dev`, Infisical supplies those keys, so sending a chat message costs money in either profile. For a session that spends nothing at all, use `pnpm serve:dev` with a `.dev.vars` that omits those keys — the AI gateway then raises a clear error instead of billing.
+</Warning>
+
+When you need the production-shaped environment — testing image extraction, browser rendering, real R2 behavior, or anything running in a container — opt in explicitly:
 
 ```bash
-CLOUDFLARE_VITE_FORCE_LOCAL=true pnpm serve:dev
+pnpm dev:full
+# or, on either command:
+pnpm dev --full
+pnpm serve:dev --full
 ```
 
-This disables remote-only features such as deployed AI chat, browser rendering, and email invite delivery, but core workspace, document, and auth flows still run locally.
+**The full profile bills real usage** against the Cloudflare account, and sends real email. `THINKEX_DEV_PROFILE=full` is equivalent to `--full` for non-interactive callers.
 
 ## Database
 
@@ -79,7 +102,22 @@ development command uses it and deliberately skips automatic creation and migrat
 
 ## Docker
 
-Docker must be running before the dev server starts because the Worker declares Cloudflare Containers for code execution and file conversion. The first startup may pull or build large images.
+Docker is only needed for the full profile (`pnpm dev:full`), which declares Cloudflare Containers for code execution and file conversion — the first such startup may build large images. The default lite profile skips containers entirely, so Docker does not need to be running.
+
+## Reclaim local disk
+
+Local development artifacts accumulate per checkout and are never pruned automatically — Miniflare's trace store, locally built container images, and one PostgreSQL database per port and workspace ID ever used. To see what is reclaimable:
+
+```bash
+pnpm dev:clean
+```
+
+That is a dry run. Add `--yes` to apply it, and optionally:
+
+- `--databases` — also drop idle `thinkex_*` databases and their roles. Never drops this checkout's database, and never one with an open connection, so a running worktree is safe.
+- `--docker-cache` — also prune Docker's build cache. This is machine-wide, so other projects lose their cached layers too.
+
+Your local application data is never touched: `.wrangler/state/v3/do` (Durable Object storage — workspaces, documents, AI threads) and `.wrangler/state/v3/r2` (uploaded files) exist nowhere else, so no flag removes them.
 
 ## Validate Changes
 
@@ -87,15 +125,22 @@ Docker must be running before the dev server starts because the Worker declares 
 pnpm verify
 ```
 
-This runs Vite+ check, test, and build tasks with caching.
+This runs Vite+ check, test, and build tasks **through the task cache**, which fingerprints inputs and replays previous results instead of redoing work. Measured on an M-series laptop:
 
-For narrower local checks, use:
+| Command | Nothing changed | Sources changed |
+| --- | --- | --- |
+| `pnpm verify` | ~2 s | ~60 s |
+| `pnpm check` + `pnpm test` | ~38 s every time | ~38 s |
+
+So `pnpm verify` is the right habit for "is everything still OK", especially across several worktrees running the same checks on mostly-unchanged code. It is *slower* than the raw runners on a full cache miss, because it also fingerprints inputs and archives outputs — so while actively iterating, reach for the narrower commands instead:
 
 ```bash
-pnpm check
-pnpm test
-pnpm build
+pnpm test --project node   # ~6 s, 355 tests, skips the workerd pool entirely
+pnpm check                 # ~5 s, format + lint + types
+pnpm test                  # ~34 s, includes the 16 workerd test files
 pnpm doctor
 ```
+
+The workers test project is the slow part and is dominated by module transform and import inside `workerd`, one runtime per test file. It already runs in parallel across cores; raising `--maxWorkers` past the default makes it slower, not faster.
 
 `pnpm doctor` runs React Doctor against changed files. Use `pnpm doctor:full` when you intentionally want a full React scan.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
 	},
 	"scripts": {
 		"dev": "node scripts/run-local-dev.mjs --infisical",
+		"dev:full": "node scripts/run-local-dev.mjs --infisical --full",
 		"serve:dev": "node scripts/run-local-dev.mjs",
+		"dev:clean": "node scripts/clean-local-dev.mjs",
 		"build": "vp run ciBuild",
 		"build:app": "NODE_ENV=production CLOUDFLARE_VITE_FORCE_LOCAL=true CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false vp build && node scripts/patch-worker-observability.mjs",
 		"build:production": "NODE_ENV=production CLOUDFLARE_ENV=production CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false vp build && node scripts/patch-worker-observability.mjs",

--- a/scripts/clean-local-dev.mjs
+++ b/scripts/clean-local-dev.mjs
@@ -1,0 +1,187 @@
+import { execFileSync } from "node:child_process";
+import { rmSync, statSync } from "node:fs";
+import { Client } from "pg";
+
+import { getLocalPostgresConfig } from "./local-postgres-config.mjs";
+
+// Reclaims local development artifacts that nothing prunes on its own.
+//
+// Deliberately NOT touched, because they hold local application data that exists
+// nowhere else: .wrangler/state/v3/do (Durable Object SQLite — workspaces,
+// documents, AI threads) and .wrangler/state/v3/r2 (uploaded files). Losing
+// those is indistinguishable from losing your local work, so this script never
+// removes them and there is no flag that makes it.
+const args = new Set(process.argv.slice(2));
+const apply = args.has("--yes");
+const includeDatabases = args.has("--databases");
+const includeDockerCache = args.has("--docker-cache");
+
+const TRACE_STORE = ".wrangler/state/v3/observability";
+const TASK_CACHE = "node_modules/.vite/task-cache";
+const plans = [];
+let admin;
+
+function megabytes(bytes) {
+	return `${(bytes / 1024 / 1024).toFixed(0)} MB`;
+}
+
+function directorySize(path) {
+	try {
+		statSync(path);
+	} catch {
+		return 0;
+	}
+
+	return Number.parseInt(execFileSync("du", ["-sk", path], { encoding: "utf8" }), 10) * 1024;
+}
+
+function docker(dockerArgs) {
+	return execFileSync("docker", dockerArgs, {
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+}
+
+// Miniflare's local trace store. Pure telemetry — nothing in the app reads it,
+// and `pnpm dev` no longer writes it, so this only reclaims the backlog.
+const traceBytes = directorySize(TRACE_STORE);
+
+if (traceBytes > 0) {
+	plans.push({
+		label: `Miniflare trace store (${TRACE_STORE})`,
+		bytes: traceBytes,
+		run: () => rmSync(TRACE_STORE, { recursive: true, force: true }),
+	});
+}
+
+// The Vite Task cache, which speeds up `pnpm verify` but never evicts entries by
+// age or size — per Vite+'s own docs it only grows. Behind a flag because
+// clearing it means the next `pnpm verify` re-runs everything from cold.
+if (args.has("--task-cache")) {
+	const taskCacheBytes = directorySize(TASK_CACHE);
+
+	if (taskCacheBytes > 0) {
+		plans.push({
+			label: `Vite Task cache (${TASK_CACHE}) — next verify runs cold`,
+			bytes: taskCacheBytes,
+			run: () => rmSync(TASK_CACHE, { recursive: true, force: true }),
+		});
+	}
+}
+
+// Locally built container images, rebuilt on demand by `pnpm dev:full`.
+try {
+	const images = docker(["images", "--format", "{{.Repository}}:{{.Tag}}\t{{.ID}}"])
+		.split("\n")
+		.filter((line) => line.startsWith("cloudflare-dev/"))
+		.map((line) => {
+			const [reference, id] = line.split("\t");
+			return { reference, id };
+		});
+
+	if (images.length > 0) {
+		const ids = [...new Set(images.map((image) => image.id))];
+		plans.push({
+			label: `${images.length} cloudflare-dev container image(s)`,
+			detail: images.map((image) => image.reference),
+			run: () => docker(["image", "rm", "-f", ...ids]),
+		});
+	}
+} catch {
+	console.log("Docker is not reachable — skipping image cleanup.");
+}
+
+// Docker's build cache is machine-wide rather than scoped to this project, so
+// other projects lose their cached layers too. Hence its own flag.
+if (includeDockerCache) {
+	plans.push({
+		label: "Docker build cache (machine-wide, affects other projects)",
+		run: () => docker(["builder", "prune", "-f"]),
+	});
+}
+
+// Postgres databases left behind by ports and workspace IDs used at some point
+// in the past. Guarded twice: never the database this checkout resolves to, and
+// never one with an open connection — which is how a running worktree, or a psql
+// session you forgot about, announces itself.
+if (includeDatabases) {
+	const current = getLocalPostgresConfig();
+	admin = new Client({ database: "postgres" });
+	await admin.connect();
+
+	const { rows } = await admin.query(`
+		select d.datname,
+		       pg_database_size(d.datname) as bytes,
+		       (select count(*) from pg_stat_activity a where a.datname = d.datname) as connections
+		from pg_database d
+		where d.datname like 'thinkex\\_%'
+		order by d.datname
+	`);
+
+	for (const row of rows) {
+		if (row.datname === current.databaseName) {
+			console.log(`keep  ${row.datname} — this checkout's database`);
+			continue;
+		}
+
+		if (Number(row.connections) > 0) {
+			console.log(`keep  ${row.datname} — ${row.connections} open connection(s), in use`);
+			continue;
+		}
+
+		const roleName = row.datname.replace(/^thinkex_/, "thinkex_local_");
+		plans.push({
+			label: `database ${row.datname} (+ role ${roleName})`,
+			bytes: Number(row.bytes),
+			run: async () => {
+				await admin.query(`drop database ${row.datname}`);
+
+				try {
+					await admin.query(`drop role ${roleName}`);
+				} catch (error) {
+					console.log(`  kept role ${roleName}: ${error.message}`);
+				}
+			},
+		});
+	}
+}
+
+try {
+	if (plans.length === 0) {
+		console.log("Nothing to reclaim.");
+	} else {
+		const total = plans.reduce((sum, plan) => sum + (plan.bytes ?? 0), 0);
+
+		console.log(`\n${apply ? "Removing" : "Would remove"}:`);
+
+		for (const plan of plans) {
+			console.log(`  ${plan.label}${plan.bytes ? ` — ${megabytes(plan.bytes)}` : ""}`);
+
+			for (const line of plan.detail ?? []) {
+				console.log(`      ${line}`);
+			}
+		}
+
+		if (total > 0) {
+			console.log(`\n  measured total: ${megabytes(total)}`);
+			console.log("  (container images excluded — shared layers make per-image sizes overlap)");
+		}
+
+		if (apply) {
+			console.log("");
+
+			for (const plan of plans) {
+				// Some plans are synchronous filesystem/docker calls, others are queries.
+				await Promise.resolve(plan.run());
+				console.log(`removed ${plan.label}`);
+			}
+		} else {
+			console.log("\nDry run. Re-run with --yes to apply.");
+			console.log("  --databases     also drop idle thinkex_* databases and their roles");
+			console.log("  --task-cache    also clear the Vite Task cache (next verify runs cold)");
+			console.log("  --docker-cache  also prune Docker's build cache (affects other projects)");
+		}
+	}
+} finally {
+	await admin?.end();
+}

--- a/scripts/clean-local-dev.mjs
+++ b/scripts/clean-local-dev.mjs
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { rmSync, statSync } from "node:fs";
 import { Client } from "pg";
 
-import { getLocalPostgresConfig } from "./local-postgres-config.mjs";
+import { resolveLocalDatabase } from "./local-postgres-config.mjs";
 
 // Reclaims local development artifacts that nothing prunes on its own.
 //
@@ -101,48 +101,67 @@ if (includeDockerCache) {
 }
 
 // Postgres databases left behind by ports and workspace IDs used at some point
-// in the past. Guarded twice: never the database this checkout resolves to, and
-// never one with an open connection — which is how a running worktree, or a psql
-// session you forgot about, announces itself.
+// in the past. Guarded twice: never the database this checkout resolves to — via
+// resolveLocalDatabase, so a preset connection string is honoured rather than
+// re-derived — and never one with an open connection, which is how a running
+// worktree, or a psql session you forgot about, announces itself.
 if (includeDatabases) {
-	const current = getLocalPostgresConfig();
-	admin = new Client({ database: "postgres" });
-	await admin.connect();
+	const current = resolveLocalDatabase();
 
-	const { rows } = await admin.query(`
-		select d.datname,
-		       pg_database_size(d.datname) as bytes,
-		       (select count(*) from pg_stat_activity a where a.datname = d.datname) as connections
-		from pg_database d
-		where d.datname like 'thinkex\\_%'
-		order by d.datname
-	`);
+	if (current.isConfigured && !current.databaseName) {
+		console.log(
+			"skip  database cleanup — CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE is set\n" +
+				"      but its database name could not be parsed, so nothing here is safe to drop.",
+		);
+	} else {
+		// Pinned rather than inherited: `pg` reads PGHOST/PGPORT when host and port
+		// are omitted, and this script issues DROP. The connection string this repo
+		// generates is always localhost:5432, so target exactly that.
+		admin = new Client({ database: "postgres", host: "localhost", port: 5432 });
+		await admin.connect();
 
-	for (const row of rows) {
-		if (row.datname === current.databaseName) {
-			console.log(`keep  ${row.datname} — this checkout's database`);
-			continue;
+		const { rows } = await admin.query(`
+			select d.datname,
+			       pg_database_size(d.datname) as bytes,
+			       (select count(*) from pg_stat_activity a where a.datname = d.datname) as connections
+			from pg_database d
+			where d.datname like 'thinkex\\_%'
+			order by d.datname
+		`);
+
+		for (const row of rows) {
+			if (row.datname === current.databaseName) {
+				console.log(
+					`keep  ${row.datname} — this checkout's database${current.isConfigured ? " (explicitly configured)" : ""}`,
+				);
+				continue;
+			}
+
+			if (Number(row.connections) > 0) {
+				console.log(`keep  ${row.datname} — ${row.connections} open connection(s), in use`);
+				continue;
+			}
+
+			// Identifiers come from the catalog rather than our own sanitised
+			// derivation, and these are DROP statements — quote them properly.
+			const roleName = row.datname.replace(/^thinkex_/, "thinkex_local_");
+			const databaseIdentifier = admin.escapeIdentifier(row.datname);
+			const roleIdentifier = admin.escapeIdentifier(roleName);
+
+			plans.push({
+				label: `database ${row.datname} (+ role ${roleName})`,
+				bytes: Number(row.bytes),
+				run: async () => {
+					await admin.query(`drop database ${databaseIdentifier}`);
+
+					try {
+						await admin.query(`drop role ${roleIdentifier}`);
+					} catch (error) {
+						console.log(`  kept role ${roleName}: ${error.message}`);
+					}
+				},
+			});
 		}
-
-		if (Number(row.connections) > 0) {
-			console.log(`keep  ${row.datname} — ${row.connections} open connection(s), in use`);
-			continue;
-		}
-
-		const roleName = row.datname.replace(/^thinkex_/, "thinkex_local_");
-		plans.push({
-			label: `database ${row.datname} (+ role ${roleName})`,
-			bytes: Number(row.bytes),
-			run: async () => {
-				await admin.query(`drop database ${row.datname}`);
-
-				try {
-					await admin.query(`drop role ${roleName}`);
-				} catch (error) {
-					console.log(`  kept role ${roleName}: ${error.message}`);
-				}
-			},
-		});
 	}
 }
 

--- a/scripts/local-postgres-config.mjs
+++ b/scripts/local-postgres-config.mjs
@@ -22,3 +22,42 @@ export function getLocalPostgresConfig(environment = process.env) {
 		url: `postgresql://${roleName}:${roleName}@localhost:5432/${databaseName}`,
 	};
 }
+
+/**
+ * The database this checkout actually uses, which is not always the derived one:
+ * a preset CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE wins, and
+ * run-local-dev.mjs then skips provisioning and migration entirely.
+ *
+ * Every caller that needs to know "which database is this checkout's" must go
+ * through here rather than re-deriving it. clean-local-dev.mjs decides what is
+ * safe to drop from this answer, so a second, half-complete copy of the rule is
+ * how you delete a database somebody is using.
+ *
+ * `databaseName` is undefined when an explicit URL is set but unparseable —
+ * callers that delete must treat that as "do not touch anything".
+ */
+export function resolveLocalDatabase(environment = process.env) {
+	const derived = getLocalPostgresConfig(environment);
+	const configuredUrl =
+		environment.CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE?.trim();
+
+	if (!configuredUrl) {
+		return { ...derived, isConfigured: false };
+	}
+
+	return {
+		...derived,
+		databaseName: databaseNameFromUrl(configuredUrl),
+		url: configuredUrl,
+		isConfigured: true,
+	};
+}
+
+function databaseNameFromUrl(url) {
+	try {
+		const name = decodeURIComponent(new URL(url).pathname.replace(/^\//, ""));
+		return name || undefined;
+	} catch {
+		return undefined;
+	}
+}

--- a/scripts/local-postgres-config.test.mjs
+++ b/scripts/local-postgres-config.test.mjs
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { getLocalPostgresConfig, resolveLocalDatabase } from "./local-postgres-config.mjs";
+
+describe("getLocalPostgresConfig", () => {
+	it("defaults to port 3000 when CONDUCTOR_PORT is unset", () => {
+		expect(getLocalPostgresConfig({})).toMatchObject({
+			databaseName: "thinkex_3000",
+			port: "3000",
+			roleName: "thinkex_local_3000",
+		});
+	});
+
+	it("appends a normalized workspace id so a reused port cannot inherit another workspace", () => {
+		expect(
+			getLocalPostgresConfig({ CONDUCTOR_PORT: "55000", CONDUCTOR_WORKSPACE_ID: "AbC-123" }),
+		).toMatchObject({ databaseName: "thinkex_55000_abc123" });
+	});
+
+	it("rejects a port that is not a valid TCP port", () => {
+		expect(() => getLocalPostgresConfig({ CONDUCTOR_PORT: "70000" })).toThrow();
+		expect(() => getLocalPostgresConfig({ CONDUCTOR_PORT: "nope" })).toThrow();
+	});
+});
+
+// clean-local-dev.mjs decides what is safe to drop from this function's answer,
+// so each case below is the difference between keeping and deleting a database
+// somebody is using.
+describe("resolveLocalDatabase", () => {
+	it("uses the derived database when no connection string is preset", () => {
+		expect(resolveLocalDatabase({})).toMatchObject({
+			databaseName: "thinkex_3000",
+			isConfigured: false,
+		});
+	});
+
+	it("prefers a preset connection string over the derived name", () => {
+		expect(
+			resolveLocalDatabase({
+				CONDUCTOR_PORT: "55000",
+				CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE:
+					"postgresql://user:pass@localhost:5432/thinkex_9999",
+			}),
+		).toMatchObject({
+			databaseName: "thinkex_9999",
+			url: "postgresql://user:pass@localhost:5432/thinkex_9999",
+			isConfigured: true,
+		});
+	});
+
+	it("ignores query parameters when reading the database name", () => {
+		expect(
+			resolveLocalDatabase({
+				CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE:
+					"postgresql://user:pass@localhost:5432/thinkex_9999?sslmode=require",
+			}),
+		).toMatchObject({ databaseName: "thinkex_9999" });
+	});
+
+	it("reports no database name for an unparseable connection string, so callers stay hands-off", () => {
+		expect(
+			resolveLocalDatabase({
+				CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE: "not-a-url",
+			}),
+		).toMatchObject({ databaseName: undefined, isConfigured: true });
+	});
+
+	it("treats an empty connection string as absent", () => {
+		expect(
+			resolveLocalDatabase({ CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE: "   " }),
+		).toMatchObject({ databaseName: "thinkex_3000", isConfigured: false });
+	});
+});

--- a/scripts/run-local-dev.mjs
+++ b/scripts/run-local-dev.mjs
@@ -1,6 +1,6 @@
 import { spawn, spawnSync } from "node:child_process";
 
-import { getLocalPostgresConfig } from "./local-postgres-config.mjs";
+import { resolveLocalDatabase } from "./local-postgres-config.mjs";
 
 const secretsMode = process.argv.includes("--infisical") ? "infisical" : "environment";
 // "lite" (the default) runs the dev server with every Cloudflare binding emulated
@@ -12,11 +12,10 @@ const devProfile =
 	process.argv.includes("--full") || process.env.THINKEX_DEV_PROFILE?.trim() === "full"
 		? "full"
 		: "lite";
-const localPostgres = getLocalPostgresConfig();
-const configuredDatabaseUrl =
-	process.env.CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE?.trim();
-const localDatabaseUrl = configuredDatabaseUrl || localPostgres.url;
-const shouldPrepareLocalDatabase = process.env.CONDUCTOR_IS_LOCAL !== "0" && !configuredDatabaseUrl;
+const localPostgres = resolveLocalDatabase();
+const localDatabaseUrl = localPostgres.url;
+const shouldPrepareLocalDatabase =
+	process.env.CONDUCTOR_IS_LOCAL !== "0" && !localPostgres.isConfigured;
 
 if (shouldPrepareLocalDatabase) {
 	run("node", ["scripts/ensure-local-postgres.mjs"], {

--- a/scripts/run-local-dev.mjs
+++ b/scripts/run-local-dev.mjs
@@ -3,6 +3,15 @@ import { spawn, spawnSync } from "node:child_process";
 import { getLocalPostgresConfig } from "./local-postgres-config.mjs";
 
 const secretsMode = process.argv.includes("--infisical") ? "infisical" : "environment";
+// "lite" (the default) runs the dev server with every Cloudflare binding emulated
+// locally and no containers, so an ordinary session bills nothing and skips the
+// Docker build. "full" restores the production-shaped path — remote AI, Browser
+// Rendering, Email, and the real staging R2 bucket, plus the three containers —
+// for the cases that actually need it. vite.config.ts reads THINKEX_DEV_PROFILE.
+const devProfile =
+	process.argv.includes("--full") || process.env.THINKEX_DEV_PROFILE?.trim() === "full"
+		? "full"
+		: "lite";
 const localPostgres = getLocalPostgresConfig();
 const configuredDatabaseUrl =
 	process.env.CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE?.trim();
@@ -20,11 +29,31 @@ if (shouldPrepareLocalDatabase) {
 	});
 }
 
+// Say plainly what this session will and will not spend money on. "lite" only
+// forces Cloudflare *bindings* local — AI chat, web search, and PDF extraction
+// reach paid APIs over plain HTTPS with an API key, so no profile affects them.
+if (devProfile === "lite") {
+	console.log(
+		"dev profile: lite — bindings local, no containers. No Cloudflare charges, no real email.\n" +
+			"  Still billed when their keys are set: AI chat (gateway), web search, PDF extraction.\n" +
+			"  Need containers, browser rendering, or real R2? pnpm dev:full",
+	);
+} else {
+	console.log(
+		"dev profile: full — remote AI, Browser, Email and the real staging R2 bucket are live.\n" +
+			"  This session bills real usage and can deliver real email.",
+	);
+}
+
 const appOrigin = process.env.BETTER_AUTH_URL?.trim() || `http://localhost:${localPostgres.port}`;
 const serverCommand = [
 	"env",
 	`BETTER_AUTH_URL=${appOrigin}`,
 	`CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE=${localDatabaseUrl}`,
+	`THINKEX_DEV_PROFILE=${devProfile}`,
+	// Miniflare's local trace store grows without bound under .wrangler/state and
+	// nothing in the app reads it. Keep it off unless we asked for the full profile.
+	...(devProfile === "lite" ? ["X_LOCAL_OBSERVABILITY=false"] : []),
 	"pnpm",
 	"exec",
 	"vp",
@@ -34,9 +63,13 @@ const serverCommand = [
 	"--port",
 	localPostgres.port,
 ];
+// Deliberately no `--watch`: it polls every 10s and, on any secret change,
+// SIGTERMs and respawns this whole command. That is a full cold start — prebundle
+// validation, Miniflare boot, container check — not a hot reload, and it fires on
+// a change the developer did not make. Restart by hand when a secret rotates.
 const [command, args] =
 	secretsMode === "infisical"
-		? ["infisical", ["run", "--env=dev", "--path=/app", "--watch", "--", ...serverCommand]]
+		? ["infisical", ["run", "--env=dev", "--path=/app", "--", ...serverCommand]]
 		: [serverCommand[0], serverCommand.slice(1)];
 const child = spawn(command, args, {
 	env: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,57 @@
+import type { Plugin } from "vite";
 import { defineConfig, lazyPlugins } from "vite-plus";
 import {
 	assertRequiredPostHogBuildEnv,
 	createPostHogBuildPlugin,
 } from "#/integrations/posthog/build";
+
+const DECORATOR_BABEL_PLUGIN_NAME = "@rolldown/plugin-babel";
+// A decorator is always the first thing on its line, after indentation. The
+// filter this replaces is the bare substring "@", which also matches every
+// `@scoped/package` import specifier and every `@param` in a JSDoc block.
+const DECORATOR_PATTERN = /^[ \t]*@[A-Za-z_$]/m;
+
+/**
+ * `agents()` returns `[turndownStub, skillsImport, decoratorBabelPass]`. That
+ * last plugin runs `@babel/core` — with no cross-edit cache — on every file whose
+ * source contains an `@`, which is 237 of the 738 files under `src/`. Exactly one
+ * of them declares a decorator. Swap it for the same transform filtered on an
+ * actual decorator so the other 236 stop paying for Babel on every edit.
+ */
+async function withNarrowedDecoratorFilter(
+	babel: (typeof import("@rolldown/plugin-babel"))["default"],
+	agentsPlugins: ReturnType<(typeof import("agents/vite"))["default"]>,
+) {
+	// agents() is typed as returning Plugin[], but it builds the Babel pass with a
+	// factory that returns a promise, so one element is genuinely pending.
+	const resolved = await Promise.all(
+		(agentsPlugins as (Plugin | Promise<Plugin>)[]).map((plugin) => Promise.resolve(plugin)),
+	);
+	const withoutDecoratorPass = resolved.filter(
+		(plugin) => plugin.name !== DECORATOR_BABEL_PLUGIN_NAME,
+	);
+
+	if (withoutDecoratorPass.length === resolved.length) {
+		throw new Error(
+			`Expected agents() to include a "${DECORATOR_BABEL_PLUGIN_NAME}" plugin to replace, but found none. ` +
+				"The agents package changed shape — re-check how it lowers decorators before deleting this guard.",
+		);
+	}
+
+	return [
+		...withoutDecoratorPass,
+		await babel({
+			presets: [
+				{
+					preset: () => ({
+						plugins: [["@babel/plugin-proposal-decorators", { version: "2023-11" }]],
+					}),
+					rolldown: { filter: { code: DECORATOR_PATTERN } },
+				},
+			],
+		}),
+	];
+}
 
 export default defineConfig(({ command }) => {
 	assertRequiredPostHogBuildEnv(command);
@@ -10,6 +59,11 @@ export default defineConfig(({ command }) => {
 	const shouldGenerateSourceMaps =
 		command === "build" &&
 		(cloudflareEnvironment === "staging" || cloudflareEnvironment === "production");
+	// Set by scripts/run-local-dev.mjs. "lite" is the default dev server: no remote
+	// bindings (so nothing bills) and no containers (so no Docker build on start).
+	// `pnpm dev --full` opts back into the production-shaped path. Only applies to
+	// `vp dev` — builds keep the plugin defaults.
+	const isLiteDevServer = command === "serve" && process.env.THINKEX_DEV_PROFILE?.trim() !== "full";
 
 	return {
 		resolve: { tsconfigPaths: true },
@@ -143,8 +197,23 @@ export default defineConfig(({ command }) => {
 					: []),
 				...(command === "build" ? [createPostHogBuildPlugin(posthog)].filter(Boolean) : []),
 				contentCollections(),
-				agents(),
-				cloudflare({ viteEnvironment: { name: "ssr" } }),
+				...(await withNarrowedDecoratorFilter(babel, agents())),
+				cloudflare({
+					viteEnvironment: { name: "ssr" },
+					// AI, BROWSER, EMAIL and the WORKSPACE_FILES R2 bucket are `remote: true`
+					// in wrangler.jsonc, which proxies them to the real account and bills
+					// standard operational costs — and delivers real invite email.
+					...(isLiteDevServer ? { remoteBindings: false as const } : {}),
+					// Skips the getDockerPath/resolveDockerHost branch entirely, so the three
+					// container images are neither built nor started.
+					...(isLiteDevServer
+						? {
+								config: (workerConfig) => {
+									workerConfig.dev.enable_containers = false;
+								},
+							}
+						: {}),
+				}),
 				tailwindcss(),
 				tanstackStart({
 					importProtection: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
 				resolve: { tsconfigPaths: true },
 				test: {
 					name: "node",
-					include: ["src/**/*.test.{ts,tsx}"],
+					include: ["src/**/*.test.{ts,tsx}", "scripts/**/*.test.mjs"],
 					exclude: ["src/**/*.worker.test.ts"],
 					environment: "node",
 				},


### PR DESCRIPTION
## Why

`pnpm dev` started a production-shaped environment. Four Cloudflare bindings (`AI`, `BROWSER`, `EMAIL`, and the `WORKSPACE_FILES` R2 bucket pointed at the real staging bucket) were `remote: true`, so ordinary local development proxied to the real account — including delivering **real invite email to real recipients**. On top of that, every start built three container images through Docker, and a decorator Babel pass ran over 237 of the 738 files under `src/`.

None of that was a bug; it was the default configuration doing what it said. This PR makes the cheap path the default and puts the production-shaped one behind an explicit opt-in.

## What changed

| Lever | How |
| --- | --- |
| Remote bindings off | `cloudflare({ remoteBindings: false })` for `vp dev` only — builds keep plugin defaults |
| Containers off | `dev.enable_containers: false` through the plugin's `config` customizer, so no `wrangler.jsonc` duplication |
| Decorator Babel narrowed | filter goes from the bare substring `"@"` to `/^[ \t]*@[A-Za-z_$]/m` |
| No respawn on secret change | `--watch` dropped from the Infisical wrapper (Infisical itself kept) |
| Trace store off | `X_LOCAL_OBSERVABILITY=false` |

`pnpm dev:full` (or `--full`, or `THINKEX_DEV_PROFILE=full`) restores the previous behaviour. Both profiles print a one-line banner saying what the session will and will not do.

Also adds `pnpm dev:clean` for local artifacts that nothing prunes automatically.

## Results

Measured on an M-series laptop with warm caches, baseline taken by stashing `vite.config.ts` and re-running with warm-up boots so dep re-optimization did not pollute the numbers.

| | Before | After |
| --- | --- | --- |
| Dev server ready | 17.3–17.7 s | **10.1–10.3 s** (−42%) |
| First request (SSR) | 3.35–3.62 s | 2.85 s |
| `pnpm build:app` | 10.7–10.9 s | 9.9–10.4 s |

The larger effect is probably on parallel Conductor worktrees: each one used to build container images through the single shared Docker daemon, so concurrent workspaces queued behind each other. **That is reasoning from per-session costs, not measured** — I ran one server at a time.

## Verification

- `pnpm verify` green: 403 tests / 98 files, no lint, type or format issues, both builds succeed
- Full `pnpm serve:dev` boot serves `/` with 200. Docker daemon was running (29.4.0) and **no containers started**; `.wrangler/state/v3/do` was written during the session while `observability/` was not — so both levers demonstrably fired rather than coincidentally not firing
- Production build emits no unlowered decorators and does include the Babel decorator runtime helpers
- `pnpm dev:clean` database guards exercised against a live connection before running for real

## Scope notes for reviewers

- **This does not make local development free.** Only Cloudflare *bindings* are affected. AI chat reaches the model through the Vercel AI Gateway over plain HTTPS (`createGateway`), and Firecrawl and LlamaParse are likewise direct API calls gated only by key presence — no profile changes them. The docs say this explicitly, and the dev banner repeats it.
- **Three features need `pnpm dev:full`**: code execution (`compute` tool), Office→PDF conversion, and PDF text extraction. They error rather than degrade quietly. Database, auth, workspaces, documents and file upload/download all work normally in lite — Postgres is a host service, never a container.
- The decorator swap is **guarded**: if `agents()` stops returning a `@rolldown/plugin-babel` entry, config resolution throws rather than silently reverting to the wide filter.
- `pnpm dev:clean` never touches `.wrangler/state/v3/{do,r2}`, which hold local workspaces, documents and uploads. Databases and Docker build cache are opt-in flags.

## Deliberately not included

Worker cold start (~664 ms) — the checked-in CPU profile is stale and should be regenerated first. Disabling the React Compiler in dev — biggest remaining per-edit number, but it makes local rendering differ from production and there is no measurement to justify the trade yet.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789355816&installation_model_id=425282&pr_number=786&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F786&signature=d04809a555409c3eaa0ba37c45f392e4a85d9e66b32d1b74228d09aa54a80203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lite and full local development profiles, with clearer service, cost, and Docker behavior.
  * Added commands to clean up local traces, caches, images, and unused development databases safely.
* **Documentation**
  * Expanded local development guidance covering profiles, bindings, remote-only features, billing, email, storage cleanup, and validation.
* **Bug Fixes**
  * Improved local development startup behavior and prevented unnecessary restarts when secrets change.
  * Improved development compatibility for decorator-based functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->