### PR TITLE
feat(workspaces): collapse deep breadcrumb paths into a menu

### DIFF
--- a/src/features/workspaces/components/WorkspaceBreadcrumbOverflow.tsx
+++ b/src/features/workspaces/components/WorkspaceBreadcrumbOverflow.tsx
@@ -14,8 +14,6 @@ import { getWorkspaceItemDisplay } from "#/features/workspaces/model/item-displa
 import type { WorkspaceItem } from "#/features/workspaces/contracts";
 import { cn } from "#/lib/utils";
 
-const showPathLabel = "Show path";
-
 interface WorkspaceBreadcrumbOverflowProps {
 	items: WorkspaceItem[];
 	className?: string;
@@ -45,7 +43,7 @@ export default function WorkspaceBreadcrumbOverflow({
 										<button
 											type="button"
 											className="flex size-7 items-center justify-center rounded-sm text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
-											aria-label={showPathLabel}
+											aria-label="Show path"
 										/>
 									}
 								>
@@ -53,7 +51,7 @@ export default function WorkspaceBreadcrumbOverflow({
 								</DropdownMenuTrigger>
 							}
 						/>
-						<TooltipContent>{showPathLabel}</TooltipContent>
+						<TooltipContent>Show path</TooltipContent>
 					</Tooltip>
 					<DropdownMenuContent align="start" className="w-56">
 						{items.map((item) => {

--- a/src/features/workspaces/components/WorkspaceBreadcrumbOverflow.tsx
+++ b/src/features/workspaces/components/WorkspaceBreadcrumbOverflow.tsx
@@ -9,38 +9,52 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "#/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "#/components/ui/tooltip";
 import { getWorkspaceItemDisplay } from "#/features/workspaces/model/item-display";
 import type { WorkspaceItem } from "#/features/workspaces/contracts";
+import { cn } from "#/lib/utils";
 
-interface WorkspaceMobileBreadcrumbOverflowProps {
+const showPathLabel = "Show path";
+
+interface WorkspaceBreadcrumbOverflowProps {
 	items: WorkspaceItem[];
+	className?: string;
 	onNavigateToItem: (item: WorkspaceItem) => void;
 }
 
-export default function WorkspaceMobileBreadcrumbOverflow({
+/** Crumbs hidden from the bar, reachable through a bare "…" menu. */
+export default function WorkspaceBreadcrumbOverflow({
 	items,
+	className,
 	onNavigateToItem,
-}: WorkspaceMobileBreadcrumbOverflowProps) {
+}: WorkspaceBreadcrumbOverflowProps) {
 	if (items.length === 0) {
 		return null;
 	}
 
 	return (
 		<>
-			<BreadcrumbSeparator className="text-muted-foreground/60 sm:hidden" />
-			<BreadcrumbItem className="sm:hidden">
+			<BreadcrumbSeparator className={cn("text-muted-foreground/60", className)} />
+			<BreadcrumbItem className={className}>
 				<DropdownMenu>
-					<DropdownMenuTrigger
-						render={
-							<button
-								type="button"
-								className="flex size-7 items-center justify-center rounded-sm text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
-								aria-label="Open breadcrumb path"
-							/>
-						}
-					>
-						<BreadcrumbEllipsis className="size-7" />
-					</DropdownMenuTrigger>
+					<Tooltip>
+						<TooltipTrigger
+							render={
+								<DropdownMenuTrigger
+									render={
+										<button
+											type="button"
+											className="flex size-7 items-center justify-center rounded-sm text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+											aria-label={showPathLabel}
+										/>
+									}
+								>
+									<BreadcrumbEllipsis className="size-7" />
+								</DropdownMenuTrigger>
+							}
+						/>
+						<TooltipContent>{showPathLabel}</TooltipContent>
+					</Tooltip>
 					<DropdownMenuContent align="start" className="w-56">
 						{items.map((item) => {
 							const { Icon, iconClassName, label } = getWorkspaceItemDisplay(item);

--- a/src/features/workspaces/components/WorkspaceContextBar.tsx
+++ b/src/features/workspaces/components/WorkspaceContextBar.tsx
@@ -15,10 +15,10 @@ import {
 	DeleteWorkspaceItemAlert,
 	RenameWorkspaceItemDialog,
 } from "#/features/workspaces/components/WorkspaceItemActionDialogs";
+import WorkspaceBreadcrumbOverflow from "#/features/workspaces/components/WorkspaceBreadcrumbOverflow";
 import WorkspaceItemActionsMenu from "#/features/workspaces/components/WorkspaceItemActionsMenu";
 import { WorkspaceItemToolbarSlot } from "#/features/workspaces/components/WorkspaceItemToolbarSlot";
 import { MoveWorkspaceItemsDialog } from "#/features/workspaces/components/WorkspaceMoveItemsDialog";
-import WorkspaceMobileBreadcrumbOverflow from "#/features/workspaces/components/WorkspaceMobileBreadcrumbOverflow";
 import WorkspaceRootActionsMenu from "#/features/workspaces/components/WorkspaceRootActionsMenu";
 import { WorkspaceSearchDialog } from "#/features/workspaces/components/WorkspaceSearchDialog";
 import { WorkspaceToolbarGroup } from "#/features/workspaces/components/WorkspaceToolbar";
@@ -35,6 +35,9 @@ const breadcrumbContentClassName = "flex min-w-0 items-center gap-1.5 truncate";
 const breadcrumbCurrentClassName = `${breadcrumbContentClassName} text-foreground`;
 const breadcrumbLinkClassName = `${breadcrumbContentClassName} rounded-sm border-0 bg-transparent p-0 font-[inherit] text-muted-foreground underline-offset-4 outline-none transition-colors hover:text-foreground hover:underline focus-visible:ring-2 focus-visible:ring-ring active:translate-y-0`;
 const currentCrumbLabelClassName = "[text-shadow:0.025em_0_0_currentColor]";
+// Past this depth the bar keeps the workspace crumb and the tail, and collapses the rest.
+const maxVisibleCrumbs = 3;
+const visibleTailCrumbs = 2;
 
 interface WorkspaceContextBarProps {
 	workspace: WorkspaceSummary;
@@ -60,7 +63,11 @@ export default function WorkspaceContextBar({
 	const { Icon: WorkspaceIcon, color } = getWorkspaceDisplay(workspace);
 	const [searchOpen, setSearchOpen] = useState(false);
 	const breadcrumbs = getWorkspaceBreadcrumbItems(activeItem, itemsById);
+	// Mobile only ever has room for the current crumb, so it collapses everything above it.
 	const mobileOverflowBreadcrumbs = breadcrumbs.slice(0, -1);
+	const collapsedCrumbCount =
+		breadcrumbs.length > maxVisibleCrumbs ? breadcrumbs.length - visibleTailCrumbs : 0;
+	const overflowBreadcrumbs = breadcrumbs.slice(0, collapsedCrumbCount);
 	const createParentId = getWorkspaceBrowseParentId(activeItem);
 	const workspaceItems = Array.from(itemsById.values());
 	const {
@@ -119,8 +126,14 @@ export default function WorkspaceContextBar({
 								/>
 							)}
 						</BreadcrumbItem>
-						<WorkspaceMobileBreadcrumbOverflow
+						<WorkspaceBreadcrumbOverflow
+							className="sm:hidden"
 							items={mobileOverflowBreadcrumbs}
+							onNavigateToItem={onNavigateToItem}
+						/>
+						<WorkspaceBreadcrumbOverflow
+							className="hidden sm:flex"
+							items={overflowBreadcrumbs}
 							onNavigateToItem={onNavigateToItem}
 						/>
 						{breadcrumbs.map((item, index) => (
@@ -128,6 +141,7 @@ export default function WorkspaceContextBar({
 								key={item.id}
 								item={item}
 								isCurrent={item.id === activeItem?.id}
+								isCollapsed={index < collapsedCrumbCount}
 								isMobileHidden={index < breadcrumbs.length - 1}
 								onClick={() => onNavigateToItem(item)}
 								onRenameItem={setRenamingItem}
@@ -190,6 +204,7 @@ export default function WorkspaceContextBar({
 
 function WorkspaceBreadcrumbItem({
 	item,
+	isCollapsed,
 	isCurrent,
 	isMobileHidden,
 	onClick,
@@ -198,6 +213,7 @@ function WorkspaceBreadcrumbItem({
 	onDeleteItem,
 }: {
 	item: WorkspaceItem;
+	isCollapsed: boolean;
 	isCurrent: boolean;
 	isMobileHidden: boolean;
 	onClick: () => void;
@@ -206,12 +222,12 @@ function WorkspaceBreadcrumbItem({
 	onDeleteItem: (item: WorkspaceItem) => void;
 }) {
 	const { Icon, iconClassName } = getWorkspaceItemDisplay(item);
-	const mobileHiddenClassName = isMobileHidden ? "hidden sm:flex" : undefined;
+	const visibilityClassName = getCrumbVisibilityClassName(isCollapsed, isMobileHidden);
 
 	return (
 		<>
-			<BreadcrumbSeparator className={cn("text-muted-foreground/60", mobileHiddenClassName)} />
-			<BreadcrumbItem className={cn("min-w-0", isCurrent && "flex-shrink", mobileHiddenClassName)}>
+			<BreadcrumbSeparator className={cn("text-muted-foreground/60", visibilityClassName)} />
+			<BreadcrumbItem className={cn("min-w-0", isCurrent && "flex-shrink", visibilityClassName)}>
 				{isCurrent ? (
 					<WorkspaceItemActionsMenu
 						item={item}
@@ -248,6 +264,15 @@ function WorkspaceBreadcrumbItem({
 			</BreadcrumbItem>
 		</>
 	);
+}
+
+/** Collapsed crumbs move into the "…" menu; the rest still make room for the current crumb on mobile. */
+function getCrumbVisibilityClassName(isCollapsed: boolean, isMobileHidden: boolean) {
+	if (isCollapsed) {
+		return "hidden";
+	}
+
+	return isMobileHidden ? "hidden sm:flex" : undefined;
 }
 
 function CrumbButton({

--- a/src/features/workspaces/components/WorkspaceContextBar.tsx
+++ b/src/features/workspaces/components/WorkspaceContextBar.tsx
@@ -222,7 +222,12 @@ function WorkspaceBreadcrumbItem({
 	onDeleteItem: (item: WorkspaceItem) => void;
 }) {
 	const { Icon, iconClassName } = getWorkspaceItemDisplay(item);
-	const visibilityClassName = getCrumbVisibilityClassName(isCollapsed, isMobileHidden);
+	// Collapsed crumbs live in the "…" menu; the rest still make room for the current crumb on mobile.
+	const visibilityClassName = isCollapsed
+		? "hidden"
+		: isMobileHidden
+			? "hidden sm:flex"
+			: undefined;
 
 	return (
 		<>
@@ -264,15 +269,6 @@ function WorkspaceBreadcrumbItem({
 			</BreadcrumbItem>
 		</>
 	);
-}
-
-/** Collapsed crumbs move into the "…" menu; the rest still make room for the current crumb on mobile. */
-function getCrumbVisibilityClassName(isCollapsed: boolean, isMobileHidden: boolean) {
-	if (isCollapsed) {
-		return "hidden";
-	}
-
-	return isMobileHidden ? "hidden sm:flex" : undefined;
 }
 
 function CrumbButton({


### PR DESCRIPTION
Deep workspace paths used to keep every crumb in the context bar, and the list is `flex-nowrap overflow-hidden` — so anything past the available width just clipped off the right edge with no way to reach it.

Now, past three levels, the bar shows the workspace crumb, a bare `…`, then the last two levels. The collapsed crumbs live in the menu behind the ellipsis.

**Rule:** collapse when there are more than 3 crumbs below the workspace; always keep the last 2. Count-based, no measurement — labels are already capped at `max-w-40` with truncate, so widths are bounded. If long names turn out to overflow anyway, the next step is a ResizeObserver "fit as many as possible" pass.

`WorkspaceMobileBreadcrumbOverflow` is generalised to `WorkspaceBreadcrumbOverflow` and now serves both breakpoints — mobile still collapses everything above the current crumb, desktop only the middle. Two instances, CSS-gated, so no media-query hook or hydration mismatch.

The trigger stays a bare `…` visually, with an `aria-label` and tooltip of "Show path" (matching MUI's `expandText` default).

Verified: `pnpm check` clean. Confirmed the Tooltip-wrapping-DropdownMenuTrigger composition renders a single `<button>` carrying both (`aria-haspopup="menu"` + `data-slot="tooltip-trigger"`), not nested buttons.

https://claude.ai/code/session_01K2DD5GWi4FSkJdRQBpKhGw

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789534381&installation_model_id=425282&pr_number=802&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F802&signature=4b272a01f403c7948a0b249311995294b4055d0a2d69bbfcaa157a441bab5f6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

