### PR TITLE
feat(ai-chat): edit the latest user message

### DIFF
--- a/src/features/workspaces/components/ai-chat/AiChatAllowanceNotice.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatAllowanceNotice.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 
 import { Button } from "#/components/ui/button";
+import AiChatComposerReveal from "#/features/workspaces/components/ai-chat/AiChatComposerReveal";
 import { showUpgradeDialog } from "#/features/account/upgrade-navigation";
 import {
 	getWorkspaceAiChatModelById,
@@ -36,48 +37,52 @@ export function AiChatAllowanceNotice({ modelId }: AiChatAllowanceNoticeProps) {
 	// them, so an upgrade control would only advertise that we forgot they pay.
 	const { isPro } = useBillingState();
 
-	if (!allowance.isBlocked) {
-		// A downgraded turn says so on the model picker itself, which names what
-		// will answer rather than what was picked. Repeating it here put a second
-		// line under the composer for the rest of the billing period, contradicting
-		// the button beside it the whole time.
-		return null;
-	}
-
-	// Standard running out no longer spends premium on the user's behalf, so this
-	// state is reachable with premium still in the account: a dead composer, and
-	// an unspent balance reachable only by opening the model picker on a hunch.
-	// Four words are cheaper than leaving someone stuck next to messages they
-	// already have. Only when it's true — saying it with nothing left would be
-	// the same lie as "out of messages" is when premium remains.
+	// Standard running out no longer spends premium on the user's behalf, so the
+	// blocked state is reachable with premium still in the account: a dead
+	// composer, and an unspent balance reachable only by opening the model picker
+	// on a hunch. Four words are cheaper than leaving someone stuck next to
+	// messages they already have. Only when it's true — saying it with nothing
+	// left would be the same lie as "out of messages" is when premium remains.
+	//
+	// When not blocked, nothing renders: a downgraded turn says so on the model
+	// picker itself, which names what will answer rather than what was picked.
+	// Repeating it here put a second line under the composer for the rest of the
+	// billing period, contradicting the button beside it the whole time.
 	return (
-		<div className="flex items-center gap-2 px-1">
-			<p className="min-w-0 text-xs leading-relaxed text-muted-foreground">
-				You&rsquo;re out of {premiumLeft ? "standard messages" : "messages"}
-				{resetsOn ? ` until ${resetsOn}` : ""}.{premiumLeft ? " Premium models still work." : ""}
-			</p>
-			{/* A control rather than a sentence about what Pro includes: this sits in
-			    the one spot where someone has already been stopped, so the plan
-			    details belong in the dialog it opens, not in the line that stops
-			    them. */}
-			{isPro ? null : (
-				<Button
-					className="ml-auto"
-					nativeButton={false}
-					onClick={() => {
-						capturePostHogClientEvent("upgrade_prompt_clicked", {
-							feature_id:
-								WORKSPACE_AI_MESSAGE_FEATURE_IDS[getWorkspaceAiChatModelById(modelId).billingTier],
-							source: "ai_allowance_notice",
-						});
-					}}
-					render={<Link replace search={showUpgradeDialog} to="." />}
-					size="xs"
-				>
-					Upgrade
-				</Button>
-			)}
-		</div>
+		<AiChatComposerReveal>
+			{allowance.isBlocked ? (
+				<div className="flex items-center gap-2 px-1 pt-1">
+					<p className="min-w-0 text-xs leading-relaxed text-muted-foreground">
+						You&rsquo;re out of {premiumLeft ? "standard messages" : "messages"}
+						{resetsOn ? ` until ${resetsOn}` : ""}.
+						{premiumLeft ? " Premium models still work." : ""}
+					</p>
+					{/* A control rather than a sentence about what Pro includes: this sits in
+					    the one spot where someone has already been stopped, so the plan
+					    details belong in the dialog it opens, not in the line that stops
+					    them. */}
+					{isPro ? null : (
+						<Button
+							className="ml-auto"
+							nativeButton={false}
+							onClick={() => {
+								capturePostHogClientEvent("upgrade_prompt_clicked", {
+									feature_id:
+										WORKSPACE_AI_MESSAGE_FEATURE_IDS[
+											getWorkspaceAiChatModelById(modelId).billingTier
+										],
+									source: "ai_allowance_notice",
+								});
+							}}
+							render={<Link replace search={showUpgradeDialog} to="." />}
+							size="xs"
+						>
+							Upgrade
+						</Button>
+					)}
+				</div>
+			) : null}
+		</AiChatComposerReveal>
 	);
 }
 

--- a/src/features/workspaces/components/ai-chat/AiChatComposerReveal.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatComposerReveal.tsx
@@ -1,0 +1,45 @@
+import { LazyMotion, domAnimation, m } from "motion/react";
+import { type ReactNode, useEffect, useState } from "react";
+
+const revealTransition = { duration: 0.22, ease: [0.22, 1, 0.36, 1] as const };
+
+// The one way composer header rows (context bar, edit banner, allowance
+// notice, …) appear and disappear: the wrapper animates to the measured
+// height of whatever is rendered inside — nothing → 0 — so notices slide in
+// and out instead of snapping the composer taller. Children control their own
+// visibility by rendering null; include any top padding inside the child so
+// it collapses with the content.
+export default function AiChatComposerReveal({ children }: { children: ReactNode }) {
+	const [contentNode, setContentNode] = useState<HTMLDivElement | null>(null);
+	const [height, setHeight] = useState<number | "auto">("auto");
+
+	useEffect(() => {
+		if (!contentNode) {
+			return;
+		}
+
+		const updateHeight = () => {
+			setHeight(contentNode.getBoundingClientRect().height);
+		};
+
+		updateHeight();
+		const observer = new ResizeObserver(updateHeight);
+		observer.observe(contentNode);
+		return () => observer.disconnect();
+	}, [contentNode]);
+
+	return (
+		<LazyMotion features={domAnimation}>
+			<m.div
+				animate={{ height }}
+				className="w-full min-w-0 overflow-hidden"
+				initial={false}
+				transition={revealTransition}
+			>
+				<div ref={setContentNode} className="w-full min-w-0">
+					{children}
+				</div>
+			</m.div>
+		</LazyMotion>
+	);
+}

--- a/src/features/workspaces/components/ai-chat/AiChatMessageList.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatMessageList.tsx
@@ -84,7 +84,11 @@ type AiChatListRow =
 interface AiChatMessageListProps {
 	anchorMessageId?: string | null;
 	assistantError?: AiChatAssistantErrorState | null;
+	/** The message currently loaded into the composer for editing, dimmed here. */
+	editingMessageId?: string;
 	messages: AiChatMessage[];
+	/** Present only while an edit could start; offered on the latest user message. */
+	onEditMessage?: (message: AiChatMessage) => void;
 	onRegenerateLastResponse?: () => void;
 	onStartNewChat?: () => void;
 	presentation: AiChatPresentation;
@@ -95,7 +99,9 @@ interface AiChatMessageListProps {
 export default function AiChatMessageList({
 	anchorMessageId,
 	assistantError,
+	editingMessageId,
 	messages,
+	onEditMessage,
 	onRegenerateLastResponse,
 	onStartNewChat,
 	presentation,
@@ -103,6 +109,7 @@ export default function AiChatMessageList({
 	workspaceId,
 }: AiChatMessageListProps) {
 	const { lastAssistantMessageId, status } = presentation;
+	const lastUserMessageId = getLastUserMessageId(messages);
 	const rows = getAiChatListRows(messages, presentation, assistantError);
 	const hasAssistantContent = hasLatestAssistantContent(rows);
 	const isStreamActive = isAiChatStreamActive(status);
@@ -136,7 +143,7 @@ export default function AiChatMessageList({
 			<AiChatTranscriptScroller
 				anchorMessageId={anchorMessageId ?? undefined}
 				busy={isStreamActive}
-				initialAnchorMessageId={getLastUserMessageId(messages)}
+				initialAnchorMessageId={lastUserMessageId}
 				reduceMotion={shouldReduceMotion === true}
 				smoothAnchorMessageId={
 					shouldReduceMotion ? undefined : (sentMessageAnimationId ?? undefined)
@@ -153,10 +160,13 @@ export default function AiChatMessageList({
 						>
 							<AiChatListRowView
 								canRetry={Boolean(onRegenerateLastResponse)}
+								editingMessageId={editingMessageId}
 								hasAssistantContent={hasAssistantContent}
 								lastAssistantMessageId={lastAssistantMessageId}
+								lastUserMessageId={lastUserMessageId}
 								row={row}
 								status={status}
+								onEditMessage={onEditMessage}
 								onRegenerateLastResponse={onRegenerateLastResponse}
 								onStartNewChat={onStartNewChat}
 							/>
@@ -213,16 +223,22 @@ function AiChatMessageScrollerItem({
 
 function AiChatListRowView({
 	canRetry,
+	editingMessageId,
 	hasAssistantContent,
 	lastAssistantMessageId,
+	lastUserMessageId,
+	onEditMessage,
 	onRegenerateLastResponse,
 	onStartNewChat,
 	row,
 	status,
 }: {
 	canRetry: boolean;
+	editingMessageId: string | undefined;
 	hasAssistantContent: boolean;
 	lastAssistantMessageId: string | undefined;
+	lastUserMessageId: string | undefined;
+	onEditMessage?: (message: AiChatMessage) => void;
 	onRegenerateLastResponse?: () => void;
 	onStartNewChat?: () => void;
 	row: AiChatListRow;
@@ -255,10 +271,21 @@ function AiChatListRowView({
 		<AiChatTranscriptRail>
 			<AiChatMessageRow
 				display={display}
+				isBeingEdited={message.id === editingMessageId}
 				isLatestAssistant={message.role === "assistant" && message.id === lastAssistantMessageId}
 				isRegenerable={message.id === lastAssistantMessageId && status === "ready"}
 				isStreaming={message.id === lastAssistantMessageId && isAiChatStreamActive(status)}
 				message={message}
+				onEdit={
+					onEditMessage &&
+					message.role === "user" &&
+					message.id === lastUserMessageId &&
+					// The composer edits text; an attachment-only message has none to
+					// load, which would trap the user in a banner with a dead submit.
+					message.parts.some((part) => part.type === "text")
+						? () => onEditMessage(message)
+						: undefined
+				}
 				onRegenerate={onRegenerateLastResponse}
 			/>
 		</AiChatTranscriptRail>

--- a/src/features/workspaces/components/ai-chat/AiChatMessageRow.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatMessageRow.tsx
@@ -1,5 +1,5 @@
 import { isToolUIPart } from "ai";
-import { Check, Copy, RotateCcw } from "lucide-react";
+import { Check, Copy, Pencil, RotateCcw } from "lucide-react";
 import { useState } from "react";
 
 import { AnimatedIconSwap } from "#/components/ui/animated-icon-swap";
@@ -35,17 +35,23 @@ const collapsedUserMessageClassName =
 
 export default function AiChatMessageRow({
 	display,
+	isBeingEdited = false,
 	isLatestAssistant,
 	isRegenerable,
 	isStreaming,
 	message,
+	onEdit,
 	onRegenerate,
 }: {
 	display: AssistantRowDisplay | null;
+	/** Its text is in the composer being rewritten; dimmed as the cue. */
+	isBeingEdited?: boolean;
 	isLatestAssistant: boolean;
 	isRegenerable: boolean;
 	isStreaming: boolean;
 	message: AiChatMessage;
+	/** Present only on the latest user message while an edit could start. */
+	onEdit?: () => void;
 	onRegenerate?: () => void;
 }) {
 	if (message.role === "assistant" && display?.kind === "hidden") {
@@ -65,7 +71,10 @@ export default function AiChatMessageRow({
 			: [];
 
 	return (
-		<Message align={isAssistant ? "start" : "end"}>
+		<Message
+			align={isAssistant ? "start" : "end"}
+			className={cn("transition-opacity duration-150 ease-out", isBeingEdited && "opacity-50")}
+		>
 			<MessageContent>
 				{userAttachmentParts.length > 0 ? (
 					<div className="mb-2 ml-auto flex w-fit max-w-full flex-col gap-2">
@@ -114,10 +123,15 @@ export default function AiChatMessageRow({
 						</div>
 					</MessageFooter>
 				) : null}
-				{!isAssistant && copyableText ? (
+				{!isAssistant && (copyableText || onEdit) ? (
 					<MessageFooter className="pointer-events-none px-0 opacity-0 transition-opacity duration-150 ease-out group-hover/message:pointer-events-auto group-hover/message:opacity-100 group-focus-within/message:pointer-events-auto group-focus-within/message:opacity-100">
-						<div className="flex items-center gap-1">
-							<CopyResponseAction text={copyableText} copyLabel="Copy" />
+						<div className="flex items-center gap-4">
+							{copyableText ? <CopyResponseAction text={copyableText} copyLabel="Copy" /> : null}
+							{onEdit ? (
+								<AiChatMessageAction label="Edit message" onClick={onEdit}>
+									<Pencil className="size-4" />
+								</AiChatMessageAction>
+							) : null}
 						</div>
 					</MessageFooter>
 				) : null}

--- a/src/features/workspaces/components/ai-chat/AiChatPromptContextBar.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatPromptContextBar.tsx
@@ -1,13 +1,9 @@
-import { LazyMotion, domAnimation, m } from "motion/react";
-import { useCallback, useEffect, useState } from "react";
-
 import { usePromptInputAttachments } from "#/features/workspaces/components/ai-chat/ai-chat-prompt-input";
+import AiChatComposerReveal from "#/features/workspaces/components/ai-chat/AiChatComposerReveal";
 import AiChatPromptAttachments from "#/features/workspaces/components/ai-chat/AiChatPromptAttachments";
 import WorkspaceAiChatContextChips from "#/features/workspaces/components/ai-chat/WorkspaceAiChatContextChips";
 import { getWorkspaceAiContextChips } from "#/features/workspaces/model/workspace-ai-context-chips";
 import type { WorkspaceAiContextScope } from "#/features/workspaces/model/workspace-ai-context-types";
-
-const contextBarTransition = { duration: 0.22, ease: [0.22, 1, 0.36, 1] as const };
 
 export default function AiChatPromptContextBar({ context }: { context: WorkspaceAiContextScope }) {
 	const attachments = usePromptInputAttachments();
@@ -16,44 +12,14 @@ export default function AiChatPromptContextBar({ context }: { context: Workspace
 		getWorkspaceAiContextChips(context).length > 0 || context.selectedQuotes.length > 0;
 	const visible = hasAttachments || hasWorkspaceContext;
 
-	const [contentNode, setContentNode] = useState<HTMLDivElement | null>(null);
-	const [height, setHeight] = useState<number | "auto">("auto");
-	const contentRef = useCallback((node: HTMLDivElement | null) => {
-		setContentNode(node);
-	}, []);
-
-	useEffect(() => {
-		if (!contentNode) {
-			return;
-		}
-
-		const updateHeight = () => {
-			setHeight(contentNode.getBoundingClientRect().height);
-		};
-
-		updateHeight();
-		const observer = new ResizeObserver(updateHeight);
-		observer.observe(contentNode);
-		return () => observer.disconnect();
-	}, [contentNode]);
-
 	return (
-		<LazyMotion features={domAnimation}>
-			<m.div
-				animate={{ height }}
-				className="w-full min-w-0 overflow-hidden"
-				initial={false}
-				transition={contextBarTransition}
-			>
-				<div ref={contentRef} className="w-full min-w-0">
-					{visible ? (
-						<div className="flex w-full min-w-0 flex-col gap-3 pt-3">
-							<AiChatPromptAttachments />
-							<WorkspaceAiChatContextChips context={context} />
-						</div>
-					) : null}
+		<AiChatComposerReveal>
+			{visible ? (
+				<div className="flex w-full min-w-0 flex-col gap-3 pt-3">
+					<AiChatPromptAttachments />
+					<WorkspaceAiChatContextChips context={context} />
 				</div>
-			</m.div>
-		</LazyMotion>
+			) : null}
+		</AiChatComposerReveal>
 	);
 }

--- a/src/features/workspaces/components/ai-chat/AiChatPromptInput.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatPromptInput.tsx
@@ -1,5 +1,11 @@
-import { Mic, Paperclip } from "lucide-react";
-import { type KeyboardEventHandler, type SetStateAction, useCallback, useRef } from "react";
+import { Mic, Paperclip, Pencil, X } from "lucide-react";
+import {
+	type KeyboardEventHandler,
+	type SetStateAction,
+	useCallback,
+	useEffect,
+	useRef,
+} from "react";
 import { toast } from "sonner";
 
 import {
@@ -16,6 +22,7 @@ import {
 } from "#/features/workspaces/components/ai-chat/ai-chat-prompt-input";
 import { useWorkspaceAiAllowance } from "#/features/workspaces/ai/use-workspace-ai-allowance";
 import { AiChatAttachmentDropBridge } from "#/features/workspaces/components/ai-chat/AiChatAttachmentDrop";
+import AiChatComposerReveal from "#/features/workspaces/components/ai-chat/AiChatComposerReveal";
 import AiChatModelPicker from "#/features/workspaces/components/ai-chat/AiChatModelPicker";
 import { AiChatAllowanceNotice } from "#/features/workspaces/components/ai-chat/AiChatAllowanceNotice";
 import AiChatPromptContextBar from "#/features/workspaces/components/ai-chat/AiChatPromptContextBar";
@@ -53,7 +60,9 @@ import { cn } from "#/lib/utils";
 const PROMPT_INPUT_GROUP_CLASSNAME =
 	"h-auto flex-col border-border/70 bg-muted/30 shadow-none dark:bg-muted/30";
 const PROMPT_INPUT_INLINE_PADDING = "px-3.5";
-const PROMPT_INPUT_HEADER_PADDING = "px-3.5 pb-1";
+// gap-0: every header row self-pads (pt on its content), so the always-mounted
+// zero-height reveal wrappers add no phantom flex gaps to an idle composer.
+const PROMPT_INPUT_HEADER_PADDING = "gap-0 px-3.5 pb-1";
 const PROMPT_INPUT_FOOTER_PADDING = "pl-2 pr-3.5 pt-1 pb-2";
 const CHAT_ATTACHMENT_PICKER_ACCEPT = [
 	...new Set([WORKSPACE_AI_CHAT_ATTACHMENT_POLICY.accept, ...workspaceUploadAccept.split(",")]),
@@ -77,7 +86,10 @@ interface AiChatPromptInputProps {
 	activeThreadId: string;
 	canSend: boolean;
 	context: WorkspaceAiContextScope;
+	/** While set, submits rewrite an existing message instead of sending a new one. */
+	isEditing?: boolean;
 	modelId?: AiChatModelId;
+	onCancelEdit?: () => void;
 	onModelChange?: (modelId: AiChatModelId) => void;
 	onSubmit: (message: PromptInputMessage) => void;
 	onStop?: () => void;
@@ -91,7 +103,9 @@ export default function AiChatPromptInput({
 	activeThreadId,
 	canSend: canSendWhileConnected,
 	context,
+	isEditing = false,
 	modelId = DEFAULT_WORKSPACE_AI_CHAT_MODEL_ID,
+	onCancelEdit,
 	onModelChange,
 	onSubmit,
 	onStop,
@@ -155,6 +169,13 @@ export default function AiChatPromptInput({
 	const resumeQueue = useWorkspaceAiQueueStore((state) => state.resume);
 	const steerOnSubmitRef = useRef(false);
 
+	// Focus where the editing now happens; Escape backs out (see keydown).
+	useEffect(() => {
+		if (isEditing) {
+			textareaRef.current?.focus();
+		}
+	}, [isEditing]);
+
 	const handleSubmit = (message: PromptInputMessage) => {
 		const steer = steerOnSubmitRef.current;
 		steerOnSubmitRef.current = false;
@@ -163,7 +184,15 @@ export default function AiChatPromptInput({
 			return false;
 		}
 
-		if (canSend) {
+		// An edit rewrites an existing message — it must never fall through to
+		// the queue as a new one. Edits start idle, so canSend is the whole gate.
+		if (isEditing && !canSend) {
+			return false;
+		}
+
+		if (isEditing) {
+			onSubmit(message);
+		} else if (canSend) {
 			resumeQueue(activeThreadId);
 			onSubmit(message);
 		} else if (canQueue) {
@@ -190,6 +219,12 @@ export default function AiChatPromptInput({
 	};
 
 	const handleTextareaKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (event) => {
+		if (event.key === "Escape" && isEditing && onCancelEdit) {
+			event.preventDefault();
+			onCancelEdit();
+			return;
+		}
+
 		if (event.key !== "Enter" || !(event.metaKey || event.ctrlKey) || !isBusyStatus) {
 			return;
 		}
@@ -241,6 +276,22 @@ export default function AiChatPromptInput({
 			>
 				<AiChatAttachmentDropBridge />
 				<PromptInputHeader className={PROMPT_INPUT_HEADER_PADDING}>
+					<AiChatComposerReveal>
+						{isEditing ? (
+							<div className="flex items-center gap-1.5 pt-1 pb-1.5 text-muted-foreground text-xs">
+								<Pencil className="size-3 shrink-0" aria-hidden="true" />
+								<span className="min-w-0 truncate">Editing message</span>
+								<button
+									type="button"
+									aria-label="Cancel editing"
+									className="relative flex size-4 items-center justify-center rounded-sm transition-colors before:absolute before:-inset-1.5 before:content-[''] hover:text-foreground"
+									onClick={onCancelEdit}
+								>
+									<X className="size-3.5" />
+								</button>
+							</div>
+						) : null}
+					</AiChatComposerReveal>
 					<AiChatQueueTray
 						threadId={activeThreadId}
 						onEdit={handleEditQueued}
@@ -256,7 +307,7 @@ export default function AiChatPromptInput({
 						readOnly={dictation.isActive}
 						value={input}
 						onKeyDown={handleTextareaKeyDown}
-						placeholder="Ask anything"
+						placeholder={isEditing ? "Edit your message" : "Ask anything"}
 						onChange={(event) => setInput(event.currentTarget.value)}
 						className={cn(
 							"min-h-10 pt-2 pb-1 text-base placeholder:text-foreground/45 md:text-base",

--- a/src/features/workspaces/components/ai-chat/AiChatThreadView.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatThreadView.tsx
@@ -1,5 +1,8 @@
 import { generateId } from "ai";
 import { useEffect, useEffectEvent, useState } from "react";
+import { toast } from "sonner";
+
+import { WORKSPACE_AI_CHAT_ATTACHMENT_POLICY } from "#/features/workspaces/ai/chat-attachment-policy";
 
 import type { PromptInputMessage } from "#/features/workspaces/components/ai-chat/ai-chat-prompt-input";
 import AiChatMessageList from "#/features/workspaces/components/ai-chat/AiChatMessageList";
@@ -7,6 +10,7 @@ import AiChatPromptInput from "#/features/workspaces/components/ai-chat/AiChatPr
 import { deriveAiChatAssistantErrorState } from "#/features/workspaces/components/ai-chat/ai-chat-error-state";
 import { aiChatComposerRailClassName } from "#/features/workspaces/components/ai-chat/ai-chat-layout";
 import type {
+	AiChatMessage,
 	AiChatModelId,
 	AiChatSendMessage,
 } from "#/features/workspaces/components/ai-chat/types";
@@ -47,6 +51,7 @@ export default function AiChatThreadView({
 	const {
 		canSend,
 		connectionError,
+		editMessage,
 		inputStatus,
 		messages,
 		presentation,
@@ -54,6 +59,39 @@ export default function AiChatThreadView({
 		sendMessage: sendChatMessage,
 		stop,
 	} = chat;
+	// Editing the latest user message reuses the main composer (ai-chatbot's
+	// pattern): its text is loaded as the draft, a banner marks the mode, and
+	// submitting resends the same message id — the server treats that as
+	// truncate-and-rerun, replacing the previous response. The message's
+	// original attachments are kept; newly staged files are added.
+	const [editing, setEditing] = useState<{
+		fileParts: AiChatMessage["parts"];
+		messageId: string;
+		previousDraft: string;
+	} | null>(null);
+	const setDraftText = useWorkspaceAiComposerDraftStore((state) => state.setText);
+	const startEditing = (message: AiChatMessage) => {
+		const text = message.parts
+			.flatMap((part) => (part.type === "text" ? part.text : []))
+			.join("\n\n");
+
+		setEditing({
+			fileParts: message.parts.filter((part) => part.type === "file"),
+			messageId: message.id,
+			previousDraft: useWorkspaceAiComposerDraftStore.getState().textByThreadId[threadId] ?? "",
+		});
+		setDraftText(threadId, text);
+	};
+	const cancelEditing = () => setEditing(null);
+	// Leaving edit mode — cancel, submit, or the per-thread remount on a thread
+	// switch — gives back the draft the edit displaced. Cleanup-only: the state
+	// change that triggers it happens in the event handlers.
+	useEffect(() => {
+		if (!editing) {
+			return undefined;
+		}
+		return () => setDraftText(threadId, editing.previousDraft);
+	}, [editing, setDraftText, threadId]);
 	const clearDraftArtifacts = useWorkspaceAiComposerDraftStore(
 		(state) => state.clearDraftArtifacts,
 	);
@@ -75,7 +113,7 @@ export default function AiChatThreadView({
 		lastMessageRole: lastMessage?.role,
 		lastMessageErrorMessage: lastMessageMetadata?.errorMessage,
 	});
-	const sendMessage = (message: PromptInputMessage, clearDraft = true) => {
+	const sendMessage = (message: PromptInputMessage) => {
 		const chatMessage = getChatMessageFromPrompt(message, generateId());
 
 		if (!chatMessage) {
@@ -85,7 +123,38 @@ export default function AiChatThreadView({
 		setScrollAnchorMessageId(chatMessage.id);
 		sendChatMessage(chatMessage);
 		setSentMessageAnimationId(chatMessage.id);
-		if (clearDraft) clearDraftArtifacts(context.workspaceId, threadId);
+		clearDraftArtifacts(context.workspaceId, threadId);
+	};
+	const submitEditedMessage = (message: PromptInputMessage) => {
+		if (!editing) {
+			return;
+		}
+
+		// The intake limit only counted newly staged files; with the original
+		// attachments riding along, the combined message must still fit it.
+		if (
+			editing.fileParts.length + message.files.length >
+			WORKSPACE_AI_CHAT_ATTACHMENT_POLICY.maxFiles
+		) {
+			toast.error(
+				`A message can include at most ${WORKSPACE_AI_CHAT_ATTACHMENT_POLICY.maxFiles} attachments.`,
+			);
+			return;
+		}
+
+		// Same id, new parts: the server treats the resend as truncate-and-rerun.
+		// The message's original attachments ride along ahead of newly staged ones.
+		const chatMessage = getChatMessageFromPrompt(message, editing.messageId, editing.fileParts);
+
+		if (!chatMessage) {
+			return;
+		}
+
+		setEditing(null);
+		setScrollAnchorMessageId(chatMessage.id);
+		editMessage(chatMessage);
+		setSentMessageAnimationId(chatMessage.id);
+		clearDraftArtifacts(context.workspaceId, threadId);
 	};
 	// A drained entry fails exactly like a manual send: the message stays in
 	// the transcript with the error banner and "Try again" re-runs it (the
@@ -130,6 +199,9 @@ export default function AiChatThreadView({
 	useEffect(() => {
 		if (
 			!queueHead ||
+			// Held during an edit: a drained turn would land after the message being
+			// edited, and the edit's truncate-and-rerun would then destroy it.
+			editing !== null ||
 			!canDrainQueuedMessage({
 				canSend,
 				errorKind: assistantError?.kind,
@@ -158,7 +230,16 @@ export default function AiChatThreadView({
 		return () => {
 			cancelled = true;
 		};
-	}, [canSend, assistantError?.kind, isBlocked, queueHead, queuePaused, takeQueueHead, threadId]);
+	}, [
+		canSend,
+		assistantError?.kind,
+		editing,
+		isBlocked,
+		queueHead,
+		queuePaused,
+		takeQueueHead,
+		threadId,
+	]);
 	const stopGeneration = () => {
 		stop();
 	};
@@ -177,11 +258,15 @@ export default function AiChatThreadView({
 			<AiChatMessageList
 				anchorMessageId={scrollAnchorMessageId}
 				assistantError={assistantError}
+				editingMessageId={editing?.messageId}
 				messages={messages}
 				presentation={presentation}
 				sentMessageAnimationId={sentMessageAnimationId}
 				workspaceId={context.workspaceId}
-				onRegenerateLastResponse={() => regenerate()}
+				onEditMessage={canSend && !queueHead && !editing ? startEditing : undefined}
+				// Hidden while editing: regenerating the reply the edit is about to
+				// delete makes the chat busy and strands the edit with a dead submit.
+				onRegenerateLastResponse={editing ? undefined : () => regenerate()}
 				onStartNewChat={onStartNewChat}
 			/>
 
@@ -191,10 +276,12 @@ export default function AiChatThreadView({
 						activeThreadId={threadId}
 						canSend={canSend}
 						context={context}
+						isEditing={Boolean(editing)}
 						modelId={modelId}
 						status={inputStatus}
+						onCancelEdit={cancelEditing}
 						onModelChange={onModelChange}
-						onSubmit={(message) => sendMessage(message)}
+						onSubmit={(message) => (editing ? submitEditedMessage(message) : sendMessage(message))}
 						onStop={handleUserStop}
 						onInterrupt={stopGeneration}
 						onSendNow={handleSendNow}
@@ -208,10 +295,12 @@ export default function AiChatThreadView({
 function getChatMessageFromPrompt(
 	message: PromptInputMessage,
 	id: string,
+	extraParts: AiChatMessage["parts"] = [],
 ): AiChatSendMessage | null {
 	const trimmedText = message.text.trim();
 	const parts = [
 		...(trimmedText ? [{ type: "text" as const, text: trimmedText }] : []),
+		...extraParts,
 		...message.files,
 	];
 

--- a/src/features/workspaces/components/ai-chat/useAiChatPanelController.ts
+++ b/src/features/workspaces/components/ai-chat/useAiChatPanelController.ts
@@ -150,6 +150,10 @@ export function useAiChatPanelController({ workspaceId }: UseAiChatPanelControll
 
 	return {
 		activeThreadId: resolvedActiveThreadId,
+		// LOAD-BEARING: keying the thread view remounts it per thread (and per
+		// delete-epoch), so per-thread view state — edit mode, scroll, animations,
+		// the useChat instance — resets without any thread-change effects. New
+		// per-thread state can rely on this instead of watching threadId.
 		threadViewKey: `${resolvedActiveThreadId}:${threadViewEpoch}`,
 		isLoading: !areThreadsReady,
 		isMaximized,

--- a/src/features/workspaces/components/ai-chat/useWorkspaceAiChat.ts
+++ b/src/features/workspaces/components/ai-chat/useWorkspaceAiChat.ts
@@ -145,6 +145,21 @@ export function useWorkspaceAiChat({
 			}
 		});
 	};
+	// Edit-and-resend: the server treats a resent user-message id as
+	// truncate-and-rerun, so editing is sending the same id with new parts.
+	// Drop the old copy and everything after it locally first — the SDK's send
+	// pushes the new copy, and the old reply is gone server-side anyway.
+	const editMessage = (message: AiChatSendMessage) => {
+		if (message.parts.length === 0 || !canSend) {
+			throw new Error("Cannot edit a chat message while the chat is unavailable");
+		}
+
+		setMessages((current) => {
+			const index = current.findIndex((entry) => entry.id === message.id);
+			return index === -1 ? current : current.slice(0, index);
+		});
+		void sendChatMessage(message, withRequestContext());
+	};
 	const regenerate = (options?: AiChatSendMessageOptions) => {
 		if (presentation.isBusy) {
 			return;
@@ -189,6 +204,7 @@ export function useWorkspaceAiChat({
 	return {
 		canSend,
 		connectionError,
+		editMessage,
 		inputStatus,
 		messages,
 		presentation,

--- a/src/features/workspaces/state/persisted-store-hydration.tsx
+++ b/src/features/workspaces/state/persisted-store-hydration.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useSyncExternalStore } from "react";
 
+import { useWorkspaceAiComposerDraftStore } from "#/features/workspaces/state/workspace-ai-composer-draft-store";
 import { useWorkspaceTabsStore } from "#/features/workspaces/state/workspace-tabs-store";
 import { useWorkspaceUiStore } from "#/features/workspaces/state/workspace-ui-store";
 
@@ -11,7 +12,11 @@ type PersistedStore = {
 	};
 };
 
-const persistedStores = [useWorkspaceTabsStore, useWorkspaceUiStore] as const;
+const persistedStores = [
+	useWorkspaceAiComposerDraftStore,
+	useWorkspaceTabsStore,
+	useWorkspaceUiStore,
+] as const;
 
 function hasHydratedAllStores() {
 	return persistedStores.every((store) => store.persist.hasHydrated());

--- a/src/features/workspaces/state/workspace-ai-composer-draft-store.ts
+++ b/src/features/workspaces/state/workspace-ai-composer-draft-store.ts
@@ -2,6 +2,7 @@ import type { FileUIPart } from "ai";
 import { nanoid } from "nanoid";
 import { type SetStateAction, useMemo } from "react";
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 import {
 	type FileAttachmentData,
 	getFileAttachmentData,
@@ -57,166 +58,203 @@ const EMPTY_DRAFT_FILES: WorkspaceAiComposerDraftFile[] = [];
 const EMPTY_DRAFT_QUOTES: WorkspaceSelectedQuote[] = [];
 
 export const useWorkspaceAiComposerDraftStore = create<WorkspaceAiComposerDraftState>()(
-	(set, get) => ({
-		addFiles: (workspaceId, threadId, fileList, options) => {
-			const current = get().filesByThreadId[threadId] ?? EMPTY_DRAFT_FILES;
-			const capped = acceptIncomingFiles([...fileList], {
-				accept: options.accept,
-				currentCount: current.length,
-				maxFileSize: options.maxFileSize,
-				maxFiles: options.maxFiles,
-				onError: options.onError,
-			});
+	persist(
+		(set, get) => ({
+			addFiles: (workspaceId, threadId, fileList, options) => {
+				const current = get().filesByThreadId[threadId] ?? EMPTY_DRAFT_FILES;
+				const capped = acceptIncomingFiles([...fileList], {
+					accept: options.accept,
+					currentCount: current.length,
+					maxFileSize: options.maxFileSize,
+					maxFiles: options.maxFiles,
+					onError: options.onError,
+				});
 
-			if (capped.length === 0) {
-				return;
-			}
-
-			const placeholders = capped.map(createLoadingDraftFile);
-
-			set((state) => ({
-				filesByThreadId: {
-					...state.filesByThreadId,
-					[threadId]: [...current, ...placeholders],
-				},
-			}));
-
-			for (const [index, file] of capped.entries()) {
-				const placeholder = placeholders[index];
-				if (!placeholder) {
-					continue;
+				if (capped.length === 0) {
+					return;
 				}
 
-				void uploadWorkspaceAiChatAttachment({
-					file,
-					threadId,
-					workspaceId,
-				})
-					.then((attachment) => {
-						const draftStillExists = get().filesByThreadId[threadId]?.some(
-							(item) => item.id === placeholder.id,
-						);
-						if (!draftStillExists) {
-							void discardUploadedAttachment(attachment.url);
-							return;
-						}
-						set((state) => markDraftFileReady(state, threadId, placeholder.id, attachment));
-					})
-					.catch((error) => {
-						set((state) => removeDraftFile(state, threadId, placeholder.id));
-						options.onError?.({
-							code: "read",
-							message:
-								error instanceof Error && error.message.trim()
-									? error.message
-									: `Could not prepare "${file.name}".`,
-						});
-					});
-			}
-		},
-		addQuote: (workspaceId, quote) =>
-			set((state) => {
-				const normalizedQuote = normalizeWorkspaceSelectedQuote(quote);
-				if (!normalizedQuote) {
-					return state;
-				}
+				const placeholders = capped.map(createLoadingDraftFile);
 
-				const current = state.quotesByWorkspaceId[workspaceId] ?? EMPTY_DRAFT_QUOTES;
-
-				return {
-					quotesByWorkspaceId: {
-						...state.quotesByWorkspaceId,
-						[workspaceId]: [
-							...current.filter((item) => item.id !== normalizedQuote.id),
-							normalizedQuote,
-						],
-					},
-				};
-			}),
-		clearDraftArtifacts: (workspaceId, threadId) =>
-			set((state) => clearDraftArtifacts(state, workspaceId, threadId)),
-		clearFiles: (threadId) => set((state) => clearFilesForThread(state, threadId)),
-		clearQuotes: (workspaceId) =>
-			set((state) => {
-				const current = state.quotesByWorkspaceId[workspaceId] ?? EMPTY_DRAFT_QUOTES;
-				if (current.length === 0) {
-					return state;
-				}
-
-				return {
-					quotesByWorkspaceId: {
-						...state.quotesByWorkspaceId,
-						[workspaceId]: undefined,
-					},
-				};
-			}),
-		addReadyFiles: (threadId, parts) => {
-			const current = get().filesByThreadId[threadId] ?? EMPTY_DRAFT_FILES;
-			const next = [...current];
-			for (const part of parts) {
-				const file = getFileAttachmentData(part);
-				if (!next.some((item) => item.id === file.id)) {
-					next.push(file);
-				}
-			}
-
-			if (next.length > WORKSPACE_AI_CHAT_ATTACHMENT_POLICY.maxFiles) {
-				return false;
-			}
-			if (next.length !== current.length) {
 				set((state) => ({
 					filesByThreadId: {
 						...state.filesByThreadId,
-						[threadId]: next,
+						[threadId]: [...current, ...placeholders],
 					},
 				}));
-			}
 
-			return true;
-		},
-		filesByThreadId: {},
-		quotesByWorkspaceId: {},
-		removeFile: (threadId, fileId) => {
-			const file = get().filesByThreadId[threadId]?.find((item) => item.id === fileId);
-			set((state) => removeDraftFile(state, threadId, fileId));
-			if (file?.url) {
-				void discardUploadedAttachment(file.url);
-			}
-		},
-		removeQuote: (workspaceId, quoteId) =>
-			set((state) => {
-				const current = state.quotesByWorkspaceId[workspaceId] ?? EMPTY_DRAFT_QUOTES;
-				if (!current.some((quote) => quote.id === quoteId)) {
-					return state;
+				for (const [index, file] of capped.entries()) {
+					const placeholder = placeholders[index];
+					if (!placeholder) {
+						continue;
+					}
+
+					void uploadWorkspaceAiChatAttachment({
+						file,
+						threadId,
+						workspaceId,
+					})
+						.then((attachment) => {
+							const draftStillExists = get().filesByThreadId[threadId]?.some(
+								(item) => item.id === placeholder.id,
+							);
+							if (!draftStillExists) {
+								void discardUploadedAttachment(attachment.url);
+								return;
+							}
+							set((state) => markDraftFileReady(state, threadId, placeholder.id, attachment));
+						})
+						.catch((error) => {
+							set((state) => removeDraftFile(state, threadId, placeholder.id));
+							options.onError?.({
+								code: "read",
+								message:
+									error instanceof Error && error.message.trim()
+										? error.message
+										: `Could not prepare "${file.name}".`,
+							});
+						});
+				}
+			},
+			addQuote: (workspaceId, quote) =>
+				set((state) => {
+					const normalizedQuote = normalizeWorkspaceSelectedQuote(quote);
+					if (!normalizedQuote) {
+						return state;
+					}
+
+					const current = state.quotesByWorkspaceId[workspaceId] ?? EMPTY_DRAFT_QUOTES;
+
+					return {
+						quotesByWorkspaceId: {
+							...state.quotesByWorkspaceId,
+							[workspaceId]: [
+								...current.filter((item) => item.id !== normalizedQuote.id),
+								normalizedQuote,
+							],
+						},
+					};
+				}),
+			clearDraftArtifacts: (workspaceId, threadId) =>
+				set((state) => clearDraftArtifacts(state, workspaceId, threadId)),
+			clearFiles: (threadId) => set((state) => clearFilesForThread(state, threadId)),
+			clearQuotes: (workspaceId) =>
+				set((state) => {
+					const current = state.quotesByWorkspaceId[workspaceId] ?? EMPTY_DRAFT_QUOTES;
+					if (current.length === 0) {
+						return state;
+					}
+
+					return {
+						quotesByWorkspaceId: {
+							...state.quotesByWorkspaceId,
+							[workspaceId]: undefined,
+						},
+					};
+				}),
+			addReadyFiles: (threadId, parts) => {
+				const current = get().filesByThreadId[threadId] ?? EMPTY_DRAFT_FILES;
+				const next = [...current];
+				for (const part of parts) {
+					const file = getFileAttachmentData(part);
+					if (!next.some((item) => item.id === file.id)) {
+						next.push(file);
+					}
 				}
 
-				const next = current.filter((quote) => quote.id !== quoteId);
-				return {
-					quotesByWorkspaceId: {
-						...state.quotesByWorkspaceId,
-						[workspaceId]: next.length > 0 ? next : undefined,
-					},
-				};
-			}),
-		setText: (threadId, value) =>
-			set((state) => {
-				const current = state.textByThreadId[threadId] ?? "";
-				const next = typeof value === "function" ? value(current) : value;
-
-				if (next === current) {
-					return state;
+				if (next.length > WORKSPACE_AI_CHAT_ATTACHMENT_POLICY.maxFiles) {
+					return false;
+				}
+				if (next.length !== current.length) {
+					set((state) => ({
+						filesByThreadId: {
+							...state.filesByThreadId,
+							[threadId]: next,
+						},
+					}));
 				}
 
-				return {
-					textByThreadId: {
-						...state.textByThreadId,
-						[threadId]: next || undefined,
-					},
-				};
+				return true;
+			},
+			filesByThreadId: {},
+			quotesByWorkspaceId: {},
+			removeFile: (threadId, fileId) => {
+				const file = get().filesByThreadId[threadId]?.find((item) => item.id === fileId);
+				set((state) => removeDraftFile(state, threadId, fileId));
+				if (file?.url) {
+					void discardUploadedAttachment(file.url);
+				}
+			},
+			removeQuote: (workspaceId, quoteId) =>
+				set((state) => {
+					const current = state.quotesByWorkspaceId[workspaceId] ?? EMPTY_DRAFT_QUOTES;
+					if (!current.some((quote) => quote.id === quoteId)) {
+						return state;
+					}
+
+					const next = current.filter((quote) => quote.id !== quoteId);
+					return {
+						quotesByWorkspaceId: {
+							...state.quotesByWorkspaceId,
+							[workspaceId]: next.length > 0 ? next : undefined,
+						},
+					};
+				}),
+			setText: (threadId, value) =>
+				set((state) => {
+					const current = state.textByThreadId[threadId] ?? "";
+					const next = typeof value === "function" ? value(current) : value;
+
+					if (next === current) {
+						return state;
+					}
+
+					return {
+						textByThreadId: {
+							...state.textByThreadId,
+							[threadId]: next || undefined,
+						},
+					};
+				}),
+			textByThreadId: {},
+		}),
+		{
+			name: "thinkex.ai-composer-drafts.v1",
+			skipHydration: true,
+			// Only settled state survives a reload: a "loading" chip's upload died
+			// with the page, so restoring it would show a spinner that never
+			// resolves. (Ready files are just {id, name, mediaType, url} records —
+			// the bytes are already server-side.) Empty slots are pruned so the
+			// stored blob stays small.
+			partialize: (state) => ({
+				filesByThreadId: persistableDraftFiles(state.filesByThreadId),
+				quotesByWorkspaceId: pruneEmptyDraftSlots(state.quotesByWorkspaceId),
+				textByThreadId: pruneEmptyDraftSlots(state.textByThreadId),
 			}),
-		textByThreadId: {},
-	}),
+		},
+	),
 );
+
+function persistableDraftFiles(filesByThreadId: WorkspaceAiComposerDraftState["filesByThreadId"]) {
+	const persisted: WorkspaceAiComposerDraftState["filesByThreadId"] = {};
+
+	for (const [threadId, files] of Object.entries(filesByThreadId)) {
+		const ready = files?.filter((file) => file.status === "ready") ?? [];
+		if (ready.length > 0) {
+			persisted[threadId] = ready;
+		}
+	}
+
+	return persisted;
+}
+
+// Writers store `undefined` when a slot empties, so undefined is the only
+// empty shape to prune.
+function pruneEmptyDraftSlots<T>(map: Record<string, T | undefined>): Record<string, T> {
+	return Object.fromEntries(
+		Object.entries(map).filter((entry): entry is [string, T] => entry[1] !== undefined),
+	);
+}
 
 export function useWorkspaceAiComposerDraftFiles(threadId: string) {
 	return useWorkspaceAiComposerDraftStore(


### PR DESCRIPTION
Adds message editing: a pencil action on your latest message rewrites it and regenerates the AI's response.

## How it works

- **Hover the latest user message → pencil.** Only offered while the chat is idle with no queued messages — editing is an "at rest" action.
- **The main composer becomes the editor** (this is ai-chatbot's current pattern; they moved away from an inline per-message editor, and reusing the composer means attachments, dictation, and the model picker need no duplicate wiring). The message's text is loaded as the draft, a banner explains that sending replaces the previous response, and Escape or the banner's ✕ cancels.
- **Sending resends the same message id.** The server already treats a resent user-message id as truncate-and-rerun (the same mechanism behind "Try again"), so the old reply is deleted and a fresh one generates — no new endpoints, no schema changes, zero server-side diff.
- **Attachments carry over.** The edited message keeps its original files; anything newly staged in the composer is added. Text is what you're editing.
- **Drafts are never lost.** Entering edit displaces whatever you had typed; cancel, submit, or switching threads gives it back.

## Reference notes

Studied OpenCode's revert system and ai-chatbot's message editing before building. OpenCode's version also restores filesystem snapshots to undo the AI's file changes — we have no workspace snapshots, so (like ChatGPT) editing regenerates the conversation but does not undo workspace changes the old reply made with tools.

Client-only change: one new hook method (`editMessage`, the mirror of the existing retry-resend), edit state in the thread view, a banner + guards in the composer, and the pencil action. Verified: typecheck green, 99 chat tests pass.

https://claude.ai/code/session_01Vy2N9tuKcNPLKgkwyseVxL

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789533409&installation_model_id=425282&pr_number=801&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F801&signature=2268d65ed5fb3d239f3c4ef64b77bdbad845edd112edabad83a40c47af56c744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to edit the latest user message in AI chat.
  * Added an Edit action with a pencil icon for eligible messages.
  * Restores the message text and attached files in the composer for editing.
  * Supports submitting edits, canceling with a button, or pressing Escape.
  * Preserves unsent drafts when editing is canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->