### PR TITLE
feat(ai-chat): give the agent a Code Mode orchestrate tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,6 @@
 - Merging IS shipping: Cloudflare Workers Builds auto-deploys every push to
   `main` to production (wrangler migrations included). The `staging` branch
   deploys to the staging env the same way. There is no manual deploy step.
+- Commits carry code and the docs that ship with it. Research notes, analysis
+  writeups, and other generated markdown (e.g. `docs/research/`) stay as
+  untracked working files — commit them only when explicitly asked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,5 +8,5 @@
   `main` to production (wrangler migrations included). The `staging` branch
   deploys to the staging env the same way. There is no manual deploy step.
 - Commits carry code and the docs that ship with it. Research notes, analysis
-  writeups, and other generated markdown (e.g. `docs/research/`) stay as
-  untracked working files — commit them only when explicitly asked.
+  writeups, and other non-shipping generated markdown (e.g. `docs/research/`)
+  stay as untracked working files — commit them only when explicitly asked.

--- a/eval/codemode.eval.ts
+++ b/eval/codemode.eval.ts
@@ -1,0 +1,113 @@
+import { env } from "cloudflare:test";
+import { generateText, stepCountIs, type ToolSet } from "ai";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineAIThreadTool } from "#/features/workspaces/ai/ai-thread-tool";
+import type {
+	AiCodemodeActivityEvent,
+	AiCodemodeOutput,
+} from "#/features/workspaces/ai/codemode-tool";
+import { createAiChatCodemodeTool } from "#/features/workspaces/ai/codemode-tool";
+import {
+	getWorkspaceAiGatewayProviderOptions,
+	getWorkspaceAiLanguageModel,
+} from "#/features/workspaces/ai/gateway";
+import { resolveWorkspaceAiChatModelId } from "#/features/workspaces/ai/models";
+
+// Deterministic fixture: per-topic averages are algebra 66, geometry 90,
+// calculus 58, statistics 92; overall average 76.5; weakest topic calculus.
+const QUIZ_SCORES = [
+	{ topic: "algebra", score: 62 },
+	{ topic: "algebra", score: 70 },
+	{ topic: "geometry", score: 88 },
+	{ topic: "geometry", score: 92 },
+	{ topic: "calculus", score: 55 },
+	{ topic: "calculus", score: 61 },
+	{ topic: "statistics", score: 90 },
+	{ topic: "statistics", score: 94 },
+];
+
+function createQuizScoresTool() {
+	return defineAIThreadTool({
+		description: "List the user's quiz results (topic and score out of 100).",
+		inputSchema: z.object({}),
+		outputSchema: z.object({
+			scores: z.array(z.object({ topic: z.string(), score: z.number() })),
+		}),
+		execute: () => ({ scores: QUIZ_SCORES }),
+	});
+}
+
+async function runOrchestrateTurn(prompt: string) {
+	const events: AiCodemodeActivityEvent[] = [];
+	const innerTools: ToolSet = { get_quiz_scores: createQuizScoresTool() };
+	const tools: ToolSet = {
+		...innerTools,
+		orchestrate: createAiChatCodemodeTool({
+			env,
+			tools: innerTools,
+			onActivity: (event) => events.push(event),
+		}),
+	};
+	const modelId = resolveWorkspaceAiChatModelId(undefined);
+
+	const result = await generateText({
+		model: getWorkspaceAiLanguageModel(modelId, env, "eval-codemode"),
+		providerOptions: getWorkspaceAiGatewayProviderOptions({ modelId }),
+		system:
+			"You are the assistant inside the Study workspace of a learning app. Ground answers in tool results.",
+		prompt,
+		tools,
+		stopWhen: stepCountIs(4),
+	});
+
+	const orchestrateRuns: Array<{ input: unknown; output: AiCodemodeOutput }> = [];
+	for (const step of result.steps) {
+		for (const part of step.content) {
+			if (part.type === "tool-result" && part.toolName === "orchestrate") {
+				orchestrateRuns.push({
+					input: part.input,
+					// SAFETY: orchestrate's execute returns AiCodemodeOutput by
+					// construction; the eval only reads it for grading.
+					output: part.output as AiCodemodeOutput,
+				});
+			}
+		}
+	}
+
+	return { text: result.text, orchestrateRuns, events };
+}
+
+// Live evals: real model turns through the real gateway and a real dynamic
+// worker isolate. Billed and slow, so they run via `pnpm eval` only.
+describe.skipIf(!process.env.AI_GATEWAY_API_KEY)("orchestrate (code mode)", () => {
+	it("computes exact arithmetic through generated code", async () => {
+		const run = await runOrchestrateTurn(
+			"Compute exactly: 48271 × 3917. I need the precise number, no estimation.",
+		);
+		console.log("[arithmetic] text:", run.text);
+		console.log("[arithmetic] runs:", JSON.stringify(run.orchestrateRuns, null, 2));
+
+		expect(run.orchestrateRuns.length).toBeGreaterThanOrEqual(1);
+		const output = run.orchestrateRuns[0]!.output;
+		expect(output.status).toBe("completed");
+		expect(run.text.replace(/[,\s.]/g, "")).toContain("189077507");
+	});
+
+	it("aggregates tool data inside one orchestrate run", async () => {
+		const run = await runOrchestrateTurn(
+			"Using my quiz scores, compute my overall average score and identify my weakest topic by average. Compute, don't estimate.",
+		);
+		console.log("[aggregation] text:", run.text);
+		console.log("[aggregation] runs:", JSON.stringify(run.orchestrateRuns, null, 2));
+		console.log("[aggregation] events:", JSON.stringify(run.events));
+
+		expect(run.orchestrateRuns.length).toBeGreaterThanOrEqual(1);
+		const output = run.orchestrateRuns[0]!.output;
+		expect(output.status).toBe("completed");
+		expect(output.calls.some((call) => call.toolName === "get_quiz_scores")).toBe(true);
+		expect(run.text).toContain("76.5");
+		expect(run.text.toLowerCase()).toContain("calculus");
+	}, 180_000);
+});

--- a/eval/support/harness.ts
+++ b/eval/support/harness.ts
@@ -140,6 +140,34 @@ async function evalToolFixture(toolName: string, input: unknown): Promise<unknow
 
 		return { results };
 	}
+	// The tools whose adapters parse the output with the real schema need a
+	// schema-valid stub — a neutral object throws inside toModelOutput.
+	if (toolName === "workspace_edit_item") {
+		const record = input as { edits?: unknown[]; path?: string };
+		return {
+			path: record.path ?? STANDUP_PATH,
+			applied: record.edits?.length ?? 1,
+			itemId: "standup-document",
+			itemType: "document",
+			lineChanges: { added: 1, removed: 1 },
+			failed: [],
+		};
+	}
+	if (toolName === "workspace_create_items") {
+		const record = input as { items?: Array<{ path?: string; type?: string }> };
+		return {
+			items: (record.items ?? []).map((item, index) => ({
+				path: item.path ?? `/Created ${index + 1}`,
+				itemId: `eval-created-${index + 1}`,
+				ref: `i_evalCreated${index + 1}`,
+				type:
+					item.type === "folder" || item.type === "flashcard" || item.type === "quiz"
+						? item.type
+						: "document",
+			})),
+			failed: [],
+		};
+	}
 	return { ok: true, note: "eval stub — no real mutation" };
 }
 

--- a/src/features/workspaces/ai/ai-thread-tool.ts
+++ b/src/features/workspaces/ai/ai-thread-tool.ts
@@ -27,6 +27,37 @@ type AIThreadToolDefinition<INPUT, OUTPUT> = Pick<
 };
 
 /**
+ * The original schemas a tool was defined with, for consumers that need the
+ * real contract rather than the provider-flattened one — Code Mode type
+ * generation renders TypeScript from these.
+ */
+export interface AIThreadToolRuntime {
+	inputSchema: FlexibleSchema<unknown>;
+	outputSchema: FlexibleSchema<unknown>;
+}
+
+const toolRuntimes = new WeakMap<object, AIThreadToolRuntime>();
+
+/**
+ * Look up the original schemas of a tool created by {@link defineAIThreadTool}.
+ *
+ * @param toolName - The tool's name, for the defect message only.
+ * @param aiTool - The tool object returned by `defineAIThreadTool`.
+ * @returns The tool's original input and output schemas.
+ * @throws When the tool was not created via `defineAIThreadTool` — every
+ *   first-party chat tool must be.
+ */
+export function requireAIThreadToolRuntime(toolName: string, aiTool: object): AIThreadToolRuntime {
+	const runtime = toolRuntimes.get(aiTool);
+
+	if (!runtime) {
+		throw new Error(`Tool "${toolName}" was not defined via defineAIThreadTool`);
+	}
+
+	return runtime;
+}
+
+/**
  * Defines a first-party tool with runtime-validated input and output. The
  * output schema stays application-side (providers only need the input
  * contract), and the model-facing input schema is made provider-portable.
@@ -48,7 +79,7 @@ export function defineAIThreadTool<INPUT, OUTPUT>(
 	const validateInput = inputSchema.validate;
 	const validateOutput = validatedOutputSchema.validate;
 
-	return tool<INPUT, OUTPUT, Record<string, unknown>>({
+	const created = tool<INPUT, OUTPUT, Record<string, unknown>>({
 		...modelDefinition,
 		inputSchema: modelInputSchema,
 		execute: async (input: INPUT, options: ToolExecutionOptions<unknown>) => {
@@ -69,6 +100,16 @@ export function defineAIThreadTool<INPUT, OUTPUT>(
 			return validatedOutput.value;
 		},
 	} as unknown as Tool<INPUT, OUTPUT, Record<string, unknown>>) as Tool<any, any, any>;
+
+	toolRuntimes.set(created, {
+		// SAFETY: FlexibleSchema is read here only to render JSON Schema /
+		// TypeScript types, never to produce typed values, so widening the
+		// generic to unknown cannot be misused.
+		inputSchema: definition.inputSchema as FlexibleSchema<unknown>,
+		outputSchema: outputSchema as FlexibleSchema<unknown>,
+	});
+
+	return created;
 }
 
 type ModelJsonSchema = Awaited<Schema["jsonSchema"]>;

--- a/src/features/workspaces/ai/ai-tool-registry.ts
+++ b/src/features/workspaces/ai/ai-tool-registry.ts
@@ -23,6 +23,10 @@ function defineAiToolRegistry<const TRegistry extends Record<string, AiToolDefin
 
 export const AI_TOOL_REGISTRY = defineAiToolRegistry({
 	activate_skill: readTool({ icon: "guidance", title: "Use guidance" }),
+	// Registered as read access: its inner tool set is built from the turn's
+	// already-capability-filtered tools, so a view-only turn's orchestrate tool
+	// contains read tools only.
+	orchestrate: readTool({ icon: "guidance", title: "Run steps" }),
 	web_search: readTool({ icon: "search", title: "Search web" }),
 	web_fetch: readTool({ icon: "web", title: "Read URL" }),
 	research_discover: readTool({

--- a/src/features/workspaces/ai/chat/chat-endpoint.ts
+++ b/src/features/workspaces/ai/chat/chat-endpoint.ts
@@ -190,13 +190,6 @@ export async function handleAiChatTurn(input: {
 			promptScope,
 			userId,
 		};
-		const tools = createAiChatTools({
-			env,
-			threadContext,
-			canMutate: promptScope.canMutate,
-			timeZone: body.timeZone,
-		});
-
 		const systemPrompt = buildAiChatSystemPrompt({
 			promptScope,
 			timeZone: body.timeZone,
@@ -290,6 +283,30 @@ export async function handleAiChatTurn(input: {
 			execute: async ({ writer }) => {
 				// Started inside execute so a pre-stream throw never leaks the timer.
 				turn.startPinging();
+
+				// Tools are created here, not before the stream, so the orchestrate
+				// (Code Mode) tool can surface its nested calls live: transient data
+				// parts keyed by the outer call id, replaced in place as each nested
+				// tool starts and finishes. Never persisted — the durable record is
+				// the tool part's own `calls` output.
+				const tools = createAiChatTools({
+					env,
+					threadContext,
+					canMutate: promptScope.canMutate,
+					timeZone: body.timeZone,
+					onCodemodeActivity: (event) => {
+						try {
+							writer.write({
+								type: "data-codemode-activity",
+								id: `codemode-${event.invocationId}`,
+								data: event,
+								transient: true,
+							});
+						} catch {
+							// Stream already closed — progress is best-effort.
+						}
+					},
+				});
 
 				if (isFirstExchange && userMessage) {
 					// Title generation runs concurrently with the reply and is DELIVERED

--- a/src/features/workspaces/ai/chat/chat-tools.ts
+++ b/src/features/workspaces/ai/chat/chat-tools.ts
@@ -2,22 +2,25 @@ import type { ToolSet } from "ai";
 
 import type { AIThreadContext } from "#/features/workspaces/ai/ai-thread-metadata";
 import { requireAiToolDefinition } from "#/features/workspaces/ai/ai-tool-registry";
+import type { AiCodemodeActivityListener } from "#/features/workspaces/ai/codemode-tool";
+import { createAiChatCodemodeTool } from "#/features/workspaces/ai/codemode-tool";
 import { createAIThreadResearchTools } from "#/features/workspaces/ai/research-tools";
 import { createAIThreadSkillTools } from "#/features/workspaces/ai/skill-tools";
 import { createAIThreadTimeTools } from "#/features/workspaces/ai/time-tools";
 import { createAIThreadWebTools } from "#/features/workspaces/ai/web-tools";
 import { createAIThreadWorkspaceTools } from "#/features/workspaces/ai/workspace-tools";
 
-// Tool surface for the Postgres chat path: the same AI SDK tool modules the
-// Think implementation uses, assembled directly (no Think workspace/sandbox,
-// no Code Mode orchestration — tools are mounted plainly). Write tools are
-// filtered per turn by the caller's membership capabilities via the registry's
-// access policy, mirroring getActiveToolNames in ai-thread-runtime.
+// Tool surface for the Postgres chat path. Write tools are filtered per turn
+// by the caller's membership capabilities via the registry's access policy,
+// mirroring getActiveToolNames in ai-thread-runtime. The orchestrate (Code
+// Mode) tool is built LAST, from the already-filtered set, so generated code
+// can never reach a tool the turn itself couldn't call directly.
 export function createAiChatTools(input: {
 	env: Cloudflare.Env;
 	threadContext: AIThreadContext;
 	canMutate: boolean;
 	timeZone?: string;
+	onCodemodeActivity?: AiCodemodeActivityListener;
 }): ToolSet {
 	const tools: ToolSet = {
 		...createAIThreadWebTools(input.env),
@@ -30,11 +33,20 @@ export function createAiChatTools(input: {
 		}),
 	};
 
-	if (input.canMutate) {
-		return tools;
-	}
+	const allowed = input.canMutate
+		? tools
+		: (Object.fromEntries(
+				Object.entries(tools).filter(
+					([name]) => requireAiToolDefinition(name).model.access === "read",
+				),
+			) as ToolSet);
 
-	return Object.fromEntries(
-		Object.entries(tools).filter(([name]) => requireAiToolDefinition(name).model.access === "read"),
-	) as ToolSet;
+	return {
+		...allowed,
+		orchestrate: createAiChatCodemodeTool({
+			env: input.env,
+			tools: allowed,
+			...(input.onCodemodeActivity ? { onActivity: input.onCodemodeActivity } : {}),
+		}),
+	};
 }

--- a/src/features/workspaces/ai/codemode-tool.ts
+++ b/src/features/workspaces/ai/codemode-tool.ts
@@ -7,6 +7,10 @@ import {
 	defineAIThreadTool,
 	requireAIThreadToolRuntime,
 } from "#/features/workspaces/ai/ai-thread-tool";
+// Pure TS despite the components path (strings in, strings out) — the same
+// summarizer the chat rows use, so a nested call reads identically to a
+// direct one.
+import { getFinishedToolSummary } from "#/features/workspaces/components/ai-chat/ai-chat-tool-summaries";
 
 /**
  * The namespace generated code uses to call tools (`tools.web_search(...)`).
@@ -62,6 +66,8 @@ const codemodeCallSchema = z.object({
 	action: codemodeCallActionSchema.optional(),
 	toolName: z.string(),
 	status: z.enum(["completed", "failed"]),
+	/** The chat-row one-liner for this call; stripped from the model's view. */
+	summary: z.string().optional(),
 	error: z.string().optional(),
 });
 
@@ -209,17 +215,21 @@ export function createAiChatCodemodeTool(input: {
 										...(context.abortSignal ? { abortSignal: context.abortSignal } : {}),
 									});
 									const action = getDocumentEditAction(name, output, invocationId);
+									const callSummary = getCallSummary(name, "completed", args, output);
 									calls.push({
 										toolName: name,
 										status: "completed",
+										...(callSummary ? { summary: callSummary } : {}),
 										...(action ? { action } : {}),
 									});
 									emit(index, name, "completed");
 									return output;
 								} catch (error) {
+									const callSummary = getCallSummary(name, "failed", args, undefined);
 									calls.push({
 										toolName: name,
 										status: "failed",
+										...(callSummary ? { summary: callSummary } : {}),
 										error: truncate(errorMessage(error), MAX_ERROR_CHARS),
 									});
 									emit(index, name, "failed");
@@ -269,9 +279,26 @@ export function createAiChatCodemodeTool(input: {
 	});
 }
 
-/** The model's view of a run: call records without app-only `action` payloads. */
+/** One-liner for a nested call, same phrasing as a direct chat row. */
+function getCallSummary(
+	toolName: string,
+	status: "completed" | "failed",
+	toolInput: unknown,
+	output: unknown,
+) {
+	try {
+		return truncate(
+			getFinishedToolSummary({ baseStatus: status, output, toolInput, toolName }).summary,
+			200,
+		);
+	} catch {
+		return undefined;
+	}
+}
+
+/** The model's view of a run: call records without app-only UI payloads. */
 function getCodemodeModelOutput(output: AiCodemodeOutput): JSONValue {
-	const calls = output.calls.map(({ action: _action, ...call }) => call);
+	const calls = output.calls.map(({ action: _action, summary: _summary, ...call }) => call);
 	// SAFETY: every field is JSON — `result` crossed the isolate's JSON-RPC
 	// boundary and was bounded by boundResult; the rest is schema-validated
 	// strings, booleans, and arrays of them.

--- a/src/features/workspaces/ai/codemode-tool.ts
+++ b/src/features/workspaces/ai/codemode-tool.ts
@@ -32,6 +32,10 @@ const MAX_RESULT_CHARS = 16_000;
 const MAX_LOG_ENTRIES = 50;
 const MAX_LOG_CHARS = 2_000;
 const MAX_ERROR_CHARS = 4_000;
+// Bounds call cardinality, not just payload bytes: a generated loop could
+// otherwise append records (each replayed into context on every later turn)
+// and emit stream parts for the whole 60s timeout window.
+const MAX_NESTED_CALLS = 100;
 
 const CODEMODE_DESCRIPTION = `Run JavaScript to do calculations or drive several tools in one pass: bulk reads, cross-item synthesis, data aggregation, anything with loops or arithmetic. Prefer this over chaining many individual tool calls, and use it for any non-trivial math — compute, don't estimate.
 
@@ -204,6 +208,20 @@ export function createAiChatCodemodeTool(input: {
 							// document-edit receipt id (same chain as direct calls).
 							execute: async (args: unknown) => {
 								const index = callIndex++;
+								if (index >= MAX_NESTED_CALLS) {
+									// One marker record for the whole overflow, then reject with
+									// an error the generated code can catch and react to.
+									if (index === MAX_NESTED_CALLS) {
+										calls.push({
+											toolName: name,
+											status: "failed",
+											error: `Nested tool call limit reached (${MAX_NESTED_CALLS}); further calls were rejected.`,
+										});
+									}
+									throw new Error(
+										`Nested tool call limit reached (${MAX_NESTED_CALLS}); batch the work instead.`,
+									);
+								}
 								const invocationId = crypto.randomUUID();
 								emit(index, name, "running");
 

--- a/src/features/workspaces/ai/codemode-tool.ts
+++ b/src/features/workspaces/ai/codemode-tool.ts
@@ -1,0 +1,357 @@
+import { DynamicWorkerExecutor } from "@cloudflare/codemode";
+import { createCodeTool } from "@cloudflare/codemode/ai";
+import type { JSONValue, ToolSet } from "ai";
+import { z } from "zod";
+
+import {
+	defineAIThreadTool,
+	requireAIThreadToolRuntime,
+} from "#/features/workspaces/ai/ai-thread-tool";
+
+/**
+ * The namespace generated code uses to call tools (`tools.web_search(...)`).
+ * "codemode" is reserved for the platform SDK's own helpers.
+ */
+const CODEMODE_TOOL_NAMESPACE = "tools";
+
+/**
+ * Tools that must not be callable from generated code:
+ * - `workspace_delete_items`: deletion stays a direct, per-call-visible tool so
+ *   one bad generated loop cannot mass-delete items in a single opaque run.
+ * - `activate_skill`: its output is guidance meant to land in the model's
+ *   context verbatim; routing it through a code result would mangle it.
+ */
+const CODEMODE_EXCLUDED_TOOLS = new Set(["workspace_delete_items", "activate_skill"]);
+
+/** Bounds what one run may persist and feed back to the model. */
+const MAX_RESULT_CHARS = 16_000;
+const MAX_LOG_ENTRIES = 50;
+const MAX_LOG_CHARS = 2_000;
+const MAX_ERROR_CHARS = 4_000;
+
+const CODEMODE_DESCRIPTION = `Run JavaScript to do calculations or drive several tools in one pass: bulk reads, cross-item synthesis, data aggregation, anything with loops or arithmetic. Prefer this over chaining many individual tool calls, and use it for any non-trivial math — compute, don't estimate.
+
+Available inside the code:
+{{types}}
+
+Write a single async arrow function in plain JavaScript (no TypeScript syntax, no named function definitions). Only its return value and console output come back to the conversation — return compact summaries, not full document contents.
+
+Example: async () => { const found = await tools.web_search({ query: "spaced repetition" }); return found.results.slice(0, 3); }`;
+
+const codemodeInputSchema = z.object({
+	title: z
+		.string()
+		.min(1)
+		.max(80)
+		.describe(
+			'Short plain-language label shown to the user while the code runs, e.g. "Calculating your quiz average". No jargon, no code.',
+		),
+	code: z.string().min(1).describe("JavaScript async arrow function to execute."),
+});
+
+const codemodeCallActionSchema = z.object({
+	kind: z.literal("document-edit"),
+	itemId: z.string(),
+	path: z.string(),
+	receiptId: z.string(),
+	lineChanges: z.object({ added: z.number(), removed: z.number() }).optional(),
+});
+
+const codemodeCallSchema = z.object({
+	/** Drives the app's review controls; stripped from the model's view. */
+	action: codemodeCallActionSchema.optional(),
+	toolName: z.string(),
+	status: z.enum(["completed", "failed"]),
+	error: z.string().optional(),
+});
+
+const codemodeOutputSchema = z.discriminatedUnion("status", [
+	z.object({
+		status: z.literal("completed"),
+		result: z.unknown(),
+		resultTruncated: z.boolean().optional(),
+		calls: z.array(codemodeCallSchema),
+		logs: z.array(z.string()).optional(),
+	}),
+	z.object({
+		status: z.literal("error"),
+		error: z.string(),
+		calls: z.array(codemodeCallSchema),
+		logs: z.array(z.string()).optional(),
+	}),
+]);
+
+/** One nested tool call made by a codemode run, as persisted in the tool part. */
+export type AiCodemodeCall = z.output<typeof codemodeCallSchema>;
+
+/** The codemode tool's persisted output. */
+export type AiCodemodeOutput = z.output<typeof codemodeOutputSchema>;
+
+/** Live progress for one nested call inside a codemode run. */
+export interface AiCodemodeActivityEvent {
+	/** The outer codemode tool call this activity belongs to. */
+	invocationId: string;
+	/** The model-authored run label. */
+	title: string;
+	call: {
+		index: number;
+		toolName: string;
+		status: "running" | "completed" | "failed";
+	};
+}
+
+export type AiCodemodeActivityListener = (event: AiCodemodeActivityEvent) => void;
+
+/**
+ * The chat's Code Mode tool: the model writes JavaScript that orchestrates the
+ * thread's other tools inside a network-blocked dynamic Worker isolate. Only
+ * the code's return value, console output, and compact per-call records come
+ * back; nested tool calls execute host-side through the wrapped tools, so
+ * access checks, observability, and receipts behave exactly as direct calls.
+ *
+ * @param input - The env (for the `LOADER` worker-loader binding), the already
+ *   capability-filtered tool set to expose, and an optional live-progress
+ *   listener for the UI stream.
+ * @returns An AI SDK tool taking `{ title, code }`.
+ */
+export function createAiChatCodemodeTool(input: {
+	env: Cloudflare.Env;
+	tools: ToolSet;
+	onActivity?: AiCodemodeActivityListener;
+}) {
+	// The tool a provider sees is deliberately lossy: defineAIThreadTool drops
+	// `outputSchema` and wraps the input in a lazy provider-portable schema
+	// that Code Mode's synchronous type generator renders as `unknown`. Code
+	// Mode hands the model TypeScript, not a provider dialect, so swap in the
+	// original schemas from the tool runtime — they render faithfully.
+	const eligible: ToolSet = Object.fromEntries(
+		Object.entries(input.tools)
+			.filter(
+				([name, aiTool]) =>
+					!CODEMODE_EXCLUDED_TOOLS.has(name) && typeof aiTool.execute === "function",
+			)
+			.map(([name, aiTool]) => {
+				const runtime = requireAIThreadToolRuntime(name, aiTool);
+				return [
+					name,
+					{ ...aiTool, inputSchema: runtime.inputSchema, outputSchema: runtime.outputSchema },
+				];
+			}),
+	);
+	const executor = new DynamicWorkerExecutor({
+		loader: input.env.LOADER,
+		// Generated code gets no network of its own; tools run host-side.
+		globalOutbound: null,
+	});
+	// Built once for the type block in the model-facing description; execution
+	// uses a per-invocation instance so call records can't interleave across
+	// concurrent runs.
+	const description = createCodeTool({
+		tools: [{ name: CODEMODE_TOOL_NAMESPACE, tools: eligible }],
+		executor,
+		description: CODEMODE_DESCRIPTION,
+	}).description;
+
+	if (typeof description !== "string") {
+		throw new Error("Code Mode did not produce a tool description");
+	}
+
+	return defineAIThreadTool({
+		description,
+		inputSchema: codemodeInputSchema,
+		outputSchema: codemodeOutputSchema,
+		toModelOutput: ({ output }) => ({
+			type: "json" as const,
+			value: getCodemodeModelOutput(output),
+		}),
+		execute: async ({ title, code }, context) => {
+			const calls: AiCodemodeCall[] = [];
+			let callIndex = 0;
+
+			const emit = (
+				index: number,
+				toolName: string,
+				status: "running" | "completed" | "failed",
+			) => {
+				input.onActivity?.({
+					invocationId: context.invocationId,
+					title,
+					call: { index, toolName, status },
+				});
+			};
+
+			const instrumented: ToolSet = Object.fromEntries(
+				Object.entries(eligible).map(([name, aiTool]) => {
+					const execute = aiTool.execute;
+					if (!execute) {
+						throw new Error(`Codemode tool "${name}" lost its execute function`);
+					}
+
+					return [
+						name,
+						{
+							...aiTool,
+							// Codemode's dispatcher calls execute with the validated args
+							// only; the wrapped tool still expects AI SDK call options, so
+							// synthesize them. The fresh id doubles as the nested call's
+							// invocationId — for workspace_edit_item that id IS the
+							// document-edit receipt id (same chain as direct calls).
+							execute: async (args: unknown) => {
+								const index = callIndex++;
+								const invocationId = crypto.randomUUID();
+								emit(index, name, "running");
+
+								try {
+									const output = await execute(args, {
+										toolCallId: invocationId,
+										messages: [],
+										context: undefined,
+										...(context.abortSignal ? { abortSignal: context.abortSignal } : {}),
+									});
+									const action = getDocumentEditAction(name, output, invocationId);
+									calls.push({
+										toolName: name,
+										status: "completed",
+										...(action ? { action } : {}),
+									});
+									emit(index, name, "completed");
+									return output;
+								} catch (error) {
+									calls.push({
+										toolName: name,
+										status: "failed",
+										error: truncate(errorMessage(error), MAX_ERROR_CHARS),
+									});
+									emit(index, name, "failed");
+									throw error;
+								}
+							},
+						},
+					];
+				}),
+			);
+
+			const runner = createCodeTool({
+				tools: [{ name: CODEMODE_TOOL_NAMESPACE, tools: instrumented }],
+				executor,
+			});
+			if (!runner.execute) {
+				throw new Error("Code Mode returned a non-executable tool");
+			}
+
+			try {
+				const output = await runner.execute(
+					{ code },
+					{ toolCallId: context.invocationId, messages: [], context: undefined },
+				);
+				if (Symbol.asyncIterator in output) {
+					// The Tool type admits streaming outputs; createCodeTool never
+					// produces one.
+					throw new Error("Code Mode returned a streaming result");
+				}
+				const bounded = boundResult(output.result);
+
+				return {
+					status: "completed" as const,
+					result: bounded.value,
+					...(bounded.truncated ? { resultTruncated: true } : {}),
+					calls,
+					...boundLogs(output.logs),
+				};
+			} catch (error) {
+				return {
+					status: "error" as const,
+					error: truncate(errorMessage(error), MAX_ERROR_CHARS),
+					calls,
+				};
+			}
+		},
+	});
+}
+
+/** The model's view of a run: call records without app-only `action` payloads. */
+function getCodemodeModelOutput(output: AiCodemodeOutput): JSONValue {
+	const calls = output.calls.map(({ action: _action, ...call }) => call);
+	// SAFETY: every field is JSON — `result` crossed the isolate's JSON-RPC
+	// boundary and was bounded by boundResult; the rest is schema-validated
+	// strings, booleans, and arrays of them.
+	return { ...output, calls } as JSONValue;
+}
+
+function getDocumentEditAction(toolName: string, output: unknown, receiptId: string) {
+	if (toolName !== "workspace_edit_item") {
+		return undefined;
+	}
+
+	const record = asRecord(output);
+	const lineChanges = asRecord(record.lineChanges);
+
+	return record.itemType === "document" &&
+		typeof record.itemId === "string" &&
+		typeof record.path === "string" &&
+		typeof record.applied === "number" &&
+		record.applied > 0
+		? {
+				kind: "document-edit" as const,
+				itemId: record.itemId,
+				path: record.path,
+				receiptId,
+				...(typeof lineChanges.added === "number" && typeof lineChanges.removed === "number"
+					? { lineChanges: { added: lineChanges.added, removed: lineChanges.removed } }
+					: {}),
+			}
+		: undefined;
+}
+
+function boundResult(result: unknown): { value: unknown; truncated: boolean } {
+	if (result === undefined) {
+		return { value: null, truncated: false };
+	}
+
+	let serialized: string | undefined;
+	try {
+		serialized = JSON.stringify(result);
+	} catch {
+		return { value: "(unserializable result)", truncated: true };
+	}
+
+	if (serialized === undefined) {
+		return { value: null, truncated: false };
+	}
+
+	if (serialized.length <= MAX_RESULT_CHARS) {
+		return { value: result, truncated: false };
+	}
+
+	return {
+		value: `${serialized.slice(0, MAX_RESULT_CHARS)}… (truncated; return a smaller summary)`,
+		truncated: true,
+	};
+}
+
+function boundLogs(logs: string[] | undefined): { logs?: string[] } {
+	if (!logs || logs.length === 0) {
+		return {};
+	}
+
+	const bounded = logs.slice(0, MAX_LOG_ENTRIES).map((line) => truncate(line, MAX_LOG_CHARS));
+	if (logs.length > MAX_LOG_ENTRIES) {
+		bounded.push(`… ${logs.length - MAX_LOG_ENTRIES} more log lines dropped`);
+	}
+
+	return { logs: bounded };
+}
+
+function truncate(value: string, max: number) {
+	return value.length <= max ? value : `${value.slice(0, max)}…`;
+}
+
+function errorMessage(error: unknown) {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: {};
+}

--- a/src/features/workspaces/ai/codemode-tool.worker.test.ts
+++ b/src/features/workspaces/ai/codemode-tool.worker.test.ts
@@ -96,7 +96,7 @@ describe("orchestrate tool execution", () => {
 		expect(output).toMatchObject({
 			status: "completed",
 			result: 42,
-			calls: [{ toolName: "double_number", status: "completed" }],
+			calls: [{ toolName: "double_number", status: "completed", summary: "Ran double number" }],
 		});
 		expect(events).toEqual([
 			{

--- a/src/features/workspaces/ai/codemode-tool.worker.test.ts
+++ b/src/features/workspaces/ai/codemode-tool.worker.test.ts
@@ -1,0 +1,160 @@
+import { env } from "cloudflare:test";
+import type { ToolExecutionOptions } from "ai";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineAIThreadTool } from "#/features/workspaces/ai/ai-thread-tool";
+import type { AiCodemodeActivityEvent } from "#/features/workspaces/ai/codemode-tool";
+import { createAiChatCodemodeTool } from "#/features/workspaces/ai/codemode-tool";
+import { createAiChatTools } from "#/features/workspaces/ai/chat/chat-tools";
+
+const directOptions = (toolCallId: string): ToolExecutionOptions<unknown> => ({
+	toolCallId,
+	messages: [],
+	context: undefined,
+});
+
+// Named to survive sanitizeToolName untouched — a name that is a JS reserved
+// word (e.g. "double") gets a trailing underscore in the sandbox namespace.
+function createDoubleNumberTool() {
+	return defineAIThreadTool({
+		description: "Double a number",
+		inputSchema: z.object({ value: z.number().describe("the number to double") }),
+		outputSchema: z.object({ doubled: z.number() }),
+		execute: ({ value }) => ({ doubled: value * 2 }),
+	});
+}
+
+describe("orchestrate tool description", () => {
+	it("renders concrete types from the original schemas and omits excluded tools", () => {
+		const tools = createAiChatTools({
+			env,
+			threadContext: {
+				id: "thread-test",
+				workspaceId: "workspace-test",
+				promptScope: { canMutate: true, workspaceName: "Test" },
+				userId: "user-test",
+			},
+			canMutate: true,
+		});
+		const orchestrate = tools.orchestrate;
+		if (!orchestrate || typeof orchestrate.description !== "string") {
+			throw new Error("Expected an orchestrate tool with a description");
+		}
+
+		// The lazy provider schemas render as `unknown` in Code Mode's sync
+		// generator; the runtime-schema swap must prevent that wholesale loss.
+		expect(orchestrate.description).not.toMatch(/type \w+Input = unknown/);
+		expect(orchestrate.description).not.toMatch(/type \w+Output = unknown/);
+		expect(orchestrate.description).toContain("workspace_read_items");
+		expect(orchestrate.description).toContain("web_search");
+		expect(orchestrate.description).not.toContain("workspace_delete_items");
+		expect(orchestrate.description).not.toContain("activate_skill");
+	});
+
+	it("keeps write tools out of a view-only turn's orchestrate tool", () => {
+		const tools = createAiChatTools({
+			env,
+			threadContext: {
+				id: "thread-test",
+				workspaceId: "workspace-test",
+				promptScope: { canMutate: false, workspaceName: "Test" },
+				userId: "user-test",
+			},
+			canMutate: false,
+		});
+		const orchestrate = tools.orchestrate;
+		if (!orchestrate || typeof orchestrate.description !== "string") {
+			throw new Error("Expected an orchestrate tool with a description");
+		}
+
+		expect(orchestrate.description).not.toContain("workspace_edit_item");
+		expect(orchestrate.description).toContain("workspace_read_items");
+	});
+});
+
+describe("orchestrate tool execution", () => {
+	it("runs generated code against nested tools and records the calls", async () => {
+		const events: AiCodemodeActivityEvent[] = [];
+		const orchestrate = createAiChatCodemodeTool({
+			env,
+			tools: { double_number: createDoubleNumberTool() },
+			onActivity: (event) => events.push(event),
+		});
+		if (!orchestrate.execute) {
+			throw new Error("Expected an executable orchestrate tool");
+		}
+
+		const output = await orchestrate.execute(
+			{
+				title: "Doubling a number",
+				code: "async () => { const r = await tools.double_number({ value: 21 }); return r.doubled; }",
+			},
+			directOptions("codemode-run"),
+		);
+
+		expect(output).toMatchObject({
+			status: "completed",
+			result: 42,
+			calls: [{ toolName: "double_number", status: "completed" }],
+		});
+		expect(events).toEqual([
+			{
+				invocationId: "codemode-run",
+				title: "Doubling a number",
+				call: { index: 0, toolName: "double_number", status: "running" },
+			},
+			{
+				invocationId: "codemode-run",
+				title: "Doubling a number",
+				call: { index: 0, toolName: "double_number", status: "completed" },
+			},
+		]);
+	});
+
+	it("reports code failures as an error output instead of throwing", async () => {
+		const orchestrate = createAiChatCodemodeTool({
+			env,
+			tools: { double_number: createDoubleNumberTool() },
+		});
+		if (!orchestrate.execute) {
+			throw new Error("Expected an executable orchestrate tool");
+		}
+
+		const output = await orchestrate.execute(
+			{ title: "Failing on purpose", code: "async () => { throw new Error('boom'); }" },
+			directOptions("codemode-error"),
+		);
+
+		expect(output).toMatchObject({ status: "error", calls: [] });
+		if (output.status !== "error") {
+			throw new Error("Expected an error output");
+		}
+		expect(output.error).toContain("boom");
+	});
+
+	it("records a failed nested call when the tool itself throws", async () => {
+		const failing = defineAIThreadTool({
+			description: "Always fails",
+			inputSchema: z.object({}),
+			outputSchema: z.object({ ok: z.boolean() }),
+			execute: () => {
+				throw new Error("tool exploded");
+			},
+		});
+		const orchestrate = createAiChatCodemodeTool({ env, tools: { failing } });
+		if (!orchestrate.execute) {
+			throw new Error("Expected an executable orchestrate tool");
+		}
+
+		const output = await orchestrate.execute(
+			{ title: "Calling a broken tool", code: "async () => { return await tools.failing({}); }" },
+			directOptions("codemode-tool-error"),
+		);
+
+		expect(output).toMatchObject({
+			status: "error",
+			calls: [{ toolName: "failing", status: "failed" }],
+		});
+	});
+});

--- a/src/features/workspaces/ai/codemode-tool.worker.test.ts
+++ b/src/features/workspaces/ai/codemode-tool.worker.test.ts
@@ -133,6 +133,32 @@ describe("orchestrate tool execution", () => {
 		expect(output.error).toContain("boom");
 	});
 
+	it("caps nested calls at the limit with one overflow marker", async () => {
+		const orchestrate = createAiChatCodemodeTool({
+			env,
+			tools: { double_number: createDoubleNumberTool() },
+		});
+		if (!orchestrate.execute) {
+			throw new Error("Expected an executable orchestrate tool");
+		}
+
+		const output = await orchestrate.execute(
+			{
+				title: "Looping past the limit",
+				code: "async () => { for (let i = 0; i < 120; i += 1) { try { await tools.double_number({ value: i }); } catch (error) { return { stoppedAt: i, message: error.message }; } } return 'no limit hit'; }",
+			},
+			directOptions("codemode-cap"),
+		);
+
+		if (output.status !== "completed") {
+			throw new Error("Expected the run to complete via the caught limit error");
+		}
+		expect(output.result).toMatchObject({ stoppedAt: 100 });
+		// 100 real calls plus exactly one overflow marker, however many rejections.
+		expect(output.calls).toHaveLength(101);
+		expect(output.calls.at(-1)).toMatchObject({ status: "failed" });
+	});
+
 	it("records a failed nested call when the tool itself throws", async () => {
 		const failing = defineAIThreadTool({
 			description: "Always fails",

--- a/src/features/workspaces/components/ai-chat/AiChatDocumentEditActions.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatDocumentEditActions.tsx
@@ -1,5 +1,6 @@
-import { FilePen } from "lucide-react";
+import { ChevronDown, FilePen } from "lucide-react";
 
+import { Popover, PopoverContent, PopoverTrigger } from "#/components/ui/popover";
 import type { AiChatDocumentEditGroup } from "#/features/workspaces/components/ai-chat/ai-chat-document-edit-actions";
 import { useDocumentEditReview } from "#/features/workspaces/documents/document-edit-review-context";
 import { useWorkspaceLocationActions } from "#/features/workspaces/locations/workspace-location-context";
@@ -12,10 +13,16 @@ import { getWorkspacePathName } from "#/features/workspaces/model/workspace-path
  * Deliberately asks the server nothing. Whether those changes can still be
  * reviewed or undone is a live question, and answering it up front would cost a
  * request per row on every chat load just to render a label. Clicking finds out.
+ *
+ * Older responses pass `collapsed`: their receipts are mostly no longer
+ * reviewable (only the latest unchanged edit is), so they shrink to one line
+ * with the rows in a popover — no layout shift, no wall of dead buttons.
  */
 export function AiChatDocumentEditActions({
+	collapsed = false,
 	groups,
 }: {
+	collapsed?: boolean;
 	groups: readonly AiChatDocumentEditGroup[];
 }) {
 	// A deleted document has nothing left to open.
@@ -26,6 +33,29 @@ export function AiChatDocumentEditActions({
 		return null;
 	}
 
+	const headerLabel = `Edited ${knownGroups.length} ${knownGroups.length === 1 ? "document" : "documents"}`;
+
+	if (collapsed) {
+		return (
+			<Popover>
+				<PopoverTrigger className="block w-fit max-w-full text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
+					<div className="inline-flex items-center gap-1.5 rounded-lg bg-muted/40 px-2.5 py-1.5 text-muted-foreground text-xs">
+						<FilePen className="size-3 shrink-0" aria-hidden="true" />
+						<span className="font-medium">{headerLabel}</span>
+						<ChevronDown className="size-3 shrink-0" aria-hidden="true" />
+					</div>
+				</PopoverTrigger>
+				<PopoverContent align="start" className="w-72 p-0">
+					<div className="divide-y divide-foreground/5">
+						{knownGroups.map((group) => (
+							<DocumentEditRow key={group.itemId} group={group} />
+						))}
+					</div>
+				</PopoverContent>
+			</Popover>
+		);
+	}
+
 	return (
 		<div
 			aria-label="Document changes from this response"
@@ -33,9 +63,7 @@ export function AiChatDocumentEditActions({
 		>
 			<div className="flex items-center gap-1.5 px-2.5 py-1.5 text-muted-foreground text-xs">
 				<FilePen className="size-3 shrink-0" aria-hidden="true" />
-				<span className="font-medium">
-					Edited {knownGroups.length} {knownGroups.length === 1 ? "document" : "documents"}
-				</span>
+				<span className="font-medium">{headerLabel}</span>
 			</div>
 			<div className="divide-y divide-foreground/5 border-foreground/5 border-t">
 				{knownGroups.map((group) => (

--- a/src/features/workspaces/components/ai-chat/AiChatDocumentEditActions.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatDocumentEditActions.tsx
@@ -16,7 +16,7 @@ import { getWorkspacePathName } from "#/features/workspaces/model/workspace-path
  *
  * Older responses pass `collapsed`: their receipts are mostly no longer
  * reviewable (only the latest unchanged edit is), so they shrink to one line
- * with the rows in a popover — no layout shift, no wall of dead buttons.
+ * that expands the rows inline — no wall of dead buttons.
  */
 export function AiChatDocumentEditActions({
 	collapsed = false,

--- a/src/features/workspaces/components/ai-chat/AiChatDocumentEditActions.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatDocumentEditActions.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown, FilePen } from "lucide-react";
 
-import { Popover, PopoverContent, PopoverTrigger } from "#/components/ui/popover";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "#/components/ui/collapsible";
 import type { AiChatDocumentEditGroup } from "#/features/workspaces/components/ai-chat/ai-chat-document-edit-actions";
 import { useDocumentEditReview } from "#/features/workspaces/documents/document-edit-review-context";
 import { useWorkspaceLocationActions } from "#/features/workspaces/locations/workspace-location-context";
@@ -36,23 +36,28 @@ export function AiChatDocumentEditActions({
 	const headerLabel = `Edited ${knownGroups.length} ${knownGroups.length === 1 ? "document" : "documents"}`;
 
 	if (collapsed) {
+		// Expands in place inside its own container, so the receipt keeps the
+		// chat's colors instead of opening a floating surface.
 		return (
-			<Popover>
-				<PopoverTrigger className="block w-fit max-w-full text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
-					<div className="inline-flex items-center gap-1.5 rounded-lg bg-muted/40 px-2.5 py-1.5 text-muted-foreground text-xs">
+			<Collapsible className="w-fit max-w-full overflow-hidden rounded-lg bg-muted/40">
+				<CollapsibleTrigger className="group/receipt block w-full text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
+					<div className="flex items-center gap-1.5 px-2.5 py-1.5 text-muted-foreground text-xs">
 						<FilePen className="size-3 shrink-0" aria-hidden="true" />
 						<span className="font-medium">{headerLabel}</span>
-						<ChevronDown className="size-3 shrink-0" aria-hidden="true" />
+						<ChevronDown
+							className="size-3 shrink-0 transition-transform group-data-[panel-open]/receipt:rotate-180"
+							aria-hidden="true"
+						/>
 					</div>
-				</PopoverTrigger>
-				<PopoverContent align="start" className="w-72 p-0">
-					<div className="divide-y divide-foreground/5">
+				</CollapsibleTrigger>
+				<CollapsibleContent>
+					<div className="divide-y divide-foreground/5 border-foreground/5 border-t">
 						{knownGroups.map((group) => (
 							<DocumentEditRow key={group.itemId} group={group} />
 						))}
 					</div>
-				</PopoverContent>
-			</Popover>
+				</CollapsibleContent>
+			</Collapsible>
 		);
 	}
 

--- a/src/features/workspaces/components/ai-chat/AiChatMessageRow.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatMessageRow.tsx
@@ -1,6 +1,6 @@
 import { isToolUIPart } from "ai";
 import { Check, Copy, Pencil, RotateCcw } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { AnimatedIconSwap } from "#/components/ui/animated-icon-swap";
 import { Button } from "#/components/ui/button";
@@ -11,6 +11,10 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "#/comp
 import { AiChatMessagePartView } from "#/features/workspaces/components/ai-chat/AiChatMessagePartView";
 import { AiChatDocumentEditActions } from "#/features/workspaces/components/ai-chat/AiChatDocumentEditActions";
 import { getAiChatDocumentEditGroups } from "#/features/workspaces/components/ai-chat/ai-chat-document-edit-actions";
+import {
+	AiChatToolActivityGroup,
+	isToolGroupBreaker,
+} from "#/features/workspaces/components/ai-chat/AiChatToolActivityGroup";
 import { stripWorkspaceCitationTags } from "#/features/workspaces/ai/workspace-references";
 import {
 	type AssistantRowDisplay,
@@ -19,6 +23,7 @@ import {
 import type {
 	AiChatMessage,
 	AiChatMessagePart,
+	AiChatToolPart,
 } from "#/features/workspaces/components/ai-chat/types";
 import { useCopyToClipboard } from "#/hooks/use-copy-to-clipboard";
 import { cn } from "#/lib/utils";
@@ -54,21 +59,24 @@ export default function AiChatMessageRow({
 	onEdit?: () => void;
 	onRegenerate?: () => void;
 }) {
+	const isAssistant = message.role === "assistant";
+	const displayParts = display?.kind === "content" ? display.parts : undefined;
+	const documentEditGroups = useMemo(
+		() =>
+			isAssistant && displayParts && !isStreaming ? getAiChatDocumentEditGroups(displayParts) : [],
+		[isAssistant, displayParts, isStreaming],
+	);
+
 	if (message.role === "assistant" && display?.kind === "hidden") {
 		return null;
 	}
 
-	const isAssistant = message.role === "assistant";
 	const displayableParts = isAssistant ? [] : getDisplayableParts(message);
 	const userAttachmentParts = isAssistant ? [] : displayableParts.filter(isAttachmentPart);
 	const userBodyParts = isAssistant
 		? []
 		: displayableParts.filter((part) => !isAttachmentPart(part));
 	const copyableText = !isStreaming ? getCopyableMessageText(message) : "";
-	const documentEditGroups =
-		isAssistant && display?.kind === "content" && !isStreaming
-			? getAiChatDocumentEditGroups(display.parts)
-			: [];
 
 	return (
 		<Message
@@ -102,7 +110,7 @@ export default function AiChatMessageRow({
 				{/* Outside the bubble on purpose: the bubble is w-fit and clips its
 				    overflow, so a receipt inside it is only as wide as the reply. */}
 				{documentEditGroups.length > 0 ? (
-					<AiChatDocumentEditActions groups={documentEditGroups} />
+					<AiChatDocumentEditActions collapsed={!isLatestAssistant} groups={documentEditGroups} />
 				) : null}
 				{isAssistant && display?.kind === "content" && display.parts.length > 0 && !isStreaming ? (
 					<MessageFooter
@@ -232,14 +240,22 @@ function AssistantMessageBody({
 
 		return (
 			<div data-slot="assistant-parts" className="flex flex-col gap-3">
-				{display.parts.map((part, index) => (
-					<AiChatMessagePartView
-						key={getMessagePartKey(message.id, part, index)}
-						interruptUnfinishedTools={display.interruptUnfinishedTools}
-						isStreaming={isStreaming}
-						part={part}
-					/>
-				))}
+				{getAssistantRenderItems(display.parts).map((item) =>
+					item.kind === "tool-group" ? (
+						<AiChatToolActivityGroup
+							key={`${message.id}-tool-group-${item.parts[0]?.toolCallId ?? item.index}`}
+							interrupted={display.interruptUnfinishedTools}
+							parts={item.parts}
+						/>
+					) : (
+						<AiChatMessagePartView
+							key={getMessagePartKey(message.id, item.part, item.index)}
+							interruptUnfinishedTools={display.interruptUnfinishedTools}
+							isStreaming={isStreaming}
+							part={item.part}
+						/>
+					),
+				)}
 				{turnStatus === "interrupted" && !isStreaming ? (
 					<div className="text-muted-foreground/70 text-xs">You stopped this response.</div>
 				) : null}
@@ -336,6 +352,45 @@ function AiChatMessageAction({
 			</Tooltip>
 		</TooltipProvider>
 	);
+}
+
+type AssistantRenderItem =
+	| { kind: "part"; part: AiChatMessagePart; index: number }
+	| { kind: "tool-group"; parts: AiChatToolPart[]; index: number };
+
+// Runs of 2+ consecutive tool parts render as one collapsible group; galleries
+// and other content-bearing tool parts break a run so collapsing never hides
+// them. display.parts is already filtered to visible parts.
+function getAssistantRenderItems(parts: AiChatMessagePart[]): AssistantRenderItem[] {
+	const items: AssistantRenderItem[] = [];
+	let run: { parts: AiChatToolPart[]; startIndex: number } | null = null;
+
+	const flush = () => {
+		if (!run) {
+			return;
+		}
+		if (run.parts.length >= 2) {
+			items.push({ kind: "tool-group", parts: run.parts, index: run.startIndex });
+		} else {
+			for (const [offset, part] of run.parts.entries()) {
+				items.push({ kind: "part", part, index: run.startIndex + offset });
+			}
+		}
+		run = null;
+	};
+
+	for (const [index, part] of parts.entries()) {
+		if (isToolUIPart(part) && !isToolGroupBreaker(part)) {
+			run ??= { parts: [], startIndex: index };
+			run.parts.push(part);
+			continue;
+		}
+		flush();
+		items.push({ kind: "part", part, index });
+	}
+	flush();
+
+	return items;
 }
 
 function getCopyableMessageText(message: AiChatMessage) {

--- a/src/features/workspaces/components/ai-chat/AiChatThreadView.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatThreadView.tsx
@@ -15,6 +15,7 @@ import type {
 	AiChatSendMessage,
 } from "#/features/workspaces/components/ai-chat/types";
 import { canDrainQueuedMessage } from "#/features/workspaces/components/ai-chat/ai-chat-queue-drain";
+import { AiChatLiveActivityProvider } from "#/features/workspaces/components/ai-chat/ai-chat-live-activity";
 import { useWorkspaceAiChat } from "#/features/workspaces/components/ai-chat/useWorkspaceAiChat";
 import { useWorkspaceAiAllowance } from "#/features/workspaces/ai/use-workspace-ai-allowance";
 import type { WorkspaceAiContextScope } from "#/features/workspaces/model/workspace-ai-context-types";
@@ -53,6 +54,7 @@ export default function AiChatThreadView({
 		connectionError,
 		editMessage,
 		inputStatus,
+		liveCodemodeActivity,
 		messages,
 		presentation,
 		regenerate,
@@ -255,20 +257,22 @@ export default function AiChatThreadView({
 
 	return (
 		<div className="relative flex min-h-0 flex-1 flex-col">
-			<AiChatMessageList
-				anchorMessageId={scrollAnchorMessageId}
-				assistantError={assistantError}
-				editingMessageId={editing?.messageId}
-				messages={messages}
-				presentation={presentation}
-				sentMessageAnimationId={sentMessageAnimationId}
-				workspaceId={context.workspaceId}
-				onEditMessage={canSend && !queueHead && !editing ? startEditing : undefined}
-				// Hidden while editing: regenerating the reply the edit is about to
-				// delete makes the chat busy and strands the edit with a dead submit.
-				onRegenerateLastResponse={editing ? undefined : () => regenerate()}
-				onStartNewChat={onStartNewChat}
-			/>
+			<AiChatLiveActivityProvider value={liveCodemodeActivity}>
+				<AiChatMessageList
+					anchorMessageId={scrollAnchorMessageId}
+					assistantError={assistantError}
+					editingMessageId={editing?.messageId}
+					messages={messages}
+					presentation={presentation}
+					sentMessageAnimationId={sentMessageAnimationId}
+					workspaceId={context.workspaceId}
+					onEditMessage={canSend && !queueHead && !editing ? startEditing : undefined}
+					// Hidden while editing: regenerating the reply the edit is about to
+					// delete makes the chat busy and strands the edit with a dead submit.
+					onRegenerateLastResponse={editing ? undefined : () => regenerate()}
+					onStartNewChat={onStartNewChat}
+				/>
+			</AiChatLiveActivityProvider>
 
 			<div className="px-3 pb-3">
 				<div className={aiChatComposerRailClassName}>

--- a/src/features/workspaces/components/ai-chat/AiChatToolActivityGroup.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatToolActivityGroup.tsx
@@ -1,7 +1,7 @@
 import { isToolUIPart } from "ai";
 import { ChevronDown } from "lucide-react";
 
-import { Popover, PopoverContent, PopoverTrigger } from "#/components/ui/popover";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "#/components/ui/collapsible";
 import {
 	getToolActivityForPart,
 	isVisibleToolPart,
@@ -23,8 +23,8 @@ import { cn } from "#/lib/utils";
  * A run of consecutive tool calls rendered as one line. While any member is
  * still running, only the latest action shows — its text swaps in place, so
  * the transcript height stays stable during streaming. Once the run settles it
- * collapses to "latest action · ran N actions", with the full list in a
- * popover (no layout shift on expand).
+ * collapses to "latest action · N steps", expanding inline (the same shape as
+ * the sources list, in the chat's own flow and background).
  */
 export function AiChatToolActivityGroup({
 	interrupted = false,
@@ -61,8 +61,8 @@ export function AiChatToolActivityGroup({
 	const failedCount = activities.filter((activity) => activity.status === "failed").length;
 
 	return (
-		<Popover>
-			<PopoverTrigger className="block min-w-0 max-w-full text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
+		<Collapsible className="w-fit max-w-full">
+			<CollapsibleTrigger className="group/collapsible block min-w-0 max-w-full text-left">
 				<div
 					title={latest.summary}
 					className="group/tool-row inline-flex min-w-0 max-w-full items-center gap-1.5 py-0.5 text-muted-foreground text-xs"
@@ -72,23 +72,23 @@ export function AiChatToolActivityGroup({
 					</span>
 					<span className="min-w-0 truncate font-medium">{latest.summary}</span>
 					<span className="shrink-0 whitespace-pre text-muted-foreground/70">
-						· ran {activities.length} actions
+						· {activities.length} steps
 						{failedCount > 0 ? `, ${failedCount} failed` : ""}
 					</span>
 					<ChevronDown
-						className="size-3.5 shrink-0 self-center text-muted-foreground/70"
+						className="size-3.5 shrink-0 self-center text-muted-foreground/70 transition-transform group-data-[panel-open]/collapsible:rotate-180"
 						aria-hidden="true"
 					/>
 				</div>
-			</PopoverTrigger>
-			<PopoverContent align="start" className="w-72 p-1.5">
-				<div className="grid gap-0.5" aria-label="Actions in this run">
+			</CollapsibleTrigger>
+			<CollapsibleContent className="mt-1">
+				<div className="grid gap-1 pl-5" aria-label="Actions in this run">
 					{activities.map((activity, index) => (
 						<div
 							// biome-ignore lint/suspicious/noArrayIndexKey: activities mirror settled, ordered parts
 							key={index}
 							title={activity.summary}
-							className="flex items-center gap-1.5 rounded-sm px-1.5 py-1 text-muted-foreground text-xs"
+							className="inline-flex min-w-0 max-w-full items-center gap-1.5 text-muted-foreground text-xs"
 						>
 							<span className="grid size-3.5 shrink-0 place-items-center text-muted-foreground/70">
 								<ToolActivityIcon icon={activity.presentation.icon} />
@@ -104,8 +104,8 @@ export function AiChatToolActivityGroup({
 						</div>
 					))}
 				</div>
-			</PopoverContent>
-		</Popover>
+			</CollapsibleContent>
+		</Collapsible>
 	);
 }
 

--- a/src/features/workspaces/components/ai-chat/AiChatToolActivityGroup.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatToolActivityGroup.tsx
@@ -1,0 +1,131 @@
+import { isToolUIPart } from "ai";
+import { ChevronDown } from "lucide-react";
+
+import { Popover, PopoverContent, PopoverTrigger } from "#/components/ui/popover";
+import {
+	getToolActivityForPart,
+	isVisibleToolPart,
+	getToolPartName,
+	type AiChatToolActivity,
+} from "#/features/workspaces/components/ai-chat/ai-chat-display-state";
+import {
+	AiChatToolActivityRow,
+	ToolActivityIcon,
+} from "#/features/workspaces/components/ai-chat/AiChatToolActivityRow";
+import type {
+	AiChatMessagePart,
+	AiChatToolPart,
+} from "#/features/workspaces/components/ai-chat/types";
+import { asRecord } from "#/lib/record";
+import { cn } from "#/lib/utils";
+
+/**
+ * A run of consecutive tool calls rendered as one line. While any member is
+ * still running, only the latest action shows — its text swaps in place, so
+ * the transcript height stays stable during streaming. Once the run settles it
+ * collapses to "latest action · ran N actions", with the full list in a
+ * popover (no layout shift on expand).
+ */
+export function AiChatToolActivityGroup({
+	interrupted = false,
+	parts,
+}: {
+	interrupted?: boolean;
+	parts: AiChatToolPart[];
+}) {
+	const visibleParts = parts.filter(isVisibleToolPart);
+	const lastVisible = visibleParts.at(-1);
+
+	if (!lastVisible) {
+		return null;
+	}
+
+	if (visibleParts.length === 1) {
+		return <AiChatToolActivityRow interrupted={interrupted} part={lastVisible} />;
+	}
+
+	const hasUnfinished = !interrupted && visibleParts.some((part) => !isSettledToolPart(part));
+	if (hasUnfinished) {
+		return <AiChatToolActivityRow part={lastVisible} />;
+	}
+
+	const activities = visibleParts
+		.map((part) => getToolActivityForPart(part, { interrupted }))
+		.filter((activity): activity is AiChatToolActivity => activity !== null);
+	const latest = activities.at(-1);
+
+	if (!latest) {
+		return null;
+	}
+
+	const failedCount = activities.filter((activity) => activity.status === "failed").length;
+
+	return (
+		<Popover>
+			<PopoverTrigger className="block min-w-0 max-w-full text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
+				<div
+					title={latest.summary}
+					className="group/tool-row inline-flex min-w-0 max-w-full items-center gap-1.5 py-0.5 text-muted-foreground text-xs"
+				>
+					<span className="grid size-3.5 shrink-0 place-items-center self-center text-muted-foreground/70">
+						<ToolActivityIcon icon={latest.presentation.icon} />
+					</span>
+					<span className="min-w-0 truncate font-medium">{latest.summary}</span>
+					<span className="shrink-0 whitespace-pre text-muted-foreground/70">
+						· ran {activities.length} actions
+						{failedCount > 0 ? `, ${failedCount} failed` : ""}
+					</span>
+					<ChevronDown
+						className="size-3.5 shrink-0 self-center text-muted-foreground/70"
+						aria-hidden="true"
+					/>
+				</div>
+			</PopoverTrigger>
+			<PopoverContent align="start" className="w-72 p-1.5">
+				<div className="grid gap-0.5" aria-label="Actions in this run">
+					{activities.map((activity, index) => (
+						<div
+							// biome-ignore lint/suspicious/noArrayIndexKey: activities mirror settled, ordered parts
+							key={index}
+							title={activity.summary}
+							className="flex items-center gap-1.5 rounded-sm px-1.5 py-1 text-muted-foreground text-xs"
+						>
+							<span className="grid size-3.5 shrink-0 place-items-center text-muted-foreground/70">
+								<ToolActivityIcon icon={activity.presentation.icon} />
+							</span>
+							<span
+								className={cn(
+									"min-w-0 truncate font-medium",
+									activity.status === "failed" && "text-destructive/80",
+								)}
+							>
+								{activity.summary}
+							</span>
+						</div>
+					))}
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}
+
+function isSettledToolPart(part: AiChatToolPart) {
+	return (
+		part.state === "output-available" ||
+		part.state === "output-error" ||
+		part.state === "output-denied"
+	);
+}
+
+/**
+ * Parts whose rendering is content, not just an activity line, stay out of
+ * groups so collapsing never hides them — today that is an image search's
+ * result gallery.
+ */
+export function isToolGroupBreaker(part: AiChatMessagePart): boolean {
+	return (
+		isToolUIPart(part) &&
+		getToolPartName(part) === "web_search" &&
+		asRecord(part.input).source === "images"
+	);
+}

--- a/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
@@ -3,7 +3,6 @@ import { LazyMotion, domAnimation, m, useReducedMotion } from "motion/react";
 import type { ReactNode } from "react";
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "#/components/ui/collapsible";
-import { Popover, PopoverContent, PopoverTrigger } from "#/components/ui/popover";
 import {
 	getAiToolPresentation,
 	type AiToolActivityIconKind,
@@ -56,16 +55,18 @@ export function AiChatToolActivityRow({
 			: [];
 
 	if (orchestrateCalls.length > 0) {
+		// Inline expansion, same shape as the sources list: the detail renders in
+		// the chat's own flow and background instead of a floating surface.
 		return (
 			<ToolActivityMotion disabled={shouldReduceMotion}>
-				<Popover>
-					<PopoverTrigger className="block min-w-0 max-w-full text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
+				<Collapsible className="w-fit max-w-full">
+					<CollapsibleTrigger className="group/collapsible min-w-0 max-w-full text-left">
 						<ActivitySummary activity={activity} canExpand sourcePreviews={[]} />
-					</PopoverTrigger>
-					<PopoverContent align="start" className="w-64 p-1.5">
+					</CollapsibleTrigger>
+					<CollapsibleContent className="mt-1">
 						<OrchestrateCallList calls={orchestrateCalls} />
-					</PopoverContent>
-				</Popover>
+					</CollapsibleContent>
+				</Collapsible>
 			</ToolActivityMotion>
 		);
 	}
@@ -128,6 +129,7 @@ function ToolActivityMotion({
 interface OrchestrateCallView {
 	toolName: string;
 	status: "completed" | "failed";
+	summary?: string;
 }
 
 function withLiveNestedAction(
@@ -165,6 +167,7 @@ function getOrchestrateCalls(part: AiChatToolPart): OrchestrateCallView[] {
 			views.push({
 				toolName: record.toolName,
 				status: record.status === "failed" ? "failed" : "completed",
+				...(typeof record.summary === "string" ? { summary: record.summary } : {}),
 			});
 		}
 	}
@@ -174,23 +177,30 @@ function getOrchestrateCalls(part: AiChatToolPart): OrchestrateCallView[] {
 
 function OrchestrateCallList({ calls }: { calls: OrchestrateCallView[] }) {
 	return (
-		<div className="grid gap-0.5" aria-label="Steps in this run">
+		// Indented under the parent row's text so the steps read as its children.
+		<div className="grid gap-1 pl-5" aria-label="Steps in this run">
 			{calls.map((call, index) => {
 				const presentation = getAiToolPresentation(call.toolName);
+				const label = call.summary ?? presentation.title;
 
 				return (
 					<div
 						// biome-ignore lint/suspicious/noArrayIndexKey: calls are append-only per run
 						key={index}
-						className="flex items-center gap-1.5 rounded-sm px-1.5 py-1 text-muted-foreground text-xs"
+						title={label}
+						className="inline-flex min-w-0 max-w-full items-center gap-1.5 text-muted-foreground text-xs"
 					>
 						<span className="grid size-3.5 shrink-0 place-items-center text-muted-foreground/70">
 							<ToolActivityIcon icon={presentation.icon} />
 						</span>
-						<span className="min-w-0 truncate font-medium">{presentation.title}</span>
-						{call.status === "failed" ? (
-							<span className="shrink-0 text-destructive/80">failed</span>
-						) : null}
+						<span
+							className={cn(
+								"min-w-0 truncate font-medium",
+								call.status === "failed" && "text-destructive/80",
+							)}
+						>
+							{label}
+						</span>
 					</div>
 				);
 			})}

--- a/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
@@ -3,15 +3,18 @@ import { LazyMotion, domAnimation, m, useReducedMotion } from "motion/react";
 import type { ReactNode } from "react";
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "#/components/ui/collapsible";
-import type {
-	AiToolActivityIconKind,
-	AiToolPresentation,
+import { Popover, PopoverContent, PopoverTrigger } from "#/components/ui/popover";
+import {
+	getAiToolPresentation,
+	type AiToolActivityIconKind,
+	type AiToolPresentation,
 } from "#/features/workspaces/ai/ai-tool-registry";
 import { AiChatImageSearchResults } from "#/features/workspaces/components/ai-chat/AiChatImageSearchResults";
 import {
 	getToolActivityForPart,
 	type AiChatToolActivity,
 } from "#/features/workspaces/components/ai-chat/ai-chat-display-state";
+import { useLiveCodemodeActivity } from "#/features/workspaces/components/ai-chat/ai-chat-live-activity";
 import type { AiChatToolReceiptSegment } from "#/features/workspaces/components/ai-chat/ai-chat-tool-receipts";
 import {
 	getToolSourceHostname,
@@ -19,6 +22,7 @@ import {
 	type ToolSourcePreview,
 } from "#/features/workspaces/components/ai-chat/ai-chat-tool-source-previews";
 import type { AiChatToolPart } from "#/features/workspaces/components/ai-chat/types";
+import { asRecord } from "#/lib/record";
 import { cn } from "#/lib/utils";
 
 const INLINE_SOURCE_LIMIT = 3;
@@ -32,10 +36,38 @@ export function AiChatToolActivityRow({
 	part: AiChatToolPart;
 }) {
 	const shouldReduceMotion = useReducedMotion();
-	const activity = getToolActivityForPart(part, { interrupted });
+	const liveActivity = useLiveCodemodeActivity(part.toolCallId);
+	const baseActivity = getToolActivityForPart(part, { interrupted });
 
-	if (!activity) {
+	if (!baseActivity) {
 		return null;
+	}
+
+	// A running orchestrate row appends the nested tool it is currently
+	// driving ("Analyzing quiz scores · Read workspace") from the live
+	// transient stream events.
+	const activity =
+		baseActivity.toolName === "orchestrate" && baseActivity.status === "running" && liveActivity
+			? withLiveNestedAction(baseActivity, liveActivity.call.toolName)
+			: baseActivity;
+	const orchestrateCalls =
+		activity.toolName === "orchestrate" && activity.status !== "running"
+			? getOrchestrateCalls(part)
+			: [];
+
+	if (orchestrateCalls.length > 0) {
+		return (
+			<ToolActivityMotion disabled={shouldReduceMotion}>
+				<Popover>
+					<PopoverTrigger className="block min-w-0 max-w-full text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
+						<ActivitySummary activity={activity} canExpand sourcePreviews={[]} />
+					</PopoverTrigger>
+					<PopoverContent align="start" className="w-64 p-1.5">
+						<OrchestrateCallList calls={orchestrateCalls} />
+					</PopoverContent>
+				</Popover>
+			</ToolActivityMotion>
+		);
 	}
 
 	const inlineContent = getInlineActivityContent(activity);
@@ -90,6 +122,79 @@ function ToolActivityMotion({
 				{children}
 			</m.div>
 		</LazyMotion>
+	);
+}
+
+interface OrchestrateCallView {
+	toolName: string;
+	status: "completed" | "failed";
+}
+
+function withLiveNestedAction(
+	activity: AiChatToolActivity,
+	nestedToolName: string,
+): AiChatToolActivity {
+	const nestedLabel = getAiToolPresentation(nestedToolName).title;
+
+	return {
+		...activity,
+		summary: `${activity.summary} · ${nestedLabel}`,
+		segments: [
+			{ kind: "text", value: activity.summary },
+			{ kind: "text", value: " · " },
+			{ kind: "name", value: nestedLabel },
+		],
+	};
+}
+
+/** The nested calls a settled orchestrate part recorded, parsed defensively. */
+function getOrchestrateCalls(part: AiChatToolPart): OrchestrateCallView[] {
+	if (part.state !== "output-available") {
+		return [];
+	}
+
+	const calls = asRecord(part.output).calls;
+	if (!Array.isArray(calls)) {
+		return [];
+	}
+
+	const views: OrchestrateCallView[] = [];
+	for (const call of calls) {
+		const record = asRecord(call);
+		if (typeof record.toolName === "string") {
+			views.push({
+				toolName: record.toolName,
+				status: record.status === "failed" ? "failed" : "completed",
+			});
+		}
+	}
+
+	return views;
+}
+
+function OrchestrateCallList({ calls }: { calls: OrchestrateCallView[] }) {
+	return (
+		<div className="grid gap-0.5" aria-label="Steps in this run">
+			{calls.map((call, index) => {
+				const presentation = getAiToolPresentation(call.toolName);
+
+				return (
+					<div
+						// biome-ignore lint/suspicious/noArrayIndexKey: calls are append-only per run
+						key={index}
+						className="flex items-center gap-1.5 rounded-sm px-1.5 py-1 text-muted-foreground text-xs"
+					>
+						<span className="grid size-3.5 shrink-0 place-items-center text-muted-foreground/70">
+							<ToolActivityIcon icon={presentation.icon} />
+						</span>
+						<span className="min-w-0 truncate font-medium">{presentation.title}</span>
+						{call.status === "failed" ? (
+							<span className="shrink-0 text-destructive/80">failed</span>
+						) : null}
+					</div>
+				);
+			})}
+		</div>
 	);
 }
 
@@ -310,7 +415,7 @@ function Favicon({
 	);
 }
 
-function ToolActivityIcon({ icon }: { icon: AiToolActivityIconKind }) {
+export function ToolActivityIcon({ icon }: { icon: AiToolActivityIconKind }) {
 	switch (icon) {
 		case "edit":
 			return <PencilLine className="size-3.5" aria-hidden="true" />;

--- a/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
@@ -14,7 +14,10 @@ import {
 	type AiChatToolActivity,
 } from "#/features/workspaces/components/ai-chat/ai-chat-display-state";
 import { useLiveCodemodeActivity } from "#/features/workspaces/components/ai-chat/ai-chat-live-activity";
-import type { AiChatToolSummarySegment } from "#/features/workspaces/components/ai-chat/ai-chat-tool-summaries";
+import {
+	isVisibleOrchestrateCallTool,
+	type AiChatToolSummarySegment,
+} from "#/features/workspaces/components/ai-chat/ai-chat-tool-summaries";
 import {
 	getToolSourceHostname,
 	getToolSourcePreviews,
@@ -44,9 +47,12 @@ export function AiChatToolActivityRow({
 
 	// A running orchestrate row appends the nested tool it is currently
 	// driving ("Analyzing quiz scores · Read workspace") from the live
-	// transient stream events.
+	// transient stream events. Registry-hidden tools stay hidden here too.
 	const activity =
-		baseActivity.toolName === "orchestrate" && baseActivity.status === "running" && liveActivity
+		baseActivity.toolName === "orchestrate" &&
+		baseActivity.status === "running" &&
+		liveActivity &&
+		isVisibleOrchestrateCallTool(liveActivity.call.toolName)
 			? withLiveNestedAction(baseActivity, liveActivity.call.toolName)
 			: baseActivity;
 	const orchestrateCalls =
@@ -163,7 +169,7 @@ function getOrchestrateCalls(part: AiChatToolPart): OrchestrateCallView[] {
 	const views: OrchestrateCallView[] = [];
 	for (const call of calls) {
 		const record = asRecord(call);
-		if (typeof record.toolName === "string") {
+		if (typeof record.toolName === "string" && isVisibleOrchestrateCallTool(record.toolName)) {
 			views.push({
 				toolName: record.toolName,
 				status: record.status === "failed" ? "failed" : "completed",

--- a/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
@@ -15,7 +15,7 @@ import {
 	type AiChatToolActivity,
 } from "#/features/workspaces/components/ai-chat/ai-chat-display-state";
 import { useLiveCodemodeActivity } from "#/features/workspaces/components/ai-chat/ai-chat-live-activity";
-import type { AiChatToolReceiptSegment } from "#/features/workspaces/components/ai-chat/ai-chat-tool-receipts";
+import type { AiChatToolSummarySegment } from "#/features/workspaces/components/ai-chat/ai-chat-tool-summaries";
 import {
 	getToolSourceHostname,
 	getToolSourcePreviews,
@@ -219,7 +219,7 @@ function ActivitySummary({
 		presentation: AiToolPresentation;
 		status: AiChatToolActivity["status"];
 		summary: string;
-		segments?: AiChatToolReceiptSegment[];
+		segments?: AiChatToolSummarySegment[];
 	};
 	canExpand?: boolean;
 	sourcePreviews: ToolSourcePreview[];
@@ -259,7 +259,7 @@ function ActivitySummaryText({
 	isRunning,
 }: {
 	summary: string;
-	segments: AiChatToolReceiptSegment[] | undefined;
+	segments: AiChatToolSummarySegment[] | undefined;
 	isRunning: boolean;
 }) {
 	if (!segments || segments.length === 0) {

--- a/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
@@ -148,7 +148,9 @@ function withLiveNestedAction(
 		...activity,
 		summary: `${activity.summary} · ${nestedLabel}`,
 		segments: [
-			{ kind: "text", value: activity.summary },
+			// Both variable-width pieces are `name` so a long model-authored title
+			// truncates instead of pushing the nested label out of the row.
+			{ kind: "name", value: activity.summary },
 			{ kind: "text", value: " · " },
 			{ kind: "name", value: nestedLabel },
 		],

--- a/src/features/workspaces/components/ai-chat/ai-chat-display-state.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-display-state.ts
@@ -11,10 +11,10 @@ import {
 	type AiToolPresentation,
 } from "#/features/workspaces/ai/ai-tool-registry";
 import {
-	getFinishedToolReceipt,
-	getRunningToolReceipt,
-	type AiChatToolReceiptSegment,
-} from "#/features/workspaces/components/ai-chat/ai-chat-tool-receipts";
+	getFinishedToolSummary,
+	getRunningToolSummary,
+	type AiChatToolSummarySegment,
+} from "#/features/workspaces/components/ai-chat/ai-chat-tool-summaries";
 
 export type AssistantRowDisplay =
 	| {
@@ -30,7 +30,7 @@ export interface AiChatToolActivity {
 	presentation: AiToolPresentation;
 	status: "completed" | "failed" | "interrupted" | "running";
 	summary: string;
-	segments?: AiChatToolReceiptSegment[];
+	segments?: AiChatToolSummarySegment[];
 	toolName: string;
 }
 
@@ -149,14 +149,14 @@ export function getToolActivityForPart(
 
 	const toolName = getToolPartName(part);
 	const presentation = getAiToolPresentation(toolName);
-	const receipt = getToolActivityReceipt(part, toolName, interrupted);
+	const toolSummary = getToolActivitySummary(part, toolName, interrupted);
 
 	return {
 		detail: part,
 		presentation,
-		status: receipt.status,
-		summary: receipt.summary,
-		segments: receipt.segments,
+		status: toolSummary.status,
+		summary: toolSummary.summary,
+		segments: toolSummary.segments,
 		toolName,
 	};
 }
@@ -170,18 +170,18 @@ export function getToolPartName(part: AiChatToolPart) {
 	return part.type === "dynamic-tool" ? part.toolName : part.type.split("-").slice(1).join("-");
 }
 
-function getToolActivityReceipt(
+function getToolActivitySummary(
 	part: AiChatToolPart,
 	toolName: string,
 	interrupted: boolean,
 ): {
 	status: AiChatToolActivity["status"];
 	summary: string;
-	segments?: AiChatToolReceiptSegment[];
+	segments?: AiChatToolSummarySegment[];
 } {
 	switch (part.state) {
 		case "output-available":
-			return getFinishedToolReceipt({
+			return getFinishedToolSummary({
 				baseStatus: "completed",
 				output: part.output,
 				toolInput: part.input,
@@ -189,14 +189,14 @@ function getToolActivityReceipt(
 			});
 		case "output-denied":
 		case "output-error":
-			return getFinishedToolReceipt({
+			return getFinishedToolSummary({
 				baseStatus: "failed",
 				output: part.output,
 				toolInput: part.input,
 				toolName,
 			});
 		default: {
-			const running = getRunningToolReceipt({
+			const running = getRunningToolSummary({
 				toolInput: part.input,
 				toolName,
 			});

--- a/src/features/workspaces/components/ai-chat/ai-chat-document-edit-actions.test.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-document-edit-actions.test.ts
@@ -19,7 +19,47 @@ describe("AI chat document edit actions", () => {
 			},
 		]);
 	});
+
+	it("derives receipts from document edits made inside an orchestrate run", () => {
+		expect(
+			getAiChatDocumentEditGroups([orchestratePart(), editPart("document", "call-direct")]),
+		).toEqual([
+			{
+				itemId: "item-document",
+				lineChanges: { added: 5, removed: 3 },
+				path: "/Document",
+				receiptIds: ["nested-edit-1", "call-direct"],
+			},
+		]);
+	});
 });
+
+function orchestratePart() {
+	return {
+		input: { title: "Updating notes", code: "async () => {}" },
+		output: {
+			status: "completed",
+			result: null,
+			calls: [
+				{ toolName: "workspace_read_items", status: "completed" },
+				{
+					toolName: "workspace_edit_item",
+					status: "completed",
+					action: {
+						kind: "document-edit",
+						itemId: "item-document",
+						path: "/Document",
+						receiptId: "nested-edit-1",
+						lineChanges: { added: 3, removed: 2 },
+					},
+				},
+			],
+		},
+		state: "output-available",
+		toolCallId: "call-orchestrate",
+		type: "tool-orchestrate",
+	} as AiChatMessagePart;
+}
 
 function editPart(itemType: "document" | "flashcard", toolCallId: string) {
 	return {

--- a/src/features/workspaces/components/ai-chat/ai-chat-document-edit-actions.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-document-edit-actions.ts
@@ -20,27 +20,55 @@ export function getAiChatDocumentEditGroups(
 	const seenReceiptIds = new Set<string>();
 
 	for (const part of parts) {
-		if (
-			!isToolUIPart(part) ||
-			getToolPartName(part) !== "workspace_edit_item" ||
-			part.state !== "output-available"
-		) {
+		if (!isToolUIPart(part) || part.state !== "output-available") {
 			continue;
 		}
 
-		const output = asRecord(part.output);
-		const path = typeof output.path === "string" ? output.path : null;
-		const itemId = typeof output.itemId === "string" ? output.itemId : null;
-		const applied = typeof output.applied === "number" ? output.applied : 0;
-		const lineChanges = readLineChanges(output.lineChanges);
-		const isDocument = output.itemType === "document";
-		if (isDocument && itemId && path && applied > 0) {
-			addToGroup(groupsByItemId, seenReceiptIds, {
-				itemId,
-				lineChanges,
-				path,
-				receiptId: part.toolCallId,
-			});
+		const toolName = getToolPartName(part);
+
+		if (toolName === "workspace_edit_item") {
+			const output = asRecord(part.output);
+			const path = typeof output.path === "string" ? output.path : null;
+			const itemId = typeof output.itemId === "string" ? output.itemId : null;
+			const applied = typeof output.applied === "number" ? output.applied : 0;
+			const lineChanges = readLineChanges(output.lineChanges);
+			const isDocument = output.itemType === "document";
+			if (isDocument && itemId && path && applied > 0) {
+				addToGroup(groupsByItemId, seenReceiptIds, {
+					itemId,
+					lineChanges,
+					path,
+					receiptId: part.toolCallId,
+				});
+			}
+			continue;
+		}
+
+		// Edits made from inside an orchestrate (Code Mode) run: the tool part
+		// records each nested document edit as a call `action`, carrying the
+		// nested invocation id that IS the document-edit receipt id.
+		if (toolName === "orchestrate") {
+			const calls = asRecord(part.output).calls;
+			if (!Array.isArray(calls)) {
+				continue;
+			}
+
+			for (const call of calls) {
+				const action = asRecord(asRecord(call).action);
+				if (
+					action.kind === "document-edit" &&
+					typeof action.itemId === "string" &&
+					typeof action.path === "string" &&
+					typeof action.receiptId === "string"
+				) {
+					addToGroup(groupsByItemId, seenReceiptIds, {
+						itemId: action.itemId,
+						lineChanges: readLineChanges(action.lineChanges),
+						path: action.path,
+						receiptId: action.receiptId,
+					});
+				}
+			}
 		}
 	}
 

--- a/src/features/workspaces/components/ai-chat/ai-chat-live-activity.tsx
+++ b/src/features/workspaces/components/ai-chat/ai-chat-live-activity.tsx
@@ -1,0 +1,72 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+import type { AiCodemodeActivityEvent } from "#/features/workspaces/ai/codemode-tool";
+import { asRecord } from "#/lib/record";
+
+/**
+ * Latest live progress event per orchestrate tool call, keyed by the outer
+ * call's id. Delivered as transient `data-codemode-activity` stream parts, so
+ * it exists only during the streaming turn — settled parts carry their own
+ * durable `calls` record instead.
+ */
+export type AiChatLiveCodemodeActivity = Readonly<Record<string, AiCodemodeActivityEvent>>;
+
+const AiChatLiveActivityContext = createContext<AiChatLiveCodemodeActivity>({});
+
+/** Provides the live orchestrate progress map to the message tree. */
+export function AiChatLiveActivityProvider({
+	children,
+	value,
+}: {
+	children: ReactNode;
+	value: AiChatLiveCodemodeActivity;
+}) {
+	return (
+		<AiChatLiveActivityContext.Provider value={value}>
+			{children}
+		</AiChatLiveActivityContext.Provider>
+	);
+}
+
+/**
+ * The latest live event for one orchestrate call, or undefined outside a
+ * streaming turn.
+ */
+export function useLiveCodemodeActivity(invocationId: string): AiCodemodeActivityEvent | undefined {
+	return useContext(AiChatLiveActivityContext)[invocationId];
+}
+
+const CALL_STATUSES = new Set(["running", "completed", "failed"]);
+
+/**
+ * Parse a `data-codemode-activity` part's payload from the untrusted stream.
+ *
+ * @returns The event, or null when the payload does not match the shape.
+ */
+export function parseCodemodeActivityEvent(data: unknown): AiCodemodeActivityEvent | null {
+	const record = asRecord(data);
+	const call = asRecord(record.call);
+
+	if (
+		typeof record.invocationId !== "string" ||
+		typeof record.title !== "string" ||
+		typeof call.index !== "number" ||
+		typeof call.toolName !== "string" ||
+		typeof call.status !== "string" ||
+		!CALL_STATUSES.has(call.status)
+	) {
+		return null;
+	}
+
+	return {
+		invocationId: record.invocationId,
+		title: record.title,
+		call: {
+			index: call.index,
+			toolName: call.toolName,
+			// SAFETY: membership in CALL_STATUSES was checked above; TypeScript
+			// cannot narrow a string through Set.has.
+			status: call.status as AiCodemodeActivityEvent["call"]["status"],
+		},
+	};
+}

--- a/src/features/workspaces/components/ai-chat/ai-chat-tool-receipts.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-tool-receipts.ts
@@ -96,6 +96,10 @@ export function getRunningToolReceipt(input: {
 	switch (input.toolName) {
 		case "activate_skill":
 			return receipt.running("Using ", ...skillGuidanceName(toolInput));
+		case "orchestrate":
+			// The model authors the label (schema: short plain-language title,
+			// streamed ahead of the code) — surface it verbatim.
+			return receipt.running(getString(toolInput.title) ?? "Working through steps");
 		case "workspace_create_items":
 			return receipt.running(`Creating ${formatCount(getArray(toolInput.items).length, "item")}`);
 		case "workspace_delete_items":
@@ -156,6 +160,8 @@ export function getFinishedToolReceipt(input: {
 	switch (input.toolName) {
 		case "activate_skill":
 			return receipt.completed("Used ", ...skillGuidanceName(asRecord(input.toolInput)));
+		case "orchestrate":
+			return summarizeOrchestrate(input.output, input.toolInput);
 		case "workspace_create_items":
 			return summarizeWorkspaceBatch(input.output, {
 				failureVerb: "create",
@@ -212,6 +218,8 @@ function summarizeFailedTool(
 	switch (toolName) {
 		case "activate_skill":
 			return receipt.failed("Couldn’t load ", ...skillGuidanceName(asRecord(toolInput)));
+		case "orchestrate":
+			return receipt.failed(orchestrateFailureSummary(toolInput));
 		case "workspace_create_items":
 			return failedCount > 0
 				? receipt.failed(`Couldn’t create ${formatCount(failedCount, "item")}`)
@@ -240,6 +248,33 @@ function summarizeFailedTool(
 		default:
 			return receipt.failed(`${capitalize(formatToolNameFallback(toolName))} failed`);
 	}
+}
+
+// The orchestrate tool reports failures as a successful output with
+// status "error" (so calls and logs survive), which is why the completed
+// branch also has to map to a failed receipt.
+function summarizeOrchestrate(output: unknown, toolInput: unknown): AiChatToolReceipt {
+	const record = asRecord(output);
+	const title = getString(asRecord(toolInput).title);
+
+	if (getString(record.status) === "error") {
+		return receipt.failed(orchestrateFailureSummary(toolInput));
+	}
+
+	const stepCount = getArray(record.calls).length;
+	const base = title ?? "Worked through steps";
+	return stepCount > 0
+		? receipt.completed(base, ` · ${formatCount(stepCount, "step")}`)
+		: receipt.completed(base);
+}
+
+function orchestrateFailureSummary(toolInput: unknown) {
+	const title = getString(asRecord(toolInput).title);
+	return title ? `Couldn’t finish ${lowercaseFirst(title)}` : "Couldn’t finish the steps";
+}
+
+function lowercaseFirst(value: string) {
+	return value.length === 0 ? value : `${value.charAt(0).toLowerCase()}${value.slice(1)}`;
 }
 
 function summarizeWorkspaceBatch(

--- a/src/features/workspaces/components/ai-chat/ai-chat-tool-summaries.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-tool-summaries.ts
@@ -1,3 +1,4 @@
+import { getAiToolPresentation } from "#/features/workspaces/ai/ai-tool-registry";
 import { asRecord } from "#/lib/record";
 
 export type AiChatToolSummaryStatus = "completed" | "failed" | "interrupted" | "running";
@@ -261,11 +262,26 @@ function summarizeOrchestrate(output: unknown, toolInput: unknown): AiChatToolSu
 		return summary.failed(orchestrateFailureSummary(toolInput));
 	}
 
-	const stepCount = getArray(record.calls).length;
+	// Count only the calls the expanded step list will show: registry-hidden
+	// tools (list workspace, time checks) stay invisible here too, so the
+	// number always matches the rows.
+	const stepCount = getVisibleOrchestrateCallCount(record.calls);
 	const base = title ?? "Worked through steps";
 	return stepCount > 0
 		? summary.completed(base, ` · ${formatCount(stepCount, "step")}`)
 		: summary.completed(base);
+}
+
+/** Recorded orchestrate calls whose tools have visible chat rows. */
+export function isVisibleOrchestrateCallTool(toolName: string) {
+	return getAiToolPresentation(toolName).visibility === "visible";
+}
+
+function getVisibleOrchestrateCallCount(calls: unknown) {
+	return getArray(calls).filter((call) => {
+		const toolName = getString(asRecord(call).toolName);
+		return toolName !== undefined && isVisibleOrchestrateCallTool(toolName);
+	}).length;
 }
 
 function orchestrateFailureSummary(toolInput: unknown) {

--- a/src/features/workspaces/components/ai-chat/ai-chat-tool-summaries.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-tool-summaries.ts
@@ -1,10 +1,10 @@
 import { asRecord } from "#/lib/record";
 
-export type AiChatToolReceiptStatus = "completed" | "failed" | "interrupted" | "running";
-type AiChatFinishedToolReceiptStatus = Exclude<AiChatToolReceiptStatus, "interrupted" | "running">;
+export type AiChatToolSummaryStatus = "completed" | "failed" | "interrupted" | "running";
+type AiChatFinishedToolSummaryStatus = Exclude<AiChatToolSummaryStatus, "interrupted" | "running">;
 
 /**
- * A receipt segment is one visual chunk of the summary that either has fixed
+ * A summary segment is one visual chunk of the summary that either has fixed
  * width (`text`, rendered `shrink-0 whitespace-pre` in the tool row) or holds
  * a variable-width label that should shrink first (`name`, rendered
  * `min-w-0 truncate`). The row-level flex layout then handles all dynamic
@@ -12,12 +12,12 @@ type AiChatFinishedToolReceiptStatus = Exclude<AiChatToolReceiptStatus, "interru
  * character caps — while status icons, favicons, and prefix/suffix words
  * stay visible.
  */
-export type AiChatToolReceiptSegment =
+export type AiChatToolSummarySegment =
 	| { kind: "text"; value: string }
 	| { kind: "name"; value: string };
 
-export interface AiChatToolReceipt {
-	status: AiChatToolReceiptStatus;
+export interface AiChatToolSummary {
+	status: AiChatToolSummaryStatus;
 	/**
 	 * Full plain-text summary used for the row title attribute, accessibility,
 	 * and telemetry. Always populated even when `segments` is present so the
@@ -29,15 +29,15 @@ export interface AiChatToolReceipt {
 	 * row renderer emits one flex child per segment; when omitted it renders
 	 * the summary as a single truncate span (legacy behavior).
 	 */
-	segments?: AiChatToolReceiptSegment[];
+	segments?: AiChatToolSummarySegment[];
 }
 
-type ReceiptPart = string | { name: string };
+type SummaryPart = string | { name: string };
 
-function toSegments(parts: readonly ReceiptPart[]): AiChatToolReceiptSegment[] {
-	const out: AiChatToolReceiptSegment[] = [];
+function toSegments(parts: readonly SummaryPart[]): AiChatToolSummarySegment[] {
+	const out: AiChatToolSummarySegment[] = [];
 	for (const part of parts) {
-		const next: AiChatToolReceiptSegment =
+		const next: AiChatToolSummarySegment =
 			typeof part === "string" ? { kind: "text", value: part } : { kind: "name", value: part.name };
 		if (next.kind === "text" && !next.value) continue;
 		const previous = out[out.length - 1];
@@ -50,11 +50,11 @@ function toSegments(parts: readonly ReceiptPart[]): AiChatToolReceiptSegment[] {
 	return out;
 }
 
-function toSummary(segments: readonly AiChatToolReceiptSegment[]): string {
+function toSummary(segments: readonly AiChatToolSummarySegment[]): string {
 	return segments.map((segment) => segment.value).join("");
 }
 
-function build(status: AiChatToolReceiptStatus, parts: readonly ReceiptPart[]): AiChatToolReceipt {
+function build(status: AiChatToolSummaryStatus, parts: readonly SummaryPart[]): AiChatToolSummary {
 	if (parts.length === 1 && typeof parts[0] === "string") {
 		return { status, summary: parts[0] };
 	}
@@ -63,56 +63,56 @@ function build(status: AiChatToolReceiptStatus, parts: readonly ReceiptPart[]): 
 }
 
 /**
- * Receipt factory. Pass strings and `{ name }` parts positionally and the
+ * Summary factory. Pass strings and `{ name }` parts positionally and the
  * builder assembles a summary string plus a matching segments array.
  *
  * @example
- *   receipt.running("Editing ", ...name(basename))
- *   receipt.completed("Updated ", ...name(basename), " with ", formatCount(count, "edit"))
+ *   summary.running("Editing ", ...name(basename))
+ *   summary.completed("Updated ", ...name(basename), " with ", formatCount(count, "edit"))
  */
-export const receipt = {
-	running: (...parts: ReceiptPart[]) => build("running", parts),
-	completed: (...parts: ReceiptPart[]) => build("completed", parts),
-	failed: (...parts: ReceiptPart[]) => build("failed", parts),
+export const summary = {
+	running: (...parts: SummaryPart[]) => build("running", parts),
+	completed: (...parts: SummaryPart[]) => build("completed", parts),
+	failed: (...parts: SummaryPart[]) => build("failed", parts),
 };
 
 /**
- * Emits a truncatable name wrapped in curly quotes as three receipt parts:
+ * Emits a truncatable name wrapped in curly quotes as three summary parts:
  * the opening quote (fixed), the name (truncates), the closing quote (fixed).
  * The quotes stay visible even when the middle gets ellipsized.
  */
-export function name(value: string | undefined): ReceiptPart[] {
+export function name(value: string | undefined): SummaryPart[] {
 	const trimmed = value?.trim();
 	if (!trimmed) return ["item"];
 	return ["“", { name: trimmed }, "”"];
 }
 
-export function getRunningToolReceipt(input: {
+export function getRunningToolSummary(input: {
 	toolInput: unknown;
 	toolName: string;
-}): AiChatToolReceipt {
+}): AiChatToolSummary {
 	const toolInput = asRecord(input.toolInput);
 
 	switch (input.toolName) {
 		case "activate_skill":
-			return receipt.running("Using ", ...skillGuidanceName(toolInput));
+			return summary.running("Using ", ...skillGuidanceName(toolInput));
 		case "orchestrate":
 			// The model authors the label (schema: short plain-language title,
 			// streamed ahead of the code) — surface it verbatim.
-			return receipt.running(getString(toolInput.title) ?? "Working through steps");
+			return summary.running(getString(toolInput.title) ?? "Working through steps");
 		case "workspace_create_items":
-			return receipt.running(`Creating ${formatCount(getArray(toolInput.items).length, "item")}`);
+			return summary.running(`Creating ${formatCount(getArray(toolInput.items).length, "item")}`);
 		case "workspace_delete_items":
-			return receipt.running(`Deleting ${formatCount(getArray(toolInput.paths).length, "item")}`);
+			return summary.running(`Deleting ${formatCount(getArray(toolInput.paths).length, "item")}`);
 		case "workspace_edit_item":
-			return receipt.running("Editing ", ...name(getBaseName(getString(toolInput.path))));
+			return summary.running("Editing ", ...name(getBaseName(getString(toolInput.path))));
 		case "workspace_move_items": {
 			const count = getArray(toolInput.paths).length;
 			const destinationName = getDestinationName(getString(toolInput.destinationPath));
 			const target = formatCount(count, "item");
 			return destinationName
-				? receipt.running(`Moving ${target} to `, ...destinationName)
-				: receipt.running(`Moving ${target}`);
+				? summary.running(`Moving ${target} to `, ...destinationName)
+				: summary.running(`Moving ${target}`);
 		}
 		case "workspace_read_items": {
 			const requests = getArray(toolInput.requests).map((request) => asRecord(request));
@@ -120,46 +120,46 @@ export function getRunningToolReceipt(input: {
 			if (requests.length === 1 && paths[0]) {
 				const range = formatPageRange(getString(requests[0]?.range));
 				return range
-					? receipt.running("Reading ", ...name(getBaseName(paths[0])), ` p. ${range}`)
-					: receipt.running("Reading ", ...name(getBaseName(paths[0])));
+					? summary.running("Reading ", ...name(getBaseName(paths[0])), ` p. ${range}`)
+					: summary.running("Reading ", ...name(getBaseName(paths[0])));
 			}
-			return receipt.running(`Reading ${formatCount(paths.length, "item")}`);
+			return summary.running(`Reading ${formatCount(paths.length, "item")}`);
 		}
 		case "workspace_rename_item": {
 			const oldName = getBaseName(getString(toolInput.path));
 			const newName = getString(toolInput.name);
 			return newName
-				? receipt.running("Renaming ", ...name(oldName), " → ", ...name(newName))
-				: receipt.running("Renaming ", ...name(oldName));
+				? summary.running("Renaming ", ...name(oldName), " → ", ...name(newName))
+				: summary.running("Renaming ", ...name(oldName));
 		}
 		case "web_fetch":
-			return receipt.running("Reading ", {
+			return summary.running("Reading ", {
 				name: formatUrlWithPath(getString(toolInput.url)),
 			});
 		case "web_search":
-			return receipt.running("Searching for ", ...name(getString(toolInput.query)));
+			return summary.running("Searching for ", ...name(getString(toolInput.query)));
 		case "research_deepen":
 			return summarizeRunningResearchDeepen(toolInput);
 		case "research_discover":
-			return receipt.running("Finding sources for ", ...name(getString(toolInput.query)));
+			return summary.running("Finding sources for ", ...name(getString(toolInput.query)));
 		default:
-			return receipt.running(`Running ${formatToolNameFallback(input.toolName)}`);
+			return summary.running(`Running ${formatToolNameFallback(input.toolName)}`);
 	}
 }
 
-export function getFinishedToolReceipt(input: {
-	baseStatus: AiChatFinishedToolReceiptStatus;
+export function getFinishedToolSummary(input: {
+	baseStatus: AiChatFinishedToolSummaryStatus;
 	output: unknown;
 	toolInput: unknown;
 	toolName: string;
-}): AiChatToolReceipt {
+}): AiChatToolSummary {
 	if (input.baseStatus === "failed") {
 		return summarizeFailedTool(input.toolName, input.output, input.toolInput);
 	}
 
 	switch (input.toolName) {
 		case "activate_skill":
-			return receipt.completed("Used ", ...skillGuidanceName(asRecord(input.toolInput)));
+			return summary.completed("Used ", ...skillGuidanceName(asRecord(input.toolInput)));
 		case "orchestrate":
 			return summarizeOrchestrate(input.output, input.toolInput);
 		case "workspace_create_items":
@@ -203,7 +203,7 @@ export function getFinishedToolReceipt(input: {
 		case "research_deepen":
 			return summarizeResearchDeepen(input.output, input.toolInput);
 		default:
-			return receipt.completed(summarizeUnknownResult(input.output, input.toolName));
+			return summary.completed(summarizeUnknownResult(input.output, input.toolName));
 	}
 }
 
@@ -211,61 +211,61 @@ function summarizeFailedTool(
 	toolName: string,
 	output: unknown,
 	toolInput: unknown,
-): AiChatToolReceipt {
+): AiChatToolSummary {
 	const outputRecord = asRecord(output);
 	const failedCount = getArray(outputRecord.failed).length;
 
 	switch (toolName) {
 		case "activate_skill":
-			return receipt.failed("Couldn’t load ", ...skillGuidanceName(asRecord(toolInput)));
+			return summary.failed("Couldn’t load ", ...skillGuidanceName(asRecord(toolInput)));
 		case "orchestrate":
-			return receipt.failed(orchestrateFailureSummary(toolInput));
+			return summary.failed(orchestrateFailureSummary(toolInput));
 		case "workspace_create_items":
 			return failedCount > 0
-				? receipt.failed(`Couldn’t create ${formatCount(failedCount, "item")}`)
-				: receipt.failed("Couldn’t update workspace");
+				? summary.failed(`Couldn’t create ${formatCount(failedCount, "item")}`)
+				: summary.failed("Couldn’t update workspace");
 		case "workspace_delete_items":
 			return failedCount > 0
-				? receipt.failed(`Couldn’t delete ${formatCount(failedCount, "item")}`)
-				: receipt.failed("Couldn’t update workspace");
+				? summary.failed(`Couldn’t delete ${formatCount(failedCount, "item")}`)
+				: summary.failed("Couldn’t update workspace");
 		case "workspace_move_items":
 			return failedCount > 0
-				? receipt.failed(`Couldn’t move ${formatCount(failedCount, "item")}`)
-				: receipt.failed("Couldn’t update workspace");
+				? summary.failed(`Couldn’t move ${formatCount(failedCount, "item")}`)
+				: summary.failed("Couldn’t update workspace");
 		case "workspace_rename_item":
 			return failedCount > 0
-				? receipt.failed(`Couldn’t rename ${formatCount(failedCount, "item")}`)
-				: receipt.failed("Couldn’t update workspace");
+				? summary.failed(`Couldn’t rename ${formatCount(failedCount, "item")}`)
+				: summary.failed("Couldn’t update workspace");
 		case "workspace_edit_item":
-			return receipt.failed(
+			return summary.failed(
 				"Couldn’t update ",
 				...name(getBaseName(getString(outputRecord.path) ?? getPathFromToolInput(toolInput))),
 			);
 		case "workspace_read_items":
 			return failedCount > 0
-				? receipt.failed(`Couldn’t read ${formatCount(failedCount, "item")}`)
-				: receipt.failed("Couldn’t read workspace");
+				? summary.failed(`Couldn’t read ${formatCount(failedCount, "item")}`)
+				: summary.failed("Couldn’t read workspace");
 		default:
-			return receipt.failed(`${capitalize(formatToolNameFallback(toolName))} failed`);
+			return summary.failed(`${capitalize(formatToolNameFallback(toolName))} failed`);
 	}
 }
 
 // The orchestrate tool reports failures as a successful output with
 // status "error" (so calls and logs survive), which is why the completed
-// branch also has to map to a failed receipt.
-function summarizeOrchestrate(output: unknown, toolInput: unknown): AiChatToolReceipt {
+// branch also has to map to a failed summary.
+function summarizeOrchestrate(output: unknown, toolInput: unknown): AiChatToolSummary {
 	const record = asRecord(output);
 	const title = getString(asRecord(toolInput).title);
 
 	if (getString(record.status) === "error") {
-		return receipt.failed(orchestrateFailureSummary(toolInput));
+		return summary.failed(orchestrateFailureSummary(toolInput));
 	}
 
 	const stepCount = getArray(record.calls).length;
 	const base = title ?? "Worked through steps";
 	return stepCount > 0
-		? receipt.completed(base, ` · ${formatCount(stepCount, "step")}`)
-		: receipt.completed(base);
+		? summary.completed(base, ` · ${formatCount(stepCount, "step")}`)
+		: summary.completed(base);
 }
 
 function orchestrateFailureSummary(toolInput: unknown) {
@@ -282,19 +282,19 @@ function summarizeWorkspaceBatch(
 	options: {
 		failureVerb: string;
 		successVerb: string;
-		destination?: ReceiptPart[];
+		destination?: SummaryPart[];
 		typeFromItem?: (item: unknown) => string;
 	},
-): AiChatToolReceipt {
+): AiChatToolSummary {
 	const record = asRecord(output);
 	const items = getArray(record.items);
 	const failedCount = getArray(record.failed).length;
 
 	if (items.length === 0 && failedCount > 0) {
-		return receipt.failed(`Couldn’t ${options.failureVerb} ${formatCount(failedCount, "item")}`);
+		return summary.failed(`Couldn’t ${options.failureVerb} ${formatCount(failedCount, "item")}`);
 	}
 
-	const base: ReceiptPart[] =
+	const base: SummaryPart[] =
 		items.length === 1
 			? singleWorkspaceItemParts(items[0], options)
 			: items.length === 2
@@ -302,14 +302,14 @@ function summarizeWorkspaceBatch(
 				: [`${options.successVerb} ${formatCount(items.length, "item")}`];
 
 	const withDestination = options.destination
-		? ([...base, " to ", ...options.destination] as ReceiptPart[])
+		? ([...base, " to ", ...options.destination] as SummaryPart[])
 		: base;
 	const withFailures =
 		failedCount > 0
-			? ([...withDestination, `, ${formatCount(failedCount, "failure")}`] as ReceiptPart[])
+			? ([...withDestination, `, ${formatCount(failedCount, "failure")}`] as SummaryPart[])
 			: withDestination;
 
-	return receipt.completed(...withFailures);
+	return summary.completed(...withFailures);
 }
 
 function singleWorkspaceItemParts(
@@ -318,7 +318,7 @@ function singleWorkspaceItemParts(
 		successVerb: string;
 		typeFromItem?: (item: unknown) => string;
 	},
-): ReceiptPart[] {
+): SummaryPart[] {
 	const type = options.typeFromItem?.(item);
 	const nameParts = name(getBaseName(getString(asRecord(item).path)));
 	return type
@@ -326,30 +326,30 @@ function singleWorkspaceItemParts(
 		: [`${options.successVerb} `, ...nameParts];
 }
 
-function summarizeWorkspaceRename(output: unknown, toolInput: unknown): AiChatToolReceipt {
+function summarizeWorkspaceRename(output: unknown, toolInput: unknown): AiChatToolSummary {
 	const record = asRecord(output);
 	const item = asRecord(record.item);
 	const failedCount = getArray(record.failed).length;
 
 	if (!record.item && failedCount > 0) {
-		return receipt.failed(`Couldn’t rename ${formatCount(failedCount, "item")}`);
+		return summary.failed(`Couldn’t rename ${formatCount(failedCount, "item")}`);
 	}
 
 	const oldName = getBaseName(getString(item.previousPath));
 	const newName = getBaseName(getString(item.path) ?? getString(asRecord(toolInput).name));
-	const parts: ReceiptPart[] = ["Renamed ", ...name(oldName), " → ", ...name(newName)];
+	const parts: SummaryPart[] = ["Renamed ", ...name(oldName), " → ", ...name(newName)];
 	if (failedCount > 0) parts.push(`, ${formatCount(failedCount, "failure")}`);
-	return receipt.completed(...parts);
+	return summary.completed(...parts);
 }
 
-function summarizeWorkspaceEdit(output: unknown, toolInput: unknown): AiChatToolReceipt {
+function summarizeWorkspaceEdit(output: unknown, toolInput: unknown): AiChatToolSummary {
 	const record = asRecord(output);
 	const failedCount = getArray(record.failed).length;
 	const warningCount = getArray(record.warnings).length;
 	const appliedCount = getNumber(record.applied) ?? 0;
 
 	if (appliedCount === 0 && failedCount > 0) {
-		return receipt.failed(
+		return summary.failed(
 			"Couldn’t update ",
 			...name(getBaseName(getString(record.path) ?? getPathFromToolInput(toolInput))),
 		);
@@ -362,10 +362,10 @@ function summarizeWorkspaceEdit(output: unknown, toolInput: unknown): AiChatTool
 	if (warningCount > 0) suffixPieces.push(formatCount(warningCount, "warning"));
 	const suffix = suffixPieces.length > 0 ? ` ${suffixPieces.join(", ")}` : "";
 
-	return receipt.completed("Updated ", ...nameParts, suffix);
+	return summary.completed("Updated ", ...nameParts, suffix);
 }
 
-function summarizeWorkspaceRead(output: unknown): AiChatToolReceipt {
+function summarizeWorkspaceRead(output: unknown): AiChatToolSummary {
 	const record = asRecord(output);
 	const results = getArray(record.results);
 	const failedCount = results.filter(
@@ -375,32 +375,32 @@ function summarizeWorkspaceRead(output: unknown): AiChatToolReceipt {
 	const pendingItems = results.filter((item) => getString(asRecord(item).status) === "pending");
 
 	if (readyItems.length === 0 && pendingItems.length === 0 && failedCount > 0) {
-		return receipt.failed(`Couldn’t read ${formatCount(failedCount, "item")}`);
+		return summary.failed(`Couldn’t read ${formatCount(failedCount, "item")}`);
 	}
 	if (readyItems.length === 0) {
-		const parts: ReceiptPart[] = [
+		const parts: SummaryPart[] = [
 			`Extraction in progress for ${formatCount(pendingItems.length, "item")}`,
 		];
 		if (failedCount > 0) parts.push(`, ${formatCount(failedCount, "failure")}`);
-		return receipt.completed(...parts);
+		return summary.completed(...parts);
 	}
 
-	const base: ReceiptPart[] =
+	const base: SummaryPart[] =
 		readyItems.length === 1
 			? singleReadParts(readyItems[0])
 			: [`Read ${formatCount(readyItems.length, "item")}`];
 
-	const withPending: ReceiptPart[] =
+	const withPending: SummaryPart[] =
 		pendingItems.length > 0
 			? [...base, ` · ${formatCount(pendingItems.length, "item")} still processing`]
 			: base;
-	const withFailures: ReceiptPart[] =
+	const withFailures: SummaryPart[] =
 		failedCount > 0 ? [...withPending, `, ${formatCount(failedCount, "failure")}`] : withPending;
 
-	return receipt.completed(...withFailures);
+	return summary.completed(...withFailures);
 }
 
-function singleReadParts(result: unknown): ReceiptPart[] {
+function singleReadParts(result: unknown): SummaryPart[] {
 	const record = asRecord(result);
 	const basename = getBaseName(getString(record.path));
 	const nameParts = name(basename);
@@ -423,63 +423,63 @@ function formatPageRange(range: string | undefined) {
 	return trimmed ? trimmed.replace(/\s*-\s*/g, "–") : undefined;
 }
 
-function summarizeWebSearch(output: unknown, toolInput: unknown): AiChatToolReceipt {
+function summarizeWebSearch(output: unknown, toolInput: unknown): AiChatToolSummary {
 	const results = getArray(asRecord(output).results);
 	const input = asRecord(toolInput);
 	const subject = getString(input.query);
 	const noun = getString(input.source) === "images" ? "image" : "source";
-	const base: ReceiptPart[] = [`Found ${formatCount(results.length, noun)}`];
+	const base: SummaryPart[] = [`Found ${formatCount(results.length, noun)}`];
 	return subject
-		? receipt.completed(...base, " for ", ...name(subject))
-		: receipt.completed(...base);
+		? summary.completed(...base, " for ", ...name(subject))
+		: summary.completed(...base);
 }
 
-function summarizeWebFetch(output: unknown, toolInput: unknown): AiChatToolReceipt {
+function summarizeWebFetch(output: unknown, toolInput: unknown): AiChatToolSummary {
 	const kind = getString(asRecord(output).kind);
 	const target = { name: formatUrlWithPath(getString(asRecord(toolInput).url)) };
-	if (kind === "unsupported") return receipt.completed("Couldn’t read ", target);
-	return receipt.completed(kind === "image" ? "Inspected " : "Read ", target);
+	if (kind === "unsupported") return summary.completed("Couldn’t read ", target);
+	return summary.completed(kind === "image" ? "Inspected " : "Read ", target);
 }
 
-function summarizeResearchDiscover(output: unknown, toolInput: unknown): AiChatToolReceipt {
+function summarizeResearchDiscover(output: unknown, toolInput: unknown): AiChatToolSummary {
 	const record = asRecord(output);
 	const total = getArray(record.papers).length + getArray(record.github).length;
 	const subject = getString(asRecord(toolInput).query);
-	const base: ReceiptPart[] = [`Found ${formatCount(total, "source")}`];
+	const base: SummaryPart[] = [`Found ${formatCount(total, "source")}`];
 	return subject
-		? receipt.completed(...base, " for ", ...name(subject))
-		: receipt.completed(...base);
+		? summary.completed(...base, " for ", ...name(subject))
+		: summary.completed(...base);
 }
 
-function summarizeResearchDeepen(output: unknown, toolInput: unknown): AiChatToolReceipt {
+function summarizeResearchDeepen(output: unknown, toolInput: unknown): AiChatToolSummary {
 	const record = asRecord(output);
 	const input = asRecord(toolInput);
 	const paper = getString(input.paper_id);
 
 	if (Array.isArray(record.passages)) {
-		return receipt.completed(
+		return summary.completed(
 			`Read ${formatCount(record.passages.length, "passage")} from `,
 			...name(paper),
 		);
 	}
 
 	if (Array.isArray(record.papers)) {
-		return receipt.completed(
+		return summary.completed(
 			`Found ${formatCount(record.papers.length, "paper")} related to `,
 			...name(paper),
 		);
 	}
 
-	return receipt.completed(summarizeUnknownResult(output, "research_deepen"));
+	return summary.completed(summarizeUnknownResult(output, "research_deepen"));
 }
 
-function summarizeRunningResearchDeepen(input: Record<string, unknown>): AiChatToolReceipt {
+function summarizeRunningResearchDeepen(input: Record<string, unknown>): AiChatToolSummary {
 	const paper = getString(input.paper_id);
 	const mode = getString(input.mode);
 
-	if (mode === "passages") return receipt.running("Reading passages from ", ...name(paper));
-	if (mode === "related") return receipt.running("Finding related papers for ", ...name(paper));
-	return receipt.running("Researching ", ...name(paper));
+	if (mode === "passages") return summary.running("Reading passages from ", ...name(paper));
+	if (mode === "related") return summary.running("Finding related papers for ", ...name(paper));
+	return summary.running("Researching ", ...name(paper));
 }
 
 function summarizeUnknownResult(output: unknown, toolName: string) {
@@ -499,7 +499,7 @@ function formatToolNameFallback(toolName: string) {
 	return words.length > 0 ? words.join(" ") : toolName;
 }
 
-function skillGuidanceName(toolInput: Record<string, unknown>): ReceiptPart[] {
+function skillGuidanceName(toolInput: Record<string, unknown>): SummaryPart[] {
 	const skill = formatToolNameFallback(getString(toolInput.name) ?? "specialized").replace(
 		/ authoring$/,
 		"",
@@ -511,8 +511,8 @@ function capitalize(value: string) {
 	return value.length === 0 ? value : `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
 }
 
-function joinNames(items: unknown[], fallbackNoun: string): ReceiptPart[] {
-	const collected: ReceiptPart[][] = [];
+function joinNames(items: unknown[], fallbackNoun: string): SummaryPart[] {
+	const collected: SummaryPart[][] = [];
 	for (const item of items.slice(0, 2)) {
 		const basename = getBaseName(getString(asRecord(item).path));
 		if (basename) collected.push(name(basename));
@@ -550,7 +550,7 @@ function formatUrlWithPath(url: string | undefined) {
 	}
 }
 
-function getDestinationName(path: string | undefined): ReceiptPart[] | undefined {
+function getDestinationName(path: string | undefined): SummaryPart[] | undefined {
 	if (!path) return undefined;
 	if (path === "/") return ["workspace root"];
 	const basename = getBaseName(path);

--- a/src/features/workspaces/components/ai-chat/ai-chat-web-fetch-presentation.test.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-web-fetch-presentation.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { AiChatToolActivity } from "#/features/workspaces/components/ai-chat/ai-chat-display-state";
-import { getFinishedToolReceipt } from "#/features/workspaces/components/ai-chat/ai-chat-tool-receipts";
+import { getFinishedToolSummary } from "#/features/workspaces/components/ai-chat/ai-chat-tool-summaries";
 import { getToolSourcePreviews } from "#/features/workspaces/components/ai-chat/ai-chat-tool-source-previews";
 
 describe("web_fetch presentation", () => {
@@ -15,7 +15,7 @@ describe("web_fetch presentation", () => {
 		const toolInput = { url: "https://example.com/article" };
 
 		expect(
-			getFinishedToolReceipt({
+			getFinishedToolSummary({
 				baseStatus: "completed",
 				output,
 				toolInput,

--- a/src/features/workspaces/components/ai-chat/useWorkspaceAiChat.ts
+++ b/src/features/workspaces/components/ai-chat/useWorkspaceAiChat.ts
@@ -10,6 +10,10 @@ import {
 	aiChatThreadsQueryKey,
 } from "#/features/workspaces/ai/chat/chat-queries";
 import { deriveAiChatPresentation } from "#/features/workspaces/components/ai-chat/ai-chat-display-state";
+import {
+	parseCodemodeActivityEvent,
+	type AiChatLiveCodemodeActivity,
+} from "#/features/workspaces/components/ai-chat/ai-chat-live-activity";
 import type {
 	AiChatMessage,
 	AiChatModelId,
@@ -46,6 +50,10 @@ export function useWorkspaceAiChat({
 	// latest props without refs or effect events.
 	const transport = createAiChatTransport(threadId);
 	const queryClient = useQueryClient();
+	// Live progress for orchestrate (Code Mode) runs: transient stream parts,
+	// latest event per call id. Never persisted — settled tool parts carry a
+	// durable record — so the map only matters while its turn streams.
+	const [liveCodemodeActivity, setLiveCodemodeActivity] = useState<AiChatLiveCodemodeActivity>({});
 
 	const chat = useChat<AiChatMessage>({
 		id: threadId,
@@ -60,6 +68,13 @@ export function useWorkspaceAiChat({
 		onData: (part) => {
 			if (part.type === "data-thread-title") {
 				void queryClient.invalidateQueries({ queryKey: aiChatThreadsQueryKey(workspaceId) });
+			}
+
+			if (part.type === "data-codemode-activity") {
+				const event = parseCodemodeActivityEvent(part.data);
+				if (event) {
+					setLiveCodemodeActivity((current) => ({ ...current, [event.invocationId]: event }));
+				}
 			}
 		},
 	});
@@ -206,6 +221,7 @@ export function useWorkspaceAiChat({
 		connectionError,
 		editMessage,
 		inputStatus,
+		liveCodemodeActivity,
 		messages,
 		presentation,
 		regenerate,

--- a/vitest.evals.config.ts
+++ b/vitest.evals.config.ts
@@ -13,6 +13,13 @@ import { defineConfig } from "vite-plus/test/config";
 // They live in their own config so they never run in the normal `pnpm test`
 // pipeline: they hit real models (real latency + spend). Run them on demand with
 // `pnpm eval`, which injects AI_GATEWAY_API_KEY (via Infisical) into the pool.
+
+// Miniflare validates every declared binding before starting; evals never
+// query Postgres (tool execution is stubbed), so a syntactically valid,
+// non-routable URL satisfies the Hyperdrive binding (same as vitest.config.ts).
+process.env.CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE ??=
+	"postgresql://test:test@127.0.0.1:1/thinkex_test";
+
 export default defineConfig({
 	test: {
 		projects: [
@@ -20,6 +27,10 @@ export default defineConfig({
 				resolve: {
 					tsconfigPaths: true,
 					alias: {
+						// Evals never touch the relational plane; keep node-postgres (a CJS
+						// package the workers module runner can't shim) out of the graph.
+						// Same stub as the app's workers test project.
+						"#/db/server": fileURLToPath(new URL("./test/stubs/db-server.ts", import.meta.url)),
 						// The worker entry pulls in the TanStack Start server handler, whose
 						// build-time virtual specifiers don't resolve under Vitest. The app's
 						// own workers project stubs it the same way.


### PR DESCRIPTION
## Problem

The chat agent can only act one tool call at a time: every intermediate result round-trips through the model's context, multi-item work burns a step per item, and the model does arithmetic in its head instead of computing it. Meanwhile each of those calls renders as its own row, so agentic turns fill the chat with noise — and our users are non-technical.

## What this does

**Orchestrate tool (Code Mode).** The model writes JavaScript that drives the turn's other tools inside a network-blocked dynamic Worker isolate (`@cloudflare/codemode` `createCodeTool` + `DynamicWorkerExecutor` over the existing `LOADER` binding — the same setup the MCP surface already runs, no Durable Object). Only the code's return value, console output, and compact per-call records come back to the model; nested calls execute host-side through the real wrapped tools, so capability filtering, validation, receipts, and observability behave exactly like direct calls.

- Input is `{ title, code }` — the model authors a plain-language label ("Calculating your quiz average") shown while the run streams.
- The TS type block in the tool description is generated from the tools' original Zod schemas via a new runtime registry on `defineAIThreadTool`; the provider-facing lazy schemas render as `unknown` in Code Mode's sync generator.
- `workspace_delete_items` stays direct-only (no mass deletion from one opaque loop) and `activate_skill` stays out (its output belongs in context verbatim). A view-only turn's code can only reach read tools by construction.
- Results are bounded (16k result chars, capped logs/errors) before persistence.

**Quieter tool UI.** Runs of consecutive tool calls collapse to one line — while streaming, only the latest action shows with in-place text swap (no layout shift); settled runs read "latest action · N steps" and expand inline (same in-flow shape as the sources list, no floating surface). The orchestrate row shows its title, the nested tool it's currently driving (via transient `data-codemode-activity` stream parts), and an expandable step list whose rows carry the same one-liners direct rows show (persisted per call, stripped from the model's view). Registry-hidden tools stay hidden inside run details. Document edits made inside a run land in the edit receipt, and receipts on older messages collapse to one line.

**Rode along:**
- `pnpm eval` was broken repo-wide since the Postgres migration (missing `#/db/server` stub alias + Hyperdrive placeholder in the evals config; schema-invalid mutation stubs in the harness). Fixed; the suite passes 11/11 with live model calls, including two new orchestrate evals.
- The "receipt" naming collision: tool-activity one-liners renamed to summaries (`ai-chat-tool-summaries.ts`); "receipt" now means only the document-edit receipt.
- `AGENTS.md`: generated markdown stays out of commits unless asked.

## Validation

- Live matrix through a `wrangler dev` probe: 9/9 correct across claude-sonnet, gemini, and gpt-luna — exact arithmetic, 40-item aggregation, and multi-tool composition (models wrote group-by + `Promise.all` code unprompted).
- 404 unit/worker tests pass, including 5 worker tests executing generated code through the real Worker Loader; `pnpm eval` 11/11.

Known gaps: stateless code mode drops approval-gated tools (none exist today — adopting the durable runtime is the path when one does), and `DynamicWorkerExecutor` doesn't pass `cpuMs`/`subRequests` limits through (60s timeout only — upstream gap).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789586116&installation_model_id=425282&pr_number=806&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F806&signature=75aafccd7898811631e8025139164d8a2abc7550887dc07036c9d6acf00b2c4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI orchestration that can run multiple workspace tools in sequence.
  * Added live progress updates for nested AI actions.
  * Grouped completed tool activity into collapsible summaries.
  * Added support for displaying document edits made during orchestrated actions.

* **Bug Fixes**
  * Improved tool visibility and permission handling for read-only interactions.
  * Enhanced activity and result handling for failed or interrupted operations.

* **Tests**
  * Added coverage for orchestration, nested tool calls, document edits, failures, and live activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->