### PR TITLE
feat(ai-chat): restore LLM analytics via PostHog generation events

### DIFF
--- a/src/features/workspaces/ai/chat/chat-endpoint.ts
+++ b/src/features/workspaces/ai/chat/chat-endpoint.ts
@@ -90,8 +90,10 @@ export async function handleAiChatTurn(input: {
 	threadId: string;
 	userId: string;
 	body: AiChatRequestBody;
+	/** Resolved from the request's consent cookie; gates telemetry content. */
+	analyticsConsent: boolean;
 }): Promise<Response> {
-	const { env, ctx, threadId, userId, body } = input;
+	const { env, ctx, threadId, userId, body, analyticsConsent } = input;
 	const isRegenerate = body.trigger === "regenerate-message";
 
 	if (!body.workspaceId) {
@@ -233,6 +235,9 @@ export async function handleAiChatTurn(input: {
 					startedAt,
 					usage: result.totalUsage,
 					providerMetadata: await Promise.resolve(result.providerMetadata).catch(() => undefined),
+					includeContent: analyticsConsent,
+					input: [{ role: "user", content: prompt }],
+					output: [{ role: "assistant", content: result.text }],
 				});
 
 				return result.text;
@@ -291,6 +296,11 @@ export async function handleAiChatTurn(input: {
 									startedAt: titleStartedAt,
 									usage: generated.usage,
 									providerMetadata: generated.providerMetadata,
+									includeContent: analyticsConsent,
+									input: [{ role: "user", content: userMessage.parts }],
+									...(generated.title
+										? { output: [{ role: "assistant", content: generated.title }] }
+										: {}),
 								});
 								const normalized = normalizeGeneratedThreadTitle(generated.title);
 								if (!normalized) {
@@ -390,6 +400,15 @@ export async function handleAiChatTurn(input: {
 						turnErrorMessage !== undefined ? "error" : isAborted ? "interrupted" : "complete",
 					errorMessage: turnErrorMessage,
 					toolNames: assistantMessage ? toolNamesFromParts(assistantMessage.parts) : undefined,
+					includeContent: analyticsConsent,
+					// Pre-hydration parts: attachment URLs, never inlined image bytes.
+					input: context.messages.map((message) => ({
+						role: message.role,
+						content: message.parts,
+					})),
+					...(assistantMessage
+						? { output: [{ role: "assistant", content: assistantMessage.parts }] }
+						: {}),
 				});
 
 				if (clean && assistantMessage) {

--- a/src/features/workspaces/ai/chat/chat-endpoint.ts
+++ b/src/features/workspaces/ai/chat/chat-endpoint.ts
@@ -39,6 +39,10 @@ import {
 	saveMessage,
 	setThreadTitle,
 } from "#/features/workspaces/ai/chat/chat-store";
+import {
+	captureAiChatGeneration,
+	toolNamesFromParts,
+} from "#/features/workspaces/ai/chat/chat-telemetry";
 import { claimTurn } from "#/features/workspaces/ai/chat/chat-turn-lifecycle";
 import { createAiChatTools } from "#/features/workspaces/ai/chat/chat-tools";
 import { formatWorkspaceAiContextForPrompt } from "#/features/workspaces/model/workspace-ai-context-prompt";
@@ -208,6 +212,7 @@ export async function handleAiChatTurn(input: {
 			systemPrompt: systemPrompt + workspaceContext,
 			contextWindow: getWorkspaceAiChatModelById(modelId).contextWindow,
 			summarize: async (prompt) => {
+				const startedAt = Date.now();
 				const result = await generateText({
 					model: getWorkspaceAiLanguageModel(AI_CHAT_COMPACTION_MODEL_ID, env, threadId),
 					providerOptions: getWorkspaceAiGatewayProviderOptions({
@@ -216,6 +221,18 @@ export async function handleAiChatTurn(input: {
 					}),
 					prompt,
 					maxOutputTokens: COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS,
+				});
+
+				captureAiChatGeneration({
+					userId,
+					workspaceId: threadContext.workspaceId,
+					threadId,
+					traceId: turn.streamId,
+					gatewayModel: getWorkspaceAiChatModelById(AI_CHAT_COMPACTION_MODEL_ID).gatewayModel,
+					task: "chat-compaction",
+					startedAt,
+					usage: result.totalUsage,
+					providerMetadata: await Promise.resolve(result.providerMetadata).catch(() => undefined),
 				});
 
 				return result.text;
@@ -236,10 +253,13 @@ export async function handleAiChatTurn(input: {
 
 		// Resolved by execute; read in onEnd so usage lands on the persisted row.
 		let totalUsagePromise: PromiseLike<unknown> | undefined;
+		let providerMetadataPromise: PromiseLike<unknown> | undefined;
 		// Set by onError; consumed by onEnd, which is the single writer for the
 		// turn's outcome (both callbacks fire on a failed stream — treating them
 		// as exclusive double-persisted the reply).
 		let turnErrorMessage: string | undefined;
+		const turnStartedAt = Date.now();
+		let firstTokenAt: number | undefined;
 
 		const stream = createUIMessageStream({
 			generateId,
@@ -254,10 +274,25 @@ export async function handleAiChatTurn(input: {
 					// old poll-and-hope timers. Persistence is the same promise; the
 					// stream write is best-effort (an ultra-short reply may close the
 					// stream first, in which case the next refetch picks the title up).
+					const titleStartedAt = Date.now();
 					ctx.waitUntil(
 						generateAIThreadTitle({ env, messages: [userMessage] })
-							.then(async (title) => {
-								const normalized = normalizeGeneratedThreadTitle(title);
+							.then(async (generated) => {
+								if (!generated) {
+									return;
+								}
+								captureAiChatGeneration({
+									userId,
+									workspaceId: threadContext.workspaceId,
+									threadId,
+									traceId: turn.streamId,
+									gatewayModel: generated.gatewayModel,
+									task: "chat-title",
+									startedAt: titleStartedAt,
+									usage: generated.usage,
+									providerMetadata: generated.providerMetadata,
+								});
+								const normalized = normalizeGeneratedThreadTitle(generated.title);
 								if (!normalized) {
 									return;
 								}
@@ -291,11 +326,15 @@ export async function handleAiChatTurn(input: {
 					tools,
 					stopWhen: stepCountIs(MAX_AGENT_STEPS),
 					abortSignal: turn.signal,
-					onChunk: () => turn.onChunk(),
+					onChunk: () => {
+						firstTokenAt ??= Date.now();
+						turn.onChunk();
+					},
 					onStepFinish: () => turn.onStepFinish(),
 				});
 
 				totalUsagePromise = result.totalUsage;
+				providerMetadataPromise = result.providerMetadata;
 				writer.merge(result.toUIMessageStream({ sendReasoning: false }));
 			},
 			onError: (error) => {
@@ -332,6 +371,26 @@ export async function handleAiChatTurn(input: {
 				// Bounded: a hung settle must not pin the client in "streaming"
 				// forever — waitUntil above still carries the real write to completion.
 				await Promise.race([settled, new Promise((resolve) => setTimeout(resolve, 5_000))]);
+
+				captureAiChatGeneration({
+					userId,
+					workspaceId: threadContext.workspaceId,
+					threadId,
+					traceId: turn.streamId,
+					gatewayModel: getWorkspaceAiChatModelById(modelId).gatewayModel,
+					requestedModel: modelId,
+					task: "chat-turn",
+					startedAt: turnStartedAt,
+					firstTokenAt,
+					usage,
+					providerMetadata: clean
+						? await Promise.resolve(providerMetadataPromise).catch(() => undefined)
+						: undefined,
+					outcome:
+						turnErrorMessage !== undefined ? "error" : isAborted ? "interrupted" : "complete",
+					errorMessage: turnErrorMessage,
+					toolNames: assistantMessage ? toolNamesFromParts(assistantMessage.parts) : undefined,
+				});
 
 				if (clean && assistantMessage) {
 					ctx.waitUntil(

--- a/src/features/workspaces/ai/chat/chat-endpoint.ts
+++ b/src/features/workspaces/ai/chat/chat-endpoint.ts
@@ -15,6 +15,7 @@ import { normalizeGeneratedThreadTitle } from "#/features/workspaces/ai/chat/cha
 import { requireThreadAccess } from "#/features/workspaces/ai/chat/chat-access";
 import { getAIThreadSoulPrompt } from "#/features/workspaces/ai/ai-thread-soul-prompt";
 import {
+	AI_THREAD_TITLE_GATEWAY_MODEL,
 	generateAIThreadTitle,
 	getWorkspaceAiGatewayProviderOptions,
 	getWorkspaceAiLanguageModel,
@@ -214,29 +215,47 @@ export async function handleAiChatTurn(input: {
 			systemPrompt: systemPrompt + workspaceContext,
 			contextWindow: getWorkspaceAiChatModelById(modelId).contextWindow,
 			summarize: async (prompt) => {
-				const startedAt = Date.now();
-				const result = await generateText({
-					model: getWorkspaceAiLanguageModel(AI_CHAT_COMPACTION_MODEL_ID, env, threadId),
-					providerOptions: getWorkspaceAiGatewayProviderOptions({
-						modelId: AI_CHAT_COMPACTION_MODEL_ID,
-						tags: ["task:chat-compaction"],
-					}),
-					prompt,
-					maxOutputTokens: COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS,
-				});
-
-				captureAiChatGeneration({
+				const telemetryBase = {
 					userId,
 					workspaceId: threadContext.workspaceId,
 					threadId,
 					traceId: turn.streamId,
 					gatewayModel: getWorkspaceAiChatModelById(AI_CHAT_COMPACTION_MODEL_ID).gatewayModel,
-					task: "chat-compaction",
-					startedAt,
-					usage: result.totalUsage,
-					providerMetadata: await Promise.resolve(result.providerMetadata).catch(() => undefined),
+					task: "chat-compaction" as const,
+					startedAt: Date.now(),
 					includeContent: analyticsConsent,
 					input: [{ role: "user", content: prompt }],
+				};
+
+				let result;
+
+				try {
+					result = await generateText({
+						model: getWorkspaceAiLanguageModel(AI_CHAT_COMPACTION_MODEL_ID, env, threadId),
+						providerOptions: getWorkspaceAiGatewayProviderOptions({
+							modelId: AI_CHAT_COMPACTION_MODEL_ID,
+							tags: ["task:chat-compaction"],
+						}),
+						prompt,
+						maxOutputTokens: COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS,
+					});
+				} catch (error) {
+					// Compaction fails open upstream, so this event is the only record
+					// the summarizer call happened — without it a failing summarizer
+					// model is invisible in the analytics.
+					captureAiChatGeneration({
+						...telemetryBase,
+						outcome: "error",
+						errorMessage: error instanceof Error ? error.message : String(error),
+					});
+					throw error;
+				}
+
+				captureAiChatGeneration({
+					...telemetryBase,
+					usage: result.totalUsage,
+					providerMetadata: await Promise.resolve(result.providerMetadata).catch(() => undefined),
+					outcome: "complete",
 					output: [{ role: "assistant", content: result.text }],
 				});
 
@@ -279,41 +298,59 @@ export async function handleAiChatTurn(input: {
 					// old poll-and-hope timers. Persistence is the same promise; the
 					// stream write is best-effort (an ultra-short reply may close the
 					// stream first, in which case the next refetch picks the title up).
-					const titleStartedAt = Date.now();
+					const titleTelemetryBase = {
+						userId,
+						workspaceId: threadContext.workspaceId,
+						threadId,
+						traceId: turn.streamId,
+						task: "chat-title" as const,
+						startedAt: Date.now(),
+						includeContent: analyticsConsent,
+						input: [{ role: "user", content: userMessage.parts }],
+					};
 					ctx.waitUntil(
-						generateAIThreadTitle({ env, messages: [userMessage] })
-							.then(async (generated) => {
-								if (!generated) {
-									return;
-								}
+						(async () => {
+							let generated;
+
+							try {
+								generated = await generateAIThreadTitle({ env, messages: [userMessage] });
+							} catch (error) {
+								// The model call failing must still produce an event — a dead
+								// title model would otherwise be invisible in the analytics.
 								captureAiChatGeneration({
-									userId,
-									workspaceId: threadContext.workspaceId,
-									threadId,
-									traceId: turn.streamId,
-									gatewayModel: generated.gatewayModel,
-									task: "chat-title",
-									startedAt: titleStartedAt,
-									usage: generated.usage,
-									providerMetadata: generated.providerMetadata,
-									includeContent: analyticsConsent,
-									input: [{ role: "user", content: userMessage.parts }],
-									...(generated.title
-										? { output: [{ role: "assistant", content: generated.title }] }
-										: {}),
+									...titleTelemetryBase,
+									gatewayModel: AI_THREAD_TITLE_GATEWAY_MODEL,
+									outcome: "error",
+									errorMessage: error instanceof Error ? error.message : String(error),
 								});
-								const normalized = normalizeGeneratedThreadTitle(generated.title);
-								if (!normalized) {
-									return;
-								}
-								try {
-									writer.write({ type: "data-thread-title", data: normalized, transient: true });
-								} catch {
-									// Stream already closed — persistence below still lands.
-								}
-								await setThreadTitle({ threadId, title: normalized });
-							})
-							.catch((error) => console.error("[ai-chat] title generation failed:", error)),
+								console.error("[ai-chat] title generation failed:", error);
+								return;
+							}
+
+							if (!generated) {
+								return;
+							}
+							captureAiChatGeneration({
+								...titleTelemetryBase,
+								gatewayModel: generated.gatewayModel,
+								usage: generated.usage,
+								providerMetadata: generated.providerMetadata,
+								outcome: "complete",
+								...(generated.title
+									? { output: [{ role: "assistant", content: generated.title }] }
+									: {}),
+							});
+							const normalized = normalizeGeneratedThreadTitle(generated.title);
+							if (!normalized) {
+								return;
+							}
+							try {
+								writer.write({ type: "data-thread-title", data: normalized, transient: true });
+							} catch {
+								// Stream already closed — persistence below still lands.
+							}
+							await setThreadTitle({ threadId, title: normalized });
+						})().catch((error) => console.error("[ai-chat] title delivery failed:", error)),
 					);
 				}
 

--- a/src/features/workspaces/ai/chat/chat-model.ts
+++ b/src/features/workspaces/ai/chat/chat-model.ts
@@ -78,3 +78,44 @@ export function settledParts(parts: UIMessage["parts"]): UIMessage["parts"] {
 
 	return settled;
 }
+
+// PostHog rejects events past ~1MB, and a near-compaction transcript (or the
+// compaction prompt, which embeds one) can exceed that. Keep the newest
+// messages whole, drop the oldest with a marker, and slice a lone entry that
+// is itself over budget (the compaction prompt case). Lives here, not in
+// chat-telemetry, so tests import it without the posthog/cloudflare chain.
+const TELEMETRY_CONTENT_CHAR_BUDGET = 400_000;
+
+export function fitTelemetryContent(entries: unknown[]): unknown[] {
+	const sizes = entries.map((entry) => JSON.stringify(entry)?.length ?? 0);
+	let total = sizes.reduce((sum, size) => sum + size, 0);
+	let omitted = 0;
+
+	while (entries.length - omitted > 1 && total > TELEMETRY_CONTENT_CHAR_BUDGET) {
+		total -= sizes[omitted] ?? 0;
+		omitted += 1;
+	}
+
+	let kept = entries.slice(omitted);
+	const only = kept[0] as { role?: unknown; content?: unknown } | undefined;
+
+	if (
+		total > TELEMETRY_CONTENT_CHAR_BUDGET &&
+		kept.length === 1 &&
+		typeof only?.content === "string"
+	) {
+		kept = [
+			{ ...only, content: `${only.content.slice(0, TELEMETRY_CONTENT_CHAR_BUDGET)}…(truncated)` },
+		];
+	}
+
+	return omitted > 0
+		? [
+				{
+					role: "system",
+					content: `(${omitted} earlier ${omitted === 1 ? "message" : "messages"} omitted from telemetry)`,
+				},
+				...kept,
+			]
+		: kept;
+}

--- a/src/features/workspaces/ai/chat/chat-telemetry.test.ts
+++ b/src/features/workspaces/ai/chat/chat-telemetry.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { fitTelemetryContent } from "#/features/workspaces/ai/chat/chat-model";
+
+describe("fitTelemetryContent", () => {
+	it("passes an under-budget transcript through untouched", () => {
+		const entries = [
+			{ role: "user", content: "hi" },
+			{ role: "assistant", content: "hello" },
+		];
+
+		expect(fitTelemetryContent(entries)).toEqual(entries);
+	});
+
+	it("drops oldest messages first and marks the omission", () => {
+		const big = "x".repeat(250_000);
+		const entries = [
+			{ role: "user", content: big },
+			{ role: "assistant", content: big },
+			{ role: "user", content: big },
+			{ role: "assistant", content: "the newest reply" },
+		];
+
+		const fitted = fitTelemetryContent(entries);
+
+		expect(fitted[0]).toEqual({
+			role: "system",
+			content: "(2 earlier messages omitted from telemetry)",
+		});
+		expect(fitted.at(-1)).toEqual(entries.at(-1));
+		expect(fitted).toHaveLength(3);
+	});
+
+	it("slices a lone over-budget entry, the compaction-prompt case", () => {
+		const fitted = fitTelemetryContent([{ role: "user", content: "y".repeat(500_000) }]);
+		const only = fitted[0] as { content: string };
+
+		expect(fitted).toHaveLength(1);
+		expect(only.content.endsWith("…(truncated)")).toBe(true);
+		expect(only.content.length).toBeLessThan(410_000);
+	});
+});

--- a/src/features/workspaces/ai/chat/chat-telemetry.ts
+++ b/src/features/workspaces/ai/chat/chat-telemetry.ts
@@ -1,11 +1,15 @@
+import { fitTelemetryContent } from "#/features/workspaces/ai/chat/chat-model";
 import { capturePostHogAiGeneration } from "#/integrations/posthog/ai-observability";
 
 // LLM analytics for the chat: one $ai_generation event per model call — the
 // turn itself plus its utility calls (compaction summary, title) — sharing the
 // turn's streamId as the trace id so PostHog groups them into one trace per
-// turn, keyed to the thread as the session. Metadata only (privacyMode is
-// forced on in the capture layer): usage, latency, served route, outcome —
-// never message content.
+// turn, keyed to the thread as the session.
+//
+// Content policy: full prompt/response content is captured by default — we are
+// early, and the conversation is the debugging signal. A user whose analytics
+// consent is off (cookie choice, GPC, or opt-in region without a choice) drops
+// the event to metadata-only: usage, latency, served route, outcome.
 
 export type AiChatGenerationTask = "chat-turn" | "chat-compaction" | "chat-title";
 
@@ -29,6 +33,12 @@ export interface AiChatGenerationTelemetry {
 	outcome?: "complete" | "interrupted" | "error";
 	errorMessage?: string;
 	toolNames?: string[];
+	/** The request's analytics consent. False strips content, keeps metadata. */
+	includeContent: boolean;
+	/** What the model saw, `[{role, content}]`-shaped. Oldest dropped to fit. */
+	input?: unknown[];
+	/** The model's reply in the same shape. */
+	output?: unknown[];
 }
 
 export function captureAiChatGeneration(input: AiChatGenerationTelemetry) {
@@ -52,8 +62,9 @@ export function captureAiChatGeneration(input: AiChatGenerationTelemetry) {
 		// gateway's actual served route when providerMetadata records one.
 		provider: slash === -1 ? "vercel-ai-gateway" : gatewayModel.slice(0, slash),
 		model: slash === -1 ? gatewayModel : gatewayModel.slice(slash + 1),
-		input: null,
-		output: null,
+		input: input.includeContent ? fitTelemetryContent(input.input ?? []) : null,
+		output: input.includeContent ? (input.output ?? null) : null,
+		...(input.includeContent ? { privacyMode: false } : {}),
 		latency: (Date.now() - input.startedAt) / 1000,
 		...(input.firstTokenAt !== undefined
 			? { timeToFirstToken: (input.firstTokenAt - input.startedAt) / 1000 }

--- a/src/features/workspaces/ai/chat/chat-telemetry.ts
+++ b/src/features/workspaces/ai/chat/chat-telemetry.ts
@@ -1,0 +1,93 @@
+import { capturePostHogAiGeneration } from "#/integrations/posthog/ai-observability";
+
+// LLM analytics for the chat: one $ai_generation event per model call — the
+// turn itself plus its utility calls (compaction summary, title) — sharing the
+// turn's streamId as the trace id so PostHog groups them into one trace per
+// turn, keyed to the thread as the session. Metadata only (privacyMode is
+// forced on in the capture layer): usage, latency, served route, outcome —
+// never message content.
+
+export type AiChatGenerationTask = "chat-turn" | "chat-compaction" | "chat-title";
+
+export interface AiChatGenerationTelemetry {
+	userId: string;
+	workspaceId: string;
+	threadId: string;
+	/** The turn's stream id — one trace groups the turn and its utility calls. */
+	traceId: string;
+	/** The gateway model string, e.g. "anthropic/claude-sonnet-5". */
+	gatewayModel: string;
+	/** The app-level model id the user picked, for the requested_model property. */
+	requestedModel?: string;
+	task: AiChatGenerationTask;
+	startedAt: number;
+	firstTokenAt?: number;
+	/** AI SDK usage (`result.totalUsage` / `result.usage`). */
+	usage?: unknown;
+	/** `result.providerMetadata`, for served-route attribution. */
+	providerMetadata?: unknown;
+	outcome?: "complete" | "interrupted" | "error";
+	errorMessage?: string;
+	toolNames?: string[];
+}
+
+export function captureAiChatGeneration(input: AiChatGenerationTelemetry) {
+	const gatewayModel = input.gatewayModel;
+	const slash = gatewayModel.indexOf("/");
+	const usage = input.usage as
+		| {
+				inputTokens?: number;
+				outputTokens?: number;
+				reasoningTokens?: number;
+				cachedInputTokens?: number;
+		  }
+		| undefined;
+
+	capturePostHogAiGeneration({
+		distinctId: input.userId,
+		traceId: input.traceId,
+		sessionId: input.threadId,
+		spanName: input.task,
+		// Requested route; capturePostHogAiGeneration overrides provider with the
+		// gateway's actual served route when providerMetadata records one.
+		provider: slash === -1 ? "vercel-ai-gateway" : gatewayModel.slice(0, slash),
+		model: slash === -1 ? gatewayModel : gatewayModel.slice(slash + 1),
+		input: null,
+		output: null,
+		latency: (Date.now() - input.startedAt) / 1000,
+		...(input.firstTokenAt !== undefined
+			? { timeToFirstToken: (input.firstTokenAt - input.startedAt) / 1000 }
+			: {}),
+		...(usage
+			? {
+					usage: {
+						inputTokens: usage.inputTokens,
+						outputTokens: usage.outputTokens,
+						reasoningTokens: usage.reasoningTokens,
+						cacheReadInputTokens: usage.cachedInputTokens,
+					},
+				}
+			: {}),
+		...(input.outcome === "error" ? { error: input.errorMessage ?? "chat turn failed" } : {}),
+		providerMetadata: (input.providerMetadata ?? undefined) as Record<string, unknown> | undefined,
+		properties: {
+			task: input.task,
+			workspace_id: input.workspaceId,
+			thread_id: input.threadId,
+			...(input.requestedModel ? { requested_model: input.requestedModel } : {}),
+			...(input.outcome ? { outcome: input.outcome } : {}),
+			...(input.toolNames && input.toolNames.length > 0 ? { tool_names: input.toolNames } : {}),
+		},
+	});
+}
+
+// Tool names off a persisted assistant message's parts, for the turn event.
+export function toolNamesFromParts(parts: { type: string }[]): string[] {
+	return [
+		...new Set(
+			parts
+				.filter((part) => part.type.startsWith("tool-"))
+				.map((part) => part.type.slice("tool-".length)),
+		),
+	];
+}

--- a/src/features/workspaces/ai/chat/route.ts
+++ b/src/features/workspaces/ai/chat/route.ts
@@ -7,6 +7,7 @@ import { ChatRequestError, chatErrorResponse } from "#/features/workspaces/ai/ch
 import { getThread, stopStream } from "#/features/workspaces/ai/chat/chat-store";
 import { WorkspaceForbiddenError } from "#/features/workspaces/server/permissions";
 import { recordOperationalFailure } from "#/integrations/observability/operational-events";
+import { hasServerAnalyticsConsent } from "#/integrations/posthog/consent.server";
 import { getTelemetryRequestDetails } from "#/integrations/posthog/server-context";
 import { getSessionFromRequest } from "#/lib/auth-queries.server";
 
@@ -76,6 +77,10 @@ export async function routeAiChatRequest(request: Request, env: Env, ctx: Execut
 			threadId,
 			userId: session.user.id,
 			body,
+			// Resolved here, where the request is in hand: the stream callbacks
+			// that capture telemetry run after the response, outside any request
+			// context a lazy read could fall back to.
+			analyticsConsent: hasServerAnalyticsConsent(request.headers),
 		});
 	} catch (error) {
 		const typedResponse = chatErrorResponse(error);

--- a/src/features/workspaces/ai/gateway.ts
+++ b/src/features/workspaces/ai/gateway.ts
@@ -182,7 +182,12 @@ export async function generateAIThreadTitle(input: { env: Cloudflare.Env; messag
 		}),
 	});
 
-	return result.output?.title;
+	return {
+		title: result.output?.title,
+		usage: result.totalUsage,
+		providerMetadata: await Promise.resolve(result.providerMetadata).catch(() => undefined),
+		gatewayModel: AI_THREAD_TITLE_GATEWAY_MODEL,
+	};
 }
 
 const AI_THREAD_TITLE_OUTPUT_SCHEMA = z.object({

--- a/src/features/workspaces/ai/gateway.ts
+++ b/src/features/workspaces/ai/gateway.ts
@@ -24,7 +24,7 @@ import {
 // has no framework dependencies; the comments carry over because the tuning
 // rationale is unchanged.
 
-const AI_THREAD_TITLE_GATEWAY_MODEL = "google/gemini-2.5-flash-lite";
+export const AI_THREAD_TITLE_GATEWAY_MODEL = "google/gemini-2.5-flash-lite";
 
 type WorkspaceAiProviderOptions = NonNullable<
 	Parameters<typeof generateText>[0]["providerOptions"]


### PR DESCRIPTION
Re-adds the LLM analytics that were deliberately dropped during the Think→Postgres migration (the pre-launch item from the migration ledger).

## What it does

Every model call in a chat turn emits one `$ai_generation` event to PostHog, grouped into **one trace per turn** (trace id = the turn's stream id, session = the thread):

- **The turn itself**: requested vs actually-served model (the gateway served-route attribution survived the migration — it once caught 105 generations labeled Gemini that OpenAI actually served), token usage incl. cache reads, wall latency, time-to-first-token, outcome (`complete`/`interrupted`/`error`), and which tools ran.
- **The compaction summary call** and **the title generation**, each as their own event in the same trace with real usage numbers.

## Content policy

Full prompt/response content is captured **by default** — we're early, and the conversation is the debugging signal:

- The turn event carries the transcript the model saw (pre-hydration: attachment URLs only, never inlined image bytes) and the assistant reply; compaction carries its prompt and summary; title carries the user message and the result.
- A user whose analytics consent is off (cookie choice, Global Privacy Control, or an opt-in region with no choice yet) drops the event to **metadata-only** — the existing `hasServerAnalyticsConsent` cookie read, resolved in the route while the request is still in hand (the capture callbacks run after the response, outside any request context).
- `fitTelemetryContent` keeps events under PostHog's ~1MB cap: oldest messages dropped first with a visible marker, and a lone over-budget entry (the compaction prompt) sliced. Focused tests cover all three behaviors.

Capture is fire-and-forget via `waitUntil` with delivery-failure logging, and no-ops entirely in dev.

## Why this integration path

PostHog documents two newer routes; both rejected deliberately: the OpenTelemetry route requires `@opentelemetry/sdk-node` (not Workers-compatible), and the `withTracing` model wrapper has a known getter-loss bug ([posthog-js#2816](https://github.com/PostHog/posthog-js/issues/2816)). The low-level `captureAiGeneration` path used here is the one the old Think-era recorder already proved on Workers — its capture layer survived the migration intact; this PR just gives it callers again. Costs need no wiring: PostHog computes them from model + token counts against OpenRouter pricing.

Verified: typecheck green, 342 tests pass across workspaces + posthog suites; live turn against dev streams normally with telemetry wired (no-op capture in dev by design).

https://claude.ai/code/session_01Vy2N9tuKcNPLKgkwyseVxL