### PR TITLE
docs(repo): note that main auto-deploys via Workers Builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,6 @@
   legacy shims, no back-compat paths, and no data migrations for existing rows
   unless explicitly requested. Prefer deleting superseded code over keeping it
   reachable.
+- Merging IS shipping: Cloudflare Workers Builds auto-deploys every push to
+  `main` to production (wrangler migrations included). The `staging` branch
+  deploys to the staging env the same way. There is no manual deploy step.


### PR DESCRIPTION
Three lines in AGENTS.md: merging is shipping — Cloudflare Workers Builds deploys every main push to production (migrations included), staging branch → staging env, no manual deploy step. Verified against `wrangler deployments list` timestamps, which track merge times to the minute. (Replaces #803, closed by premature branch cleanup.)

https://claude.ai/code/session_01Vy2N9tuKcNPLKgkwyseVxL

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789535518&installation_model_id=425282&pr_number=804&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F804&signature=5a5aa796c0afcf8a27649c96c177fcf139a8d528c616aea60519b6b8effd4e04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

