### PR TITLE
feat(ai-chat): close the error and abort edge-case gaps

### DIFF
--- a/src/features/workspaces/ai/ai-thread.ts
+++ b/src/features/workspaces/ai/ai-thread.ts
@@ -248,9 +248,23 @@ export function createAIThreadClass(getUserAIStore: () => typeof UserAIStore) {
 				thread,
 				tools: activeTools,
 			});
+			// A regeneration must not see the answer it replaces: Think assembles
+			// the prompt from the stored path, whose stale assistant tail would
+			// turn the turn into a "continue" (cloudflare/agents#2028 — remove
+			// once #2038 ships). Continuations keep their in-flight assistant.
+			let turnMessages = ctx.messages;
+			if (!ctx.continuation && ctx.body?.regenerate === true) {
+				let end = turnMessages.length;
+				while (end > 0 && turnMessages[end - 1]?.role !== "user") {
+					end -= 1;
+				}
+				if (end > 0) {
+					turnMessages = turnMessages.slice(0, end);
+				}
+			}
 			const messages = await resolveChatAttachmentModelMessages({
 				bucket: this.env.WORKSPACE_FILES,
-				messages: ctx.messages,
+				messages: turnMessages,
 				threadId: thread.id,
 				userId: thread.userId,
 				workspaceId: thread.workspaceId,

--- a/src/features/workspaces/components/AiChatPanel.tsx
+++ b/src/features/workspaces/components/AiChatPanel.tsx
@@ -70,6 +70,7 @@ function AiChatPanelLayout({ context }: AiChatPanelProps) {
 					modelId={modelId}
 					onModelChange={onModelChange}
 					onRecoveringChange={setActiveThreadIsRecovering}
+					onStartNewChat={onNewChat}
 					threadSummary={threads.find((thread) => thread.id === activeThreadId)}
 					threadId={activeThreadId}
 				/>

--- a/src/features/workspaces/components/AiChatPanel.tsx
+++ b/src/features/workspaces/components/AiChatPanel.tsx
@@ -29,6 +29,7 @@ function AiChatPanelLayout({ context }: AiChatPanelProps) {
 	const [activeThreadIsRecovering, setActiveThreadIsRecovering] = useState(false);
 	const {
 		activeThreadId,
+		threadViewKey,
 		isCreatingThread,
 		isLoading,
 		isMaximized,
@@ -64,7 +65,7 @@ function AiChatPanelLayout({ context }: AiChatPanelProps) {
 				threads={threads}
 			/>
 
-			<Suspense key={activeThreadId} fallback={<AiChatPanelLoading />}>
+			<Suspense key={threadViewKey} fallback={<AiChatPanelLoading />}>
 				<AiChatThreadView
 					context={context}
 					modelId={modelId}

--- a/src/features/workspaces/components/ai-chat/AiChatMessageList.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatMessageList.tsx
@@ -1,5 +1,5 @@
 import type { ChatErrorClassification, ChatErrorContext } from "@cloudflare/think";
-import { AlertCircle, Plus, RotateCcw } from "lucide-react";
+import { AlertCircle, Plus, RefreshCw, RotateCcw } from "lucide-react";
 import { LazyMotion, domAnimation, m, useReducedMotion } from "motion/react";
 import type { HTMLMotionProps } from "motion/react";
 import type { ReactNode } from "react";
@@ -65,6 +65,7 @@ export type AiChatAssistantErrorState =
 	| {
 			classification?: ChatErrorClassification | null;
 			kind: "assistant";
+			message?: string | null;
 			stage?: ChatErrorContext["stage"] | null;
 	  }
 	| {
@@ -307,6 +308,10 @@ function AiChatAssistantError({
 		errorState.kind === "assistant" &&
 		errorState.classification === "context_overflow" &&
 		Boolean(onStartNewChat);
+	// Classified errors get curated copy; for the rest the stored server
+	// message (usage limits, recovery reasons) beats an unexplained failure.
+	const errorDetail =
+		errorState.kind === "assistant" && !errorState.classification ? errorState.message : null;
 
 	return (
 		<Message>
@@ -318,13 +323,32 @@ function AiChatAssistantError({
 								className="mt-0.5 size-4 shrink-0 text-muted-foreground"
 								aria-hidden="true"
 							/>
-							<p className="text-sm">
-								{getChatErrorMessage({
-									errorState,
-									hasAssistantContent,
-								})}
-							</p>
+							<div className="flex flex-col gap-1">
+								<p className="text-sm">
+									{getChatErrorMessage({
+										errorState,
+										hasAssistantContent,
+									})}
+								</p>
+								{errorDetail ? (
+									<p className="text-muted-foreground text-xs">{errorDetail}</p>
+								) : null}
+							</div>
 						</div>
+						{errorState.kind === "connection" ? (
+							<Button
+								type="button"
+								variant="outline"
+								size="xs"
+								className="gap-1.5"
+								onClick={() => {
+									window.location.reload();
+								}}
+							>
+								<RefreshCw className="size-3" />
+								Refresh page
+							</Button>
+						) : null}
 						{canRetry || canStartNewChat ? (
 							<div className="flex items-center gap-2">
 								{canRetry ? (
@@ -468,7 +492,7 @@ function getChatErrorMessage({
 	hasAssistantContent: boolean;
 }) {
 	if (errorState.kind === "connection") {
-		return "The chat connection closed before the response could finish. Refresh the page to reconnect.";
+		return "The chat connection closed before the response could finish.";
 	}
 
 	if (errorState.kind === "aborted") {

--- a/src/features/workspaces/components/ai-chat/AiChatMessageList.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatMessageList.tsx
@@ -1,5 +1,5 @@
 import type { ChatErrorClassification, ChatErrorContext } from "@cloudflare/think";
-import { AlertCircle, RotateCcw } from "lucide-react";
+import { AlertCircle, Plus, RotateCcw } from "lucide-react";
 import { LazyMotion, domAnimation, m, useReducedMotion } from "motion/react";
 import type { HTMLMotionProps } from "motion/react";
 import type { ReactNode } from "react";
@@ -96,6 +96,7 @@ interface AiChatMessageListProps {
 	assistantError?: AiChatAssistantErrorState | null;
 	messages: AiChatMessage[];
 	onRegenerateLastResponse?: () => void;
+	onStartNewChat?: () => void;
 	presentation: AiChatPresentation;
 	sentMessageAnimationId?: string | null;
 	workspaceId: string;
@@ -105,6 +106,7 @@ export default function AiChatMessageList({
 	assistantError,
 	messages,
 	onRegenerateLastResponse,
+	onStartNewChat,
 	presentation,
 	sentMessageAnimationId,
 	workspaceId,
@@ -167,6 +169,7 @@ export default function AiChatMessageList({
 											row={row}
 											status={status}
 											onRegenerateLastResponse={onRegenerateLastResponse}
+											onStartNewChat={onStartNewChat}
 										/>
 									</AiChatMessageScrollerItem>
 								))}
@@ -236,6 +239,7 @@ function AiChatListRowView({
 	hasAssistantContent,
 	lastAssistantMessageId,
 	onRegenerateLastResponse,
+	onStartNewChat,
 	row,
 	status,
 }: {
@@ -243,6 +247,7 @@ function AiChatListRowView({
 	hasAssistantContent: boolean;
 	lastAssistantMessageId: string | undefined;
 	onRegenerateLastResponse?: () => void;
+	onStartNewChat?: () => void;
 	row: AiChatListRow;
 	status: AiChatPresentation["status"];
 }) {
@@ -262,6 +267,7 @@ function AiChatListRowView({
 					errorState={row.errorState}
 					hasAssistantContent={hasAssistantContent}
 					onRetry={onRegenerateLastResponse}
+					onStartNewChat={onStartNewChat}
 				/>
 			</AiChatTranscriptRail>
 		);
@@ -287,12 +293,21 @@ function AiChatAssistantError({
 	errorState,
 	hasAssistantContent,
 	onRetry,
+	onStartNewChat,
 }: {
 	canRetry: boolean;
 	errorState: AiChatAssistantErrorState;
 	hasAssistantContent: boolean;
 	onRetry?: () => void;
+	onStartNewChat?: () => void;
 }) {
+	// An overflowed chat can rarely be retried into success, so the escape
+	// hatch the copy suggests gets its own action.
+	const canStartNewChat =
+		errorState.kind === "assistant" &&
+		errorState.classification === "context_overflow" &&
+		Boolean(onStartNewChat);
+
 	return (
 		<Message>
 			<MessageContent>
@@ -310,17 +325,33 @@ function AiChatAssistantError({
 								})}
 							</p>
 						</div>
-						{canRetry ? (
-							<Button
-								type="button"
-								variant="outline"
-								size="xs"
-								className="gap-1.5"
-								onClick={onRetry}
-							>
-								<RotateCcw className="size-3" />
-								Try again
-							</Button>
+						{canRetry || canStartNewChat ? (
+							<div className="flex items-center gap-2">
+								{canRetry ? (
+									<Button
+										type="button"
+										variant="outline"
+										size="xs"
+										className="gap-1.5"
+										onClick={onRetry}
+									>
+										<RotateCcw className="size-3" />
+										Try again
+									</Button>
+								) : null}
+								{canStartNewChat ? (
+									<Button
+										type="button"
+										variant="outline"
+										size="xs"
+										className="gap-1.5"
+										onClick={onStartNewChat}
+									>
+										<Plus className="size-3" />
+										Start new chat
+									</Button>
+								) : null}
+							</div>
 						) : null}
 					</BubbleContent>
 				</Bubble>

--- a/src/features/workspaces/components/ai-chat/AiChatMessageList.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatMessageList.tsx
@@ -68,6 +68,9 @@ export type AiChatAssistantErrorState =
 			stage?: ChatErrorContext["stage"] | null;
 	  }
 	| {
+			kind: "aborted";
+	  }
+	| {
 			kind: "connection";
 	  };
 
@@ -435,6 +438,10 @@ function getChatErrorMessage({
 }) {
 	if (errorState.kind === "connection") {
 		return "The chat connection closed before the response could finish. Refresh the page to reconnect.";
+	}
+
+	if (errorState.kind === "aborted") {
+		return "The response was stopped before it started.";
 	}
 
 	if (errorState.classification === "context_overflow") {

--- a/src/features/workspaces/components/ai-chat/AiChatThreadView.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatThreadView.tsx
@@ -69,6 +69,7 @@ export default function AiChatThreadView({
 	const assistantError = deriveAiChatAssistantErrorState({
 		chatStatus: presentation.status,
 		hasConnectionError: Boolean(connectionError),
+		lastMessageRole: messages.at(-1)?.role,
 		threadSummary,
 	});
 	const sendMessage = (message: PromptInputMessage, clearDraft = true) => {

--- a/src/features/workspaces/components/ai-chat/AiChatThreadView.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatThreadView.tsx
@@ -8,6 +8,7 @@ import AiChatPromptInput from "#/features/workspaces/components/ai-chat/AiChatPr
 import { deriveAiChatAssistantErrorState } from "#/features/workspaces/components/ai-chat/ai-chat-error-state";
 import { aiChatComposerRailClassName } from "#/features/workspaces/components/ai-chat/ai-chat-layout";
 import type {
+	AiChatMessage,
 	AiChatModelId,
 	AiChatSendMessage,
 } from "#/features/workspaces/components/ai-chat/types";
@@ -25,6 +26,7 @@ export default function AiChatThreadView({
 	modelId,
 	onModelChange,
 	onRecoveringChange,
+	onStartNewChat,
 	threadSummary,
 	threadId,
 }: {
@@ -32,6 +34,7 @@ export default function AiChatThreadView({
 	modelId: AiChatModelId;
 	onModelChange: (modelId: AiChatModelId) => void;
 	onRecoveringChange?: (isRecovering: boolean) => void;
+	onStartNewChat?: (carryPrompt?: string) => void;
 	threadSummary?: AIThreadSummary;
 	threadId: string;
 }) {
@@ -125,6 +128,9 @@ export default function AiChatThreadView({
 				sentMessageAnimationId={sentMessageAnimationId}
 				workspaceId={context.workspaceId}
 				onRegenerateLastResponse={regenerate}
+				onStartNewChat={
+					onStartNewChat ? () => onStartNewChat(getLastUserMessageText(messages)) : undefined
+				}
 			/>
 
 			<div className="px-3 pb-3">
@@ -145,6 +151,18 @@ export default function AiChatThreadView({
 			</div>
 		</div>
 	);
+}
+
+// Carries the failed prompt into a fresh thread as text only — attachments
+// stay behind with the old thread.
+function getLastUserMessageText(messages: AiChatMessage[]) {
+	const lastUserMessage = [...messages].reverse().find((message) => message.role === "user");
+	const text = lastUserMessage?.parts
+		.filter((part) => part.type === "text")
+		.map((part) => part.text)
+		.join("\n\n");
+
+	return text || undefined;
 }
 
 function getChatMessageFromPrompt(

--- a/src/features/workspaces/components/ai-chat/AiChatThreadView.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatThreadView.tsx
@@ -8,7 +8,6 @@ import AiChatPromptInput from "#/features/workspaces/components/ai-chat/AiChatPr
 import { deriveAiChatAssistantErrorState } from "#/features/workspaces/components/ai-chat/ai-chat-error-state";
 import { aiChatComposerRailClassName } from "#/features/workspaces/components/ai-chat/ai-chat-layout";
 import type {
-	AiChatMessage,
 	AiChatModelId,
 	AiChatSendMessage,
 } from "#/features/workspaces/components/ai-chat/types";
@@ -34,7 +33,7 @@ export default function AiChatThreadView({
 	modelId: AiChatModelId;
 	onModelChange: (modelId: AiChatModelId) => void;
 	onRecoveringChange?: (isRecovering: boolean) => void;
-	onStartNewChat?: (carryPrompt?: string) => void;
+	onStartNewChat?: () => void;
 	threadSummary?: AIThreadSummary;
 	threadId: string;
 }) {
@@ -128,9 +127,7 @@ export default function AiChatThreadView({
 				sentMessageAnimationId={sentMessageAnimationId}
 				workspaceId={context.workspaceId}
 				onRegenerateLastResponse={regenerate}
-				onStartNewChat={
-					onStartNewChat ? () => onStartNewChat(getLastUserMessageText(messages)) : undefined
-				}
+				onStartNewChat={onStartNewChat}
 			/>
 
 			<div className="px-3 pb-3">
@@ -151,18 +148,6 @@ export default function AiChatThreadView({
 			</div>
 		</div>
 	);
-}
-
-// Carries the failed prompt into a fresh thread as text only — attachments
-// stay behind with the old thread.
-function getLastUserMessageText(messages: AiChatMessage[]) {
-	const lastUserMessage = [...messages].reverse().find((message) => message.role === "user");
-	const text = lastUserMessage?.parts
-		.filter((part) => part.type === "text")
-		.map((part) => part.text)
-		.join("\n\n");
-
-	return text || undefined;
 }
 
 function getChatMessageFromPrompt(

--- a/src/features/workspaces/components/ai-chat/ai-chat-display-state.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-display-state.ts
@@ -1,6 +1,5 @@
 import { isToolUIPart } from "ai";
 
-import { WORKSPACE_REFERENCES_DATA_PART_TYPE } from "#/features/workspaces/ai/workspace-references";
 import type {
 	AiChatMessage,
 	AiChatMessagePart,
@@ -203,10 +202,6 @@ export function getDisplayableParts(message: AiChatMessage): AiChatRenderablePar
 }
 
 export function isDisplayableMessagePart(part: AiChatMessagePart): boolean {
-	if (part.type === WORKSPACE_REFERENCES_DATA_PART_TYPE) {
-		return false;
-	}
-
 	if (part.type === "text") {
 		return part.text.length > 0 || part.state === "streaming";
 	}
@@ -219,16 +214,10 @@ export function isDisplayableMessagePart(part: AiChatMessagePart): boolean {
 		return isVisibleToolPart(part);
 	}
 
-	if (
-		part.type === "file" ||
-		part.type === "source-url" ||
-		part.type === "source-document" ||
-		part.type.startsWith("data-")
-	) {
-		return true;
-	}
-
-	return false;
+	// Deliberately excludes `data-*` parts: old transcripts can carry data parts
+	// from retired features, and counting one as displayable makes a message
+	// render as a blank bubble instead of falling through to "no response".
+	return part.type === "file" || part.type === "source-url" || part.type === "source-document";
 }
 
 export function getToolActivityForPart(

--- a/src/features/workspaces/components/ai-chat/ai-chat-error-state.test.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-error-state.test.ts
@@ -19,6 +19,7 @@ describe("AI chat error state", () => {
 				hasConnectionError: false,
 				threadSummary: {
 					lastErrorClassification: "context_overflow",
+					lastErrorMessage: "Context window exceeded",
 					lastErrorStage: "recovery",
 					lastRunResult: "error",
 				},
@@ -26,6 +27,7 @@ describe("AI chat error state", () => {
 		).toEqual({
 			classification: "context_overflow",
 			kind: "assistant",
+			message: "Context window exceeded",
 			stage: "recovery",
 		});
 	});
@@ -38,6 +40,7 @@ describe("AI chat error state", () => {
 				lastMessageRole: "user",
 				threadSummary: {
 					lastErrorClassification: null,
+					lastErrorMessage: null,
 					lastErrorStage: null,
 					lastRunResult: "aborted",
 				},
@@ -53,6 +56,7 @@ describe("AI chat error state", () => {
 				lastMessageRole: "assistant",
 				threadSummary: {
 					lastErrorClassification: null,
+					lastErrorMessage: null,
 					lastErrorStage: null,
 					lastRunResult: "aborted",
 				},

--- a/src/features/workspaces/components/ai-chat/ai-chat-error-state.test.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-error-state.test.ts
@@ -30,6 +30,36 @@ describe("AI chat error state", () => {
 		});
 	});
 
+	it("flags a run stopped before the first token so the send visibly ended", () => {
+		expect(
+			deriveAiChatAssistantErrorState({
+				chatStatus: "ready",
+				hasConnectionError: false,
+				lastMessageRole: "user",
+				threadSummary: {
+					lastErrorClassification: null,
+					lastErrorStage: null,
+					lastRunResult: "aborted",
+				},
+			}),
+		).toEqual({ kind: "aborted" });
+	});
+
+	it("stays quiet for a mid-stream stop that kept its partial reply", () => {
+		expect(
+			deriveAiChatAssistantErrorState({
+				chatStatus: "ready",
+				hasConnectionError: false,
+				lastMessageRole: "assistant",
+				threadSummary: {
+					lastErrorClassification: null,
+					lastErrorStage: null,
+					lastRunResult: "aborted",
+				},
+			}),
+		).toBeNull();
+	});
+
 	it("keeps a terminal connection error distinct", () => {
 		expect(
 			deriveAiChatAssistantErrorState({

--- a/src/features/workspaces/components/ai-chat/ai-chat-error-state.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-error-state.ts
@@ -4,7 +4,7 @@ import type { AiChatMessage, AiChatStatus } from "#/features/workspaces/componen
 
 type AIThreadErrorSummary = Pick<
 	AIThreadSummary,
-	"lastErrorClassification" | "lastErrorStage" | "lastRunResult"
+	"lastErrorClassification" | "lastErrorMessage" | "lastErrorStage" | "lastRunResult"
 >;
 
 export function deriveAiChatAssistantErrorState(input: {
@@ -31,6 +31,7 @@ export function deriveAiChatAssistantErrorState(input: {
 			...(threadError
 				? {
 						classification: threadError.lastErrorClassification,
+						message: threadError.lastErrorMessage,
 						stage: threadError.lastErrorStage,
 					}
 				: {}),

--- a/src/features/workspaces/components/ai-chat/ai-chat-error-state.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-error-state.ts
@@ -1,6 +1,6 @@
 import type { AIThreadSummary } from "#/features/workspaces/ai/user-ai-agents";
 import type { AiChatAssistantErrorState } from "#/features/workspaces/components/ai-chat/AiChatMessageList";
-import type { AiChatStatus } from "#/features/workspaces/components/ai-chat/types";
+import type { AiChatMessage, AiChatStatus } from "#/features/workspaces/components/ai-chat/types";
 
 type AIThreadErrorSummary = Pick<
 	AIThreadSummary,
@@ -10,6 +10,7 @@ type AIThreadErrorSummary = Pick<
 export function deriveAiChatAssistantErrorState(input: {
 	chatStatus: AiChatStatus;
 	hasConnectionError: boolean;
+	lastMessageRole?: AiChatMessage["role"];
 	threadSummary?: AIThreadErrorSummary;
 }): AiChatAssistantErrorState | null {
 	if (input.hasConnectionError) {
@@ -34,6 +35,15 @@ export function deriveAiChatAssistantErrorState(input: {
 					}
 				: {}),
 			kind: "assistant",
+		};
+	}
+
+	// A run stopped before the first token leaves the user message as the tail
+	// with nothing after it — without this row there is no sign the send ended.
+	// A mid-stream stop keeps its partial assistant tail, so no row is needed.
+	if (input.threadSummary?.lastRunResult === "aborted" && input.lastMessageRole === "user") {
+		return {
+			kind: "aborted",
 		};
 	}
 

--- a/src/features/workspaces/components/ai-chat/useAiChatPanelController.ts
+++ b/src/features/workspaces/components/ai-chat/useAiChatPanelController.ts
@@ -76,9 +76,8 @@ export function useAiChatPanelController({ workspaceId }: UseAiChatPanelControll
 		try {
 			await deleteThread(threadId);
 		} catch (error) {
-			if (wasActive) {
-				selectThread(threadId);
-			}
+			// No selection restore: the thread is still in the list, and the user
+			// may have moved on during the in-flight delete.
 			toast.error(getErrorMessage(error, "Unable to delete chat right now."));
 			return;
 		}

--- a/src/features/workspaces/components/ai-chat/useAiChatPanelController.ts
+++ b/src/features/workspaces/components/ai-chat/useAiChatPanelController.ts
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 import { getDefaultWorkspaceThreadId } from "#/features/workspaces/ai/ai-thread-identity";
 import type { AiChatModelId } from "#/features/workspaces/components/ai-chat/types";
 import { useWorkspaceAiChatThreads } from "#/features/workspaces/components/ai-chat/useWorkspaceAiChatThreads";
+import { evictWorkspaceAiTranscript } from "#/features/workspaces/components/ai-chat/useWorkspaceAiChat";
 import {
 	useWorkspaceActiveAiChatThreadId,
 	useWorkspaceAiChatModelId,
@@ -28,6 +29,7 @@ export function useAiChatPanelController({ workspaceId }: UseAiChatPanelControll
 	const setActiveAiChatThread = useWorkspaceUiStore((state) => state.setActiveAiChatThread);
 	const setAiChatModel = useWorkspaceUiStore((state) => state.setAiChatModel);
 	const [markingViewedThreadIds] = useState(() => new Set<string>());
+	const [threadViewEpoch, setThreadViewEpoch] = useState(0);
 	const {
 		createThread,
 		deleteThread,
@@ -59,19 +61,33 @@ export function useAiChatPanelController({ workspaceId }: UseAiChatPanelControll
 	};
 
 	const handleDeleteThread = async (threadId: string) => {
+		// The thread's socket lives on the directory DO, so deleting the thread
+		// never closes it — a still-mounted view keeps a zombie transcript whose
+		// next frame resurrects the deleted thread (cloudflare/agents#2003).
+		// Switch away first; when nothing survives, remount the view after the
+		// delete so it reconnects to a fresh default thread.
+		const wasActive = resolvedActiveThreadId === threadId;
+		const survivorId = wasActive ? threads.find((thread) => thread.id !== threadId)?.id : undefined;
+
+		if (wasActive) {
+			selectThread(survivorId);
+		}
+
 		try {
 			await deleteThread(threadId);
-			toast.success("Chat deleted.");
 		} catch (error) {
+			if (wasActive) {
+				selectThread(threadId);
+			}
 			toast.error(getErrorMessage(error, "Unable to delete chat right now."));
 			return;
 		}
 
-		if (resolvedActiveThreadId !== threadId) {
-			return;
+		evictWorkspaceAiTranscript(threadId);
+		toast.success("Chat deleted.");
+		if (wasActive && !survivorId) {
+			setThreadViewEpoch((epoch) => epoch + 1);
 		}
-
-		selectThread(undefined);
 	};
 
 	useEffect(() => {
@@ -108,6 +124,7 @@ export function useAiChatPanelController({ workspaceId }: UseAiChatPanelControll
 
 	return {
 		activeThreadId: resolvedActiveThreadId,
+		threadViewKey: `${resolvedActiveThreadId}:${threadViewEpoch}`,
 		isCreatingThread,
 		isLoading: !areThreadsReady,
 		isMaximized,

--- a/src/features/workspaces/components/ai-chat/useAiChatPanelController.ts
+++ b/src/features/workspaces/components/ai-chat/useAiChatPanelController.ts
@@ -9,6 +9,7 @@ import {
 	useWorkspaceAiChatSurfaceMode,
 	useWorkspaceUiStore,
 } from "#/features/workspaces/state/workspace-ui-store";
+import { useWorkspaceAiComposerDraftStore } from "#/features/workspaces/state/workspace-ai-composer-draft-store";
 import { getErrorMessage } from "#/lib/error-message";
 
 type UseAiChatPanelControllerInput = {
@@ -45,13 +46,16 @@ export function useAiChatPanelController({ workspaceId }: UseAiChatPanelControll
 		setActiveAiChatThread(workspaceId, threadId);
 	};
 
-	const handleNewChat = async () => {
+	const handleNewChat = async (carryPrompt?: string) => {
 		if (isCreatingThread) {
 			return;
 		}
 
 		try {
 			const thread = await createThread();
+			if (carryPrompt) {
+				useWorkspaceAiComposerDraftStore.getState().queueDirectPrompt(thread.id, carryPrompt);
+			}
 			selectThread(thread.id);
 		} catch (error) {
 			toast.error(getErrorMessage(error, "Unable to start a new chat right now."));
@@ -118,7 +122,7 @@ export function useAiChatPanelController({ workspaceId }: UseAiChatPanelControll
 		},
 		onMaximize: () => setChatSurfaceMode(workspaceId, "fullscreen"),
 		onModelChange: (nextModelId: AiChatModelId) => setAiChatModel(nextModelId),
-		onNewChat: () => void handleNewChat(),
+		onNewChat: (carryPrompt?: string) => void handleNewChat(carryPrompt),
 		onRestore: () => setChatSurfaceMode(workspaceId, "docked"),
 		onSelectThread: (threadId: string) => selectThread(threadId),
 		threads: threads.map((thread) =>

--- a/src/features/workspaces/components/ai-chat/useAiChatPanelController.ts
+++ b/src/features/workspaces/components/ai-chat/useAiChatPanelController.ts
@@ -54,7 +54,7 @@ export function useAiChatPanelController({ workspaceId }: UseAiChatPanelControll
 			const thread = await createThread();
 			selectThread(thread.id);
 		} catch (error) {
-			console.warn("[AiChatPanel] Failed to create chat thread", error);
+			toast.error(getErrorMessage(error, "Unable to start a new chat right now."));
 		}
 	};
 

--- a/src/features/workspaces/components/ai-chat/useAiChatPanelController.ts
+++ b/src/features/workspaces/components/ai-chat/useAiChatPanelController.ts
@@ -9,7 +9,6 @@ import {
 	useWorkspaceAiChatSurfaceMode,
 	useWorkspaceUiStore,
 } from "#/features/workspaces/state/workspace-ui-store";
-import { useWorkspaceAiComposerDraftStore } from "#/features/workspaces/state/workspace-ai-composer-draft-store";
 import { getErrorMessage } from "#/lib/error-message";
 
 type UseAiChatPanelControllerInput = {
@@ -46,16 +45,13 @@ export function useAiChatPanelController({ workspaceId }: UseAiChatPanelControll
 		setActiveAiChatThread(workspaceId, threadId);
 	};
 
-	const handleNewChat = async (carryPrompt?: string) => {
+	const handleNewChat = async () => {
 		if (isCreatingThread) {
 			return;
 		}
 
 		try {
 			const thread = await createThread();
-			if (carryPrompt) {
-				useWorkspaceAiComposerDraftStore.getState().queueDirectPrompt(thread.id, carryPrompt);
-			}
 			selectThread(thread.id);
 		} catch (error) {
 			toast.error(getErrorMessage(error, "Unable to start a new chat right now."));
@@ -122,7 +118,7 @@ export function useAiChatPanelController({ workspaceId }: UseAiChatPanelControll
 		},
 		onMaximize: () => setChatSurfaceMode(workspaceId, "fullscreen"),
 		onModelChange: (nextModelId: AiChatModelId) => setAiChatModel(nextModelId),
-		onNewChat: (carryPrompt?: string) => void handleNewChat(carryPrompt),
+		onNewChat: () => void handleNewChat(),
 		onRestore: () => setChatSurfaceMode(workspaceId, "docked"),
 		onSelectThread: (threadId: string) => selectThread(threadId),
 		threads: threads.map((thread) =>

--- a/src/features/workspaces/components/ai-chat/useWorkspaceAiChat.ts
+++ b/src/features/workspaces/components/ai-chat/useWorkspaceAiChat.ts
@@ -30,7 +30,21 @@ const AI_CHAT_RENDER_THROTTLE_MS = 100;
 // Last settled transcript per thread, so switching back renders instantly
 // instead of suspending on the /get-messages fetch. The server's connect-time
 // broadcast replaces the seed with authoritative state one round trip later.
+// Bounded: transcripts are heavy, and only recently visited threads are
+// likely to be revisited. Map iteration order gives us LRU for free.
+const TRANSCRIPT_CACHE_MAX_THREADS = 8;
 const transcriptCache = new Map<string, AiChatMessage[]>();
+
+function cacheTranscript(threadId: string, messages: AiChatMessage[]) {
+	transcriptCache.delete(threadId);
+	transcriptCache.set(threadId, messages);
+	for (const staleId of transcriptCache.keys()) {
+		if (transcriptCache.size <= TRANSCRIPT_CACHE_MAX_THREADS) {
+			break;
+		}
+		transcriptCache.delete(staleId);
+	}
+}
 
 export function evictWorkspaceAiTranscript(threadId: string) {
 	transcriptCache.delete(threadId);
@@ -99,7 +113,7 @@ export function useWorkspaceAiChat({ modelId, threadId }: UseWorkspaceAiChatOpti
 			transcriptCache.delete(threadId);
 			return;
 		}
-		transcriptCache.set(threadId, messages);
+		cacheTranscript(threadId, messages);
 	}, [messages, presentation.isBusy, status, threadId]);
 	const canStop = status === "submitted" || presentation.isBusy;
 	const isConnected = agent.identified && agent.readyState === agent.OPEN;

--- a/src/features/workspaces/components/ai-chat/useWorkspaceAiChat.ts
+++ b/src/features/workspaces/components/ai-chat/useWorkspaceAiChat.ts
@@ -1,5 +1,6 @@
 import { useAgentChat } from "@cloudflare/think/react";
 import { useAgent } from "agents/react";
+import { useEffect } from "react";
 
 import {
 	aiThreadAgentName,
@@ -26,12 +27,29 @@ interface UseWorkspaceAiChatOptions {
 
 const AI_CHAT_RENDER_THROTTLE_MS = 100;
 
+// Last settled transcript per thread, so switching back renders instantly
+// instead of suspending on the /get-messages fetch. The server's connect-time
+// broadcast replaces the seed with authoritative state one round trip later.
+const transcriptCache = new Map<string, AiChatMessage[]>();
+
+export function evictWorkspaceAiTranscript(threadId: string) {
+	transcriptCache.delete(threadId);
+}
+
+// React 19's use() unwraps a thenable synchronously when it carries
+// status/value (the tracked-thenable convention), so a cached transcript
+// renders without a Suspense fallback frame.
+function fulfilledThenable<T>(value: T): Promise<T> {
+	return Object.assign(Promise.resolve(value), { status: "fulfilled", value });
+}
+
 export function useWorkspaceAiChat({ modelId, threadId }: UseWorkspaceAiChatOptions) {
 	const agent = useAgent({
 		agent: userAIAgentName,
 		basePath: userAIBasePath,
 		sub: [{ agent: aiThreadAgentName, name: threadId }],
 	});
+	const cachedTranscript = transcriptCache.get(threadId);
 	const chat = useAgentChat<unknown, AiChatMessage>({
 		agent,
 		body: () => ({
@@ -41,6 +59,10 @@ export function useWorkspaceAiChat({ modelId, threadId }: UseWorkspaceAiChatOpti
 			analyticsConsent: hasAnalyticsConsent(),
 			sessionReplayConsent: hasExplicitSessionReplayConsent(),
 		}),
+		// No cache → the default /get-messages fetch, which also covers
+		// mid-stream reconnects (the socket deliberately sends no transcript
+		// while a stream is active).
+		getInitialMessages: cachedTranscript ? () => fulfilledThenable(cachedTranscript) : undefined,
 		throttle: AI_CHAT_RENDER_THROTTLE_MS,
 	});
 	const {
@@ -62,6 +84,19 @@ export function useWorkspaceAiChat({ modelId, threadId }: UseWorkspaceAiChatOpti
 		isStreaming,
 		isToolContinuation,
 	});
+
+	// Cache only settled transcripts: seeding a mid-stream partial risks a
+	// duplicate assistant bubble if the server's message id drifts while away.
+	useEffect(() => {
+		if (presentation.isBusy || status !== "ready") {
+			return;
+		}
+		if (messages.length === 0) {
+			transcriptCache.delete(threadId);
+			return;
+		}
+		transcriptCache.set(threadId, messages);
+	}, [messages, presentation.isBusy, status, threadId]);
 	const canStop = status === "submitted" || presentation.isBusy;
 	const isConnected = agent.identified && agent.readyState === agent.OPEN;
 	const inputStatus: AiChatStatus = connectionError

--- a/src/features/workspaces/components/ai-chat/useWorkspaceAiChat.ts
+++ b/src/features/workspaces/components/ai-chat/useWorkspaceAiChat.ts
@@ -63,6 +63,10 @@ export function useWorkspaceAiChat({ modelId, threadId }: UseWorkspaceAiChatOpti
 		// mid-stream reconnects (the socket deliberately sends no transcript
 		// while a stream is active).
 		getInitialMessages: cachedTranscript ? () => fulfilledThenable(cachedTranscript) : undefined,
+		// Think assembles the prompt from the stored path, so the server needs
+		// to know a regeneration when it sees one. See beforeTurn in ai-thread.
+		prepareSendMessagesRequest: ({ trigger }) =>
+			trigger === "regenerate-message" ? { body: { regenerate: true } } : {},
 		throttle: AI_CHAT_RENDER_THROTTLE_MS,
 	});
 	const {


### PR DESCRIPTION
## Problem

When a chat run fails or is stopped, the UI often left the user with nothing actionable — and a deep dive into the framework (cloudflare/agents + Think source, their issue tracker, and this repo's local patches) surfaced deeper problems: deleting a thread while viewing it leaves a zombie transcript that silently resurrects the thread, switching threads always suspends on a redundant fetch, and regeneration secretly behaves like "continue" instead of a fresh answer.

## Changes

**Error/abort affordances**
- **Stopped-run notice** — a run aborted before the first token shows an inline notice with Try again; mid-stream stops keep their partial reply and stay quiet.
- **Start new chat on overflow** — the context-overflow banner gets a real "Start new chat" button that creates and selects a fresh thread.
- **Stored error detail in the banner** — unclassified failures show the persisted server message (usage-limit reset date, recovery outcome) instead of burying it in a tooltip.
- **Refresh action on the connection banner**; **toast on new-chat failure**; **hide unrendered `data-*` parts** from old transcripts.

**Thread lifecycle (verified against framework source)**
- **Clean deletes** — the thread's socket lives on the directory DO, so deleting never closes it; a mounted view kept a zombie transcript whose next frame resurrected the deleted thread (upstream cloudflare/agents#2003, fix PR #2024 open). Now: switch to a surviving thread before deleting; when none survives, remount so the view reconnects to a fresh default thread.
- **Instant thread switching** — an in-session settled-transcript cache served via a pre-fulfilled thenable (React 19 unwraps synchronously — zero fallback frames); the server's connect-time broadcast replaces the seed with authoritative state. Streaming threads are never cached (resume handshake is their fast path; a seeded partial risks a duplicate bubble on id drift).

**Regeneration correctness**
- **Regenerate from the last user message** — Think assembles the prompt from the stored path, so regenerated turns carried the old answer plus a "continue your previous response" instruction (worst on retries of partial failed responses). Fixed app-side: flag regenerate turns in the body, trim the prompt to the last user message in `beforeTurn` (non-continuation only). Workaround for cloudflare/agents#2028; remove once upstream #2038 ships.

## Upstream

- Filed cloudflare/agents#2118: rejected sub-agent WS connects retry forever silently (synthetic close 1000 is non-terminal).
- Commented on #1045 with the active-stream transcript-gap constraint.
- Deliberately **not** using `getInitialMessages: null` (blank history on mid-stream connects) and **not** patching Think for regeneration (app-side workaround suffices until #2038).

## Deliberately skipped

A deploy version-skew "refresh to update" toast remains the biggest untouched gap; it needs build/deploy plumbing that deserves its own PR.

## Verification

`tsc --noEmit` clean; all 62 ai-chat vitest tests pass. Framework claims verified against `agents@0.19.0` / `@cloudflare/think@0.15.0` dist (with this repo's patches applied) and the upstream repo at main.

https://claude.ai/code/session_01S9YxTH6xRfC6bq3vbgmTQD