### PR TITLE
feat(ai-chat): let the assistant ask the user a question instead of guessing

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
 		"@posthog/mcp": "0.11.4",
 		"@posthog/react": "^1.10.3",
 		"@posthog/rollup-plugin": "^1.4.7",
+		"@shadcn/react": "^0.3.0",
 		"@streamdown/cjk": "^1.0.3",
 		"@streamdown/math": "^1.0.2",
 		"@tanstack/react-hotkeys": "^0.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       '@posthog/rollup-plugin':
         specifier: ^1.4.7
         version: 1.4.7(rollup@4.62.2)
+      '@shadcn/react':
+        specifier: ^0.3.0
+        version: 0.3.0(@types/react@19.2.18)(react@19.2.8)
       '@streamdown/cjk':
         specifier: ^1.0.3
         version: 1.0.3(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(react@19.2.8)(unified@11.0.5)
@@ -342,7 +345,7 @@ importers:
         version: 1.52.0(@voidzero-dev/vite-plus-core@0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12)(typescript@7.0.2)(yaml@2.9.0))(wrangler@4.122.0(@cloudflare/workers-types@5.20260812.1))
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.21.2
-        version: 0.21.2(@cloudflare/workers-types@5.20260812.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12)(typescript@7.0.2)(yaml@2.9.0))(jsdom@28.1.0(@noble/hashes@2.3.0))(msw@2.14.6(@types/node@26.2.0)(typescript@7.0.2)))
+        version: 0.21.2(@cloudflare/workers-types@5.20260812.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)
       '@cloudflare/workers-types':
         specifier: ^5.20260812.1
         version: 5.20260812.1
@@ -3564,6 +3567,17 @@ packages:
   '@sentry/server-utils@10.69.0':
     resolution: {integrity: sha512-0MwHrA8+nNvMIsqf8m3cXwCBlUjr6AS7N6CZvHJtY1DkqEvQqEbD5VIrhzEyHN/KMZIgQ8XeDCQRhjnXFQGRhg==}
     engines: {node: '>=18'}
+
+  '@shadcn/react@0.3.0':
+    resolution: {integrity: sha512-iKN0NuYe850VDHlxEfvppFrpa7CMV3zArTHusXlaSmeFeQhohGbIqclv6WwPTs/44I8EkXQpcuRt6sXEVKkWqQ==}
+    peerDependencies:
+      '@types/react': '>=19'
+      react: '>=19'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   '@shaderfrog/glsl-parser@7.0.1':
     resolution: {integrity: sha512-8mpfsoPeRhesY3pOrzNZBL8uG6N5GVX1EHLBYbd4gzKs+c7vaEIqpTNK5VrffU33qQN4cwpP2v3u4aPPBU32sw==}
@@ -9911,7 +9925,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/vitest-pool-workers@0.21.2(@cloudflare/workers-types@5.20260812.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.9(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12)(typescript@7.0.2)(yaml@2.9.0))(jsdom@28.1.0(@noble/hashes@2.3.0))(msw@2.14.6(@types/node@26.2.0)(typescript@7.0.2)))':
+  '@cloudflare/vitest-pool-workers@0.21.2(@cloudflare/workers-types@5.20260812.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)':
     dependencies:
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -11896,6 +11910,11 @@ snapshots:
       meriyah: 6.1.4
     transitivePeerDependencies:
       - supports-color
+
+  '@shadcn/react@0.3.0(@types/react@19.2.18)(react@19.2.8)':
+    optionalDependencies:
+      '@types/react': 19.2.18
+      react: 19.2.8
 
   '@shaderfrog/glsl-parser@7.0.1': {}
 

--- a/src/components/ui/questionnaire.tsx
+++ b/src/components/ui/questionnaire.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import * as React from "react";
+import { CheckIcon } from "lucide-react";
+import { Questionnaire as QuestionnairePrimitive } from "@shadcn/react/questionnaire";
+
+import { cn } from "#/lib/utils";
+import { buttonVariants, type Button } from "#/components/ui/button";
+
+function Questionnaire({
+	className,
+	...props
+}: React.ComponentProps<typeof QuestionnairePrimitive.Root>) {
+	return (
+		<QuestionnairePrimitive.Root
+			data-slot="questionnaire"
+			className={cn("flex w-full min-w-0 flex-col gap-0", className)}
+			{...props}
+		/>
+	);
+}
+
+function QuestionnaireProgress({
+	className,
+	...props
+}: React.ComponentProps<typeof QuestionnairePrimitive.Progress>) {
+	return (
+		<QuestionnairePrimitive.Progress
+			data-slot="questionnaire-progress"
+			className={cn(
+				"min-h-[1lh] w-fit min-w-[14ch] text-xs font-medium text-muted-foreground tabular-nums",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function QuestionnaireItem({
+	className,
+	...props
+}: React.ComponentProps<typeof QuestionnairePrimitive.Item>) {
+	return (
+		<QuestionnairePrimitive.Item
+			data-slot="questionnaire-item"
+			className={cn("flex min-w-0 flex-col gap-5 border-0 p-0 outline-none", className)}
+			{...props}
+		/>
+	);
+}
+
+function QuestionnaireTitle({
+	className,
+	...props
+}: React.ComponentProps<typeof QuestionnairePrimitive.Title>) {
+	return (
+		<QuestionnairePrimitive.Title
+			data-slot="questionnaire-title"
+			className={cn(
+				// Composer scale, not page-heading scale. The column layout is for
+				// the question's short label sitting above its text.
+				"mb-3 flex flex-col gap-1.5 text-sm font-medium text-pretty",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function QuestionnaireDescription({
+	className,
+	...props
+}: React.ComponentProps<typeof QuestionnairePrimitive.Description>) {
+	return (
+		<QuestionnairePrimitive.Description
+			data-slot="questionnaire-description"
+			className={cn("text-sm text-pretty text-muted-foreground", className)}
+			{...props}
+		/>
+	);
+}
+
+function QuestionnaireChoices({
+	className,
+	...props
+}: React.ComponentProps<typeof QuestionnairePrimitive.Choices>) {
+	return (
+		<QuestionnairePrimitive.Choices
+			data-slot="questionnaire-choices"
+			className={cn("group/questionnaire-choices grid min-w-0 gap-1.5", className)}
+			{...props}
+		/>
+	);
+}
+
+function QuestionnaireChoice({
+	children,
+	className,
+	...props
+}: React.ComponentProps<typeof QuestionnairePrimitive.Choice>) {
+	return (
+		<QuestionnairePrimitive.Choice
+			data-slot="questionnaire-choice"
+			className={cn(
+				// Hover carries an explicit dark counterpart: hover:bg-* and dark:bg-*
+				// tie on specificity, so a lone light-mode hover is cancelled out in
+				// dark mode and the row reads as inert.
+				"group/questionnaire-choice relative flex cursor-pointer items-start gap-3 rounded-md border border-border/60 bg-background/40 px-3 py-2 text-start text-sm transition-colors outline-none select-none hover:border-border hover:bg-accent has-[>input:focus-visible]:border-ring has-[>input:focus-visible]:ring-3 has-[>input:focus-visible]:ring-ring/50 data-invalid:border-destructive dark:bg-background/25 dark:hover:bg-accent/60 data-checked:border-primary/40 data-checked:bg-muted dark:data-checked:bg-muted",
+				"data-disabled:pointer-events-none data-disabled:cursor-not-allowed data-disabled:opacity-50",
+				className,
+			)}
+			{...props}
+		>
+			<QuestionnairePrimitive.ChoiceInput
+				data-slot="questionnaire-choice-input"
+				className="absolute inset-0 z-10 size-full cursor-pointer opacity-0"
+			/>
+			<span
+				aria-hidden="true"
+				data-slot="questionnaire-choice-indicator"
+				className="pointer-events-none relative flex size-4 shrink-0 translate-y-[--spacing(0.45)] items-center justify-center rounded-[4px] border border-input group-has-data-[slot=questionnaire-choice-description]/questionnaire-choice:translate-y-0.5 group-data-[type=radio]/questionnaire-choice:rounded-full group-data-checked/questionnaire-choice:border-primary group-data-checked/questionnaire-choice:bg-primary group-data-checked/questionnaire-choice:text-primary-foreground dark:bg-input/30 dark:group-data-checked/questionnaire-choice:bg-primary"
+			>
+				{/* The shortcut number lives in the indicator and yields to the
+				    dot/tick once chosen: one slot carries "press this" before the
+				    pick and "this is picked" after, instead of two competing badges. */}
+				<QuestionnairePrimitive.ChoiceShortcut
+					data-slot="questionnaire-choice-shortcut"
+					// One compound variant, not two competing ones: show/hide split
+					// across `group-data-[shortcut]:flex` and `group-data-checked:hidden`
+					// ties on specificity, and the number renders under the dot.
+					className="hidden font-mono text-[0.625rem] leading-none font-medium text-muted-foreground group-[[data-shortcut]:not([data-checked])]/questionnaire-choice:flex"
+				/>
+				<span
+					data-slot="questionnaire-choice-indicator-dot"
+					className="hidden size-2 rounded-full bg-primary-foreground group-data-[type=checkbox]/questionnaire-choice:hidden group-data-checked/questionnaire-choice:block"
+				/>
+				<CheckIcon
+					data-slot="questionnaire-choice-indicator-check"
+					className="hidden size-3.5 group-data-[type=radio]/questionnaire-choice:hidden group-data-checked/questionnaire-choice:block"
+				/>
+			</span>
+			<QuestionnairePrimitive.ChoiceLabel
+				data-slot="questionnaire-choice-label"
+				className="flex min-w-0 flex-1 flex-col gap-1 leading-snug"
+			>
+				{children}
+			</QuestionnairePrimitive.ChoiceLabel>
+		</QuestionnairePrimitive.Choice>
+	);
+}
+
+function QuestionnaireChoiceDescription({ className, ...props }: React.ComponentProps<"span">) {
+	return (
+		<span
+			data-slot="questionnaire-choice-description"
+			className={cn("text-muted-foreground", className)}
+			{...props}
+		/>
+	);
+}
+
+function QuestionnaireInput({
+	className,
+	...props
+}: React.ComponentProps<typeof QuestionnairePrimitive.Input>) {
+	return (
+		<div
+			data-slot="questionnaire-input-wrapper"
+			className="group/questionnaire-input relative w-full min-w-0"
+		>
+			<QuestionnairePrimitive.Input
+				data-slot="questionnaire-input"
+				className={cn(
+					"h-9 w-full min-w-0 rounded-md border border-border/60 bg-background/40 px-3 py-1 text-base transition-[color,box-shadow,background-color] outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-background/25 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+					"selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground",
+					className,
+				)}
+				{...props}
+			/>
+		</div>
+	);
+}
+
+function QuestionnaireError({
+	className,
+	...props
+}: React.ComponentProps<typeof QuestionnairePrimitive.Error>) {
+	return (
+		<QuestionnairePrimitive.Error
+			data-slot="questionnaire-error"
+			className={cn("text-sm text-destructive", className)}
+			{...props}
+		/>
+	);
+}
+
+function QuestionnairePrevious({
+	children,
+	className,
+	size = "default",
+	variant = "outline",
+	...props
+}: React.ComponentProps<typeof QuestionnairePrimitive.Previous> &
+	Pick<React.ComponentProps<typeof Button>, "size" | "variant">) {
+	return (
+		<QuestionnairePrimitive.Previous
+			data-slot="questionnaire-previous"
+			data-size={size}
+			data-variant={variant}
+			className={cn(buttonVariants({ size, variant }), "min-h-11 sm:min-h-0", className)}
+			{...props}
+		>
+			{children ?? "Previous"}
+		</QuestionnairePrimitive.Previous>
+	);
+}
+
+function QuestionnaireSkip({
+	children,
+	className,
+	size = "default",
+	variant = "outline",
+	...props
+}: React.ComponentProps<typeof QuestionnairePrimitive.Skip> &
+	Pick<React.ComponentProps<typeof Button>, "size" | "variant">) {
+	return (
+		<QuestionnairePrimitive.Skip
+			data-slot="questionnaire-skip"
+			data-size={size}
+			data-variant={variant}
+			className={cn(buttonVariants({ size, variant }), "min-h-11 sm:min-h-0", className)}
+			{...props}
+		>
+			{children ?? "Skip"}
+		</QuestionnairePrimitive.Skip>
+	);
+}
+
+function QuestionnaireNext({
+	children,
+	className,
+	size = "default",
+	variant = "default",
+	...props
+}: React.ComponentProps<typeof QuestionnairePrimitive.Next> &
+	Pick<React.ComponentProps<typeof Button>, "size" | "variant">) {
+	return (
+		<QuestionnairePrimitive.Next
+			data-slot="questionnaire-next"
+			data-size={size}
+			data-variant={variant}
+			className={cn(buttonVariants({ size, variant }), "min-h-11 sm:min-h-0", className)}
+			{...props}
+		>
+			{children ?? "Next"}
+		</QuestionnairePrimitive.Next>
+	);
+}
+
+function QuestionnaireSubmit({
+	children,
+	className,
+	size = "default",
+	variant = "default",
+	...props
+}: React.ComponentProps<typeof QuestionnairePrimitive.Submit> &
+	Pick<React.ComponentProps<typeof Button>, "size" | "variant">) {
+	return (
+		<QuestionnairePrimitive.Submit
+			data-slot="questionnaire-submit"
+			data-size={size}
+			data-variant={variant}
+			className={cn(buttonVariants({ size, variant }), "min-h-11 sm:min-h-0", className)}
+			{...props}
+		>
+			{children ?? "Submit"}
+		</QuestionnairePrimitive.Submit>
+	);
+}
+
+export {
+	Questionnaire,
+	QuestionnaireChoice,
+	QuestionnaireChoiceDescription,
+	QuestionnaireChoices,
+	QuestionnaireDescription,
+	QuestionnaireError,
+	QuestionnaireInput,
+	QuestionnaireItem,
+	QuestionnaireNext,
+	QuestionnairePrevious,
+	QuestionnaireProgress,
+	QuestionnaireSkip,
+	QuestionnaireSubmit,
+	QuestionnaireTitle,
+};

--- a/src/features/workspaces/ai/ai-tool-registry.ts
+++ b/src/features/workspaces/ai/ai-tool-registry.ts
@@ -1,4 +1,11 @@
-export type AiToolActivityIconKind = "edit" | "file" | "guidance" | "search" | "web" | "wrench";
+export type AiToolActivityIconKind =
+	| "edit"
+	| "file"
+	| "guidance"
+	| "question"
+	| "search"
+	| "web"
+	| "wrench";
 export type AiToolAccess = "read" | "write";
 export type AiToolVisibility = "hidden" | "visible";
 
@@ -23,6 +30,9 @@ function defineAiToolRegistry<const TRegistry extends Record<string, AiToolDefin
 
 export const AI_TOOL_REGISTRY = defineAiToolRegistry({
 	activate_skill: readTool({ icon: "guidance", title: "Use guidance" }),
+	// Read access: asking a question mutates nothing, so a view-only member
+	// gets a model that asks rather than one that guesses.
+	ask_user: readTool({ icon: "question", title: "Ask a question" }),
 	// Registered as read access: its inner tool set is built from the turn's
 	// already-capability-filtered tools, so a view-only turn's orchestrate tool
 	// contains read tools only.

--- a/src/features/workspaces/ai/chat/chat-endpoint.ts
+++ b/src/features/workspaces/ai/chat/chat-endpoint.ts
@@ -5,6 +5,7 @@ import {
 	createUIMessageStreamResponse,
 	generateId,
 	generateText,
+	hasToolCall,
 	stepCountIs,
 	streamText,
 	validateUIMessages,
@@ -29,6 +30,7 @@ import {
 	prepareCompactedContext,
 } from "#/features/workspaces/ai/chat/chat-compaction";
 import { ChatRequestError } from "#/features/workspaces/ai/chat/chat-errors";
+import { ASK_USER_TOOL_NAME } from "#/features/workspaces/ai/question-tools";
 import { WORKSPACE_AI_CHAT_ATTACHMENT_POLICY } from "#/features/workspaces/ai/chat-attachment-policy";
 import { parseChatAttachmentContentUrl } from "#/features/workspaces/ai/chat-attachment-storage";
 import {
@@ -388,7 +390,11 @@ export async function handleAiChatTurn(input: {
 					instructions: systemPrompt,
 					messages: modelMessages,
 					tools,
-					stopWhen: stepCountIs(MAX_AGENT_STEPS),
+					// ask_user completes instantly with a receipt, so without this the
+					// model would read its own question back and keep going. Stopping
+					// here is what hands control to the user: their answer arrives as
+					// an ordinary user message and the next turn continues from it.
+					stopWhen: [stepCountIs(MAX_AGENT_STEPS), hasToolCall(ASK_USER_TOOL_NAME)],
 					abortSignal: turn.signal,
 					onChunk: () => {
 						firstTokenAt ??= Date.now();

--- a/src/features/workspaces/ai/chat/chat-tools.ts
+++ b/src/features/workspaces/ai/chat/chat-tools.ts
@@ -4,6 +4,7 @@ import type { AIThreadContext } from "#/features/workspaces/ai/ai-thread-metadat
 import { requireAiToolDefinition } from "#/features/workspaces/ai/ai-tool-registry";
 import type { AiCodemodeActivityListener } from "#/features/workspaces/ai/codemode-tool";
 import { createAiChatCodemodeTool } from "#/features/workspaces/ai/codemode-tool";
+import { createAIThreadQuestionTools } from "#/features/workspaces/ai/question-tools";
 import { createAIThreadResearchTools } from "#/features/workspaces/ai/research-tools";
 import { createAIThreadSkillTools } from "#/features/workspaces/ai/skill-tools";
 import { createAIThreadTimeTools } from "#/features/workspaces/ai/time-tools";
@@ -48,5 +49,9 @@ export function createAiChatTools(input: {
 			tools: allowed,
 			...(input.onCodemodeActivity ? { onActivity: input.onCodemodeActivity } : {}),
 		}),
+		// Built outside `allowed`, so Code Mode can never reach it: asking ends
+		// the turn, and a generated program that "asks" mid-run would just get a
+		// receipt back and carry on past the answer it was waiting for.
+		...createAIThreadQuestionTools(),
 	};
 }

--- a/src/features/workspaces/ai/question-tools.ts
+++ b/src/features/workspaces/ai/question-tools.ts
@@ -1,0 +1,144 @@
+import type { ToolSet } from "ai";
+import { z } from "zod";
+
+import { defineAIThreadTool } from "#/features/workspaces/ai/ai-thread-tool";
+
+export const ASK_USER_TOOL_NAME = "ask_user";
+
+const MAX_QUESTIONS = 4;
+const MAX_OPTIONS = 4;
+
+// Deliberately NOT a blocking tool. `execute` records what was asked and
+// returns immediately; the turn then ends via the endpoint's
+// hasToolCall(ASK_USER_TOOL_NAME) stop condition, and the user's reply arrives
+// as an ordinary user message on the next turn.
+//
+// The alternative — a tool that awaits the answer — would park a Worker
+// request on a human, hold the turn claim, and lose the question on refresh.
+// Completing the call up front instead means the question survives into every
+// later turn's model context (convertToModelMessages drops tool parts that
+// never reached an output-* state) and renders as a settled tool row rather
+// than a permanent spinner.
+const questionOptionSchema = z.object({
+	label: z
+		.string()
+		.trim()
+		.min(1)
+		.max(60)
+		.describe("Display text for the choice. 1-5 words, concise."),
+	description: z
+		.string()
+		.trim()
+		.min(1)
+		.max(200)
+		.describe("What picking this choice means or implies."),
+});
+
+const questionSchema = z.object({
+	header: z
+		.string()
+		.trim()
+		.min(1)
+		.max(30)
+		.describe("Very short label for the question, at most 30 characters. Example: 'Auth method'."),
+	question: z.string().trim().min(1).max(300).describe("The complete question to ask."),
+	options: z
+		.array(questionOptionSchema)
+		.min(2)
+		.max(MAX_OPTIONS)
+		.describe(
+			"The choices offered. Do not include an 'Other' or catch-all option — a free-text answer is always available to the user.",
+		),
+	multiple: z
+		.boolean()
+		.default(false)
+		.describe("Set when the user may pick more than one option. Defaults to single-select."),
+});
+
+/** Also the client's parser for a pending question's tool input. */
+export const askUserInputSchema = z.object({
+	questions: z
+		.array(questionSchema)
+		.min(1)
+		.max(MAX_QUESTIONS)
+		.describe("The questions to put to the user, asked together on one screen."),
+});
+
+const askUserOutputSchema = z.object({
+	asked: z.array(
+		z.object({
+			header: z.string(),
+			question: z.string(),
+			options: z.array(z.string()),
+			multiple: z.boolean(),
+		}),
+	),
+});
+
+const askUserInputExamples = [
+	{
+		input: {
+			questions: [
+				{
+					header: "Study format",
+					question: "How should I structure the study guide?",
+					options: [
+						{ label: "Summary first", description: "Key points up front, then detail per topic." },
+						{ label: "Question bank", description: "Practice questions with worked answers." },
+					],
+					multiple: false,
+				},
+			],
+		},
+	},
+];
+
+const description = `Ask the user one or more multiple-choice questions and end your turn so they can answer.
+
+Use this when a genuine fork in the work needs their input: an ambiguous instruction, a preference you cannot infer, or a choice between directions with real trade-offs. Do not use it for questions you can answer yourself from the workspace, and do not use it to confirm work you have already been asked to do.
+
+How it behaves:
+- Your turn ENDS as soon as you call this. Say anything you need to say BEFORE calling it, and do not call any other tool in the same step.
+- The user's answers arrive as their next message. You do not receive them as this tool's result.
+- Each question needs 2-4 options. A free-text answer is always offered automatically, so never write an "Other" option yourself.
+- If you recommend an option, put it first and end its label with "(Recommended)".
+- Set multiple: true when several answers can apply at once.
+- The user may skip. If they do, proceed on your best judgement rather than asking again.`;
+
+/**
+ * The clarification tool. Its result records the question for later turns; the
+ * answer itself travels back as a normal user message.
+ */
+export function createAIThreadQuestionTools(): ToolSet {
+	return {
+		[ASK_USER_TOOL_NAME]: defineAIThreadTool({
+			description,
+			inputSchema: askUserInputSchema,
+			inputExamples: askUserInputExamples,
+			outputSchema: askUserOutputSchema,
+			toModelOutput: ({ output }) => ({
+				type: "text" as const,
+				value: formatAskUserModelOutput(output),
+			}),
+			execute: (input) => ({
+				asked: input.questions.map((question) => ({
+					header: question.header,
+					question: question.question,
+					options: question.options.map((option) => option.label),
+					multiple: question.multiple,
+				})),
+			}),
+		}),
+	};
+}
+
+// What the model reads on later turns. The answer is NOT here — it arrives as
+// the user's next message — so this only has to keep the question and its
+// options in context, which is what stops the model re-asking after a skip.
+function formatAskUserModelOutput(output: z.output<typeof askUserOutputSchema>) {
+	const asked = output.asked
+		.map((entry) => `- ${entry.header}: "${entry.question}" (${entry.options.join(" / ")})`)
+		.join("\n");
+
+	return `Asked the user and ended the turn:\n${asked}\n\nTheir reply is their next message. If they skipped, continue on your best judgement instead of asking again.`;
+}

--- a/src/features/workspaces/ai/question-tools.ts
+++ b/src/features/workspaces/ai/question-tools.ts
@@ -99,6 +99,7 @@ Use this when a genuine fork in the work needs their input: an ambiguous instruc
 
 How it behaves:
 - Your turn ENDS as soon as you call this. Say anything you need to say BEFORE calling it, and do not call any other tool in the same step.
+- Call it ONCE, with every question you need — it takes up to ${MAX_QUESTIONS} at a time. Do not make a second call in the same step.
 - The user's answers arrive as their next message. You do not receive them as this tool's result.
 - Each question needs 2-4 options. A free-text answer is always offered automatically, so never write an "Other" option yourself.
 - If you recommend an option, put it first and end its label with "(Recommended)".

--- a/src/features/workspaces/components/ai-chat/AiChatMessageRow.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatMessageRow.tsx
@@ -15,6 +15,7 @@ import {
 	AiChatToolActivityGroup,
 	isToolGroupBreaker,
 } from "#/features/workspaces/components/ai-chat/AiChatToolActivityGroup";
+import { getQuestionAnswerMetadata } from "#/features/workspaces/components/ai-chat/ai-chat-question";
 import { stripWorkspaceCitationTags } from "#/features/workspaces/ai/workspace-references";
 import {
 	type AssistantRowDisplay,
@@ -156,7 +157,36 @@ function UserMessageBody({
 	parts: AiChatMessagePart[];
 }) {
 	const [isOpen, setIsOpen] = useState(false);
+	const questionAnswer = getQuestionAnswerMetadata(message);
 	const shouldCollapse = shouldCollapseUserMessage(parts);
+
+	// An answered question renders as what the user actually did — picked
+	// options — not as the prose the model reads.
+	if (questionAnswer) {
+		return (
+			<div className="flex flex-col gap-2">
+				{questionAnswer.map((answer, index) => (
+					<div key={`${message.id}-answer-${index}`} className="flex flex-col gap-1">
+						<span className="text-xs text-secondary-foreground/70">{answer.header}</span>
+						{answer.skipped ? (
+							<span className="text-sm text-secondary-foreground/70 italic">Skipped</span>
+						) : (
+							<div className="flex flex-wrap gap-1">
+								{answer.values.map((value) => (
+									<span
+										key={value}
+										className="rounded-md bg-background/60 px-2 py-0.5 text-sm text-secondary-foreground"
+									>
+										{value}
+									</span>
+								))}
+							</div>
+						)}
+					</div>
+				))}
+			</div>
+		);
+	}
 
 	if (!shouldCollapse) {
 		return <UserMessageParts message={message} parts={parts} />;

--- a/src/features/workspaces/components/ai-chat/AiChatPromptInput.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatPromptInput.tsx
@@ -23,6 +23,12 @@ import {
 import { useWorkspaceAiAllowance } from "#/features/workspaces/ai/use-workspace-ai-allowance";
 import { AiChatAttachmentDropBridge } from "#/features/workspaces/components/ai-chat/AiChatAttachmentDrop";
 import AiChatComposerReveal from "#/features/workspaces/components/ai-chat/AiChatComposerReveal";
+import {
+	aiChatComposerFooterPadding,
+	aiChatComposerGroupClassName,
+	aiChatComposerHeaderPadding,
+	aiChatComposerInlinePadding,
+} from "#/features/workspaces/components/ai-chat/ai-chat-layout";
 import AiChatModelPicker from "#/features/workspaces/components/ai-chat/AiChatModelPicker";
 import { AiChatAllowanceNotice } from "#/features/workspaces/components/ai-chat/AiChatAllowanceNotice";
 import AiChatPromptContextBar from "#/features/workspaces/components/ai-chat/AiChatPromptContextBar";
@@ -57,13 +63,7 @@ import { cn } from "#/lib/utils";
 
 // InputGroup defaults to a single horizontal row. Stack vertically so the
 // footer toolbar stays visible below the textarea instead of being clipped.
-const PROMPT_INPUT_GROUP_CLASSNAME =
-	"h-auto flex-col border-border/70 bg-muted/30 shadow-none dark:bg-muted/30";
-const PROMPT_INPUT_INLINE_PADDING = "px-3.5";
-// gap-0: every header row self-pads (pt on its content), so the always-mounted
-// zero-height reveal wrappers add no phantom flex gaps to an idle composer.
-const PROMPT_INPUT_HEADER_PADDING = "gap-0 px-3.5 pb-1";
-const PROMPT_INPUT_FOOTER_PADDING = "pl-2 pr-3.5 pt-1 pb-2";
+// Shared with the question card, which takes this slot — see ai-chat-layout.
 const CHAT_ATTACHMENT_PICKER_ACCEPT = [
 	...new Set([WORKSPACE_AI_CHAT_ATTACHMENT_POLICY.accept, ...workspaceUploadAccept.split(",")]),
 ].join(",");
@@ -270,12 +270,12 @@ export default function AiChatPromptInput({
 			<PromptInput
 				accept={CHAT_ATTACHMENT_PICKER_ACCEPT}
 				attachments={attachments}
-				inputGroupClassName={PROMPT_INPUT_GROUP_CLASSNAME}
+				inputGroupClassName={aiChatComposerGroupClassName}
 				multiple
 				onSubmit={handleSubmit}
 			>
 				<AiChatAttachmentDropBridge />
-				<PromptInputHeader className={PROMPT_INPUT_HEADER_PADDING}>
+				<PromptInputHeader className={aiChatComposerHeaderPadding}>
 					<AiChatComposerReveal>
 						{isEditing ? (
 							<div className="flex items-center gap-1.5 pt-1 pb-1.5 text-muted-foreground text-xs">
@@ -311,12 +311,12 @@ export default function AiChatPromptInput({
 						onChange={(event) => setInput(event.currentTarget.value)}
 						className={cn(
 							"min-h-10 pt-2 pb-1 text-base placeholder:text-foreground/45 md:text-base",
-							PROMPT_INPUT_INLINE_PADDING,
+							aiChatComposerInlinePadding,
 						)}
 					/>
 				</PromptInputBody>
 
-				<PromptInputFooter className={PROMPT_INPUT_FOOTER_PADDING}>
+				<PromptInputFooter className={aiChatComposerFooterPadding}>
 					<PromptInputTools>
 						<AiChatAttachmentButton />
 

--- a/src/features/workspaces/components/ai-chat/AiChatQuestionCard.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatQuestionCard.tsx
@@ -1,0 +1,238 @@
+import { LazyMotion, domAnimation, m } from "motion/react";
+import { MessageCircleQuestionMark } from "lucide-react";
+import { useRef, useState } from "react";
+
+import { InputGroup, InputGroupAddon } from "#/components/ui/input-group";
+import {
+	Questionnaire,
+	QuestionnaireChoice,
+	QuestionnaireChoiceDescription,
+	QuestionnaireChoices,
+	QuestionnaireInput,
+	QuestionnaireItem,
+	QuestionnaireNext,
+	QuestionnairePrevious,
+	QuestionnaireProgress,
+	QuestionnaireSkip,
+	QuestionnaireSubmit,
+	QuestionnaireTitle,
+} from "#/components/ui/questionnaire";
+import {
+	aiChatComposerFooterPadding,
+	aiChatComposerGroupClassName,
+	aiChatComposerInlinePadding,
+} from "#/features/workspaces/components/ai-chat/ai-chat-layout";
+import type {
+	AiChatPendingQuestion,
+	AiChatQuestionAnswer,
+} from "#/features/workspaces/components/ai-chat/ai-chat-question";
+import { useTypeToFocusTextInput } from "#/hooks/use-type-to-focus-text-input";
+import { cn } from "#/lib/utils";
+
+/**
+ * The pending question, wearing the composer's own shell so it reads as the
+ * composer changing its contents rather than a card appearing over it. One
+ * question per step; the model may ask up to four, so the shadcn primitive's
+ * stepper earns its keep even though the common case is a single screen.
+ *
+ * Answers are read from component state rather than the form's native
+ * serialization: the free-text input shares its question's field name, so a
+ * FormData read cannot tell a typed answer from a chosen label.
+ */
+export default function AiChatQuestionCard({
+	disabled,
+	pending,
+	onAnswer,
+}: {
+	disabled: boolean;
+	pending: AiChatPendingQuestion;
+	onAnswer: (answers: AiChatQuestionAnswer[]) => void;
+}) {
+	const [selections, setSelections] = useState<Record<string, string[]>>({});
+	const [customText, setCustomText] = useState<Record<string, string>>({});
+	// Owning the active step is what lets Skip and type-to-focus know which
+	// question they are acting on without reading it back off the DOM.
+	const [activeItem, setActiveItem] = useState(() => questionFieldName(0));
+	const activeInputRef = useRef<HTMLInputElement | null>(null);
+
+	// Choices belong here as well as in the markup — the root tracks answered
+	// vs unanswered state from this list, not from what happens to be rendered.
+	const items = pending.questions.map((question, index) => ({
+		name: questionFieldName(index),
+		choices: question.options.map((option) => ({ value: option.label })),
+		// Never `required`: the stepper would block Next on an unanswered
+		// question, and Skip is meant to always be one click away.
+		required: false,
+	}));
+
+	const chooseOption = (name: string, value: string, multiple: boolean) => {
+		// A single-select pick supersedes anything typed; multi-select keeps both.
+		if (!multiple) {
+			setCustomText((current) => ({ ...current, [name]: "" }));
+		}
+		setSelections((current) => {
+			const chosen = current[name] ?? [];
+
+			if (!multiple) {
+				return { ...current, [name]: [value] };
+			}
+
+			return {
+				...current,
+				[name]: chosen.includes(value)
+					? chosen.filter((entry) => entry !== value)
+					: [...chosen, value],
+			};
+		});
+	};
+
+	const writeCustom = (name: string, value: string, multiple: boolean) => {
+		// Mirror image of the above: typing an answer to a single-select question
+		// clears the radio, so the two can never both claim to be the answer.
+		if (!multiple && value.trim()) {
+			setSelections((current) => ({ ...current, [name]: [] }));
+		}
+		setCustomText((current) => ({ ...current, [name]: value }));
+	};
+
+	const collectAnswers = (): AiChatQuestionAnswer[] =>
+		pending.questions.map((question, index) => {
+			const name = questionFieldName(index);
+			const custom = customText[name]?.trim() ?? "";
+			const values = [...(selections[name] ?? []), ...(custom ? [custom] : [])];
+
+			// Skipping clears the question's answer, so "nothing chosen" is the
+			// only representation of a skip — no separate flag to keep in step.
+			return {
+				header: question.header,
+				question: question.question,
+				values,
+				skipped: values.length === 0,
+			};
+		});
+
+	const isMultiQuestion = pending.questions.length > 1;
+
+	// Typing anywhere lands in the active question's free-text field, exactly as
+	// it does in the composer. Digits are left alone — the root binds them to
+	// choice selection.
+	useTypeToFocusTextInput({
+		enabled: !disabled,
+		ignoreKey: isDigit,
+		inputRef: activeInputRef,
+		setValue: (value) =>
+			setCustomText((current) => ({
+				...current,
+				[activeItem]: typeof value === "function" ? value(current[activeItem] ?? "") : value,
+			})),
+	});
+
+	return (
+		<LazyMotion features={domAnimation}>
+			<m.div
+				initial={{ opacity: 0, y: 8 }}
+				animate={{ opacity: 1, y: 0 }}
+				// Matches AiChatComposerReveal, so the question arriving feels like
+				// the composer's other rows rather than a separate widget.
+				transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
+			>
+				<Questionnaire
+					items={items}
+					item={activeItem}
+					onItemChange={setActiveItem}
+					// The root's keydown owns these: a number key selects, Cmd/Ctrl+Enter
+					// submits, arrows move between choices and questions. It ignores keys
+					// aimed at a text field, so the free-text input below is unaffected.
+					shortcuts="numbers"
+					onSubmit={(event) => {
+						event.preventDefault();
+						if (!disabled) {
+							onAnswer(collectAnswers());
+						}
+					}}
+				>
+					<InputGroup className={aiChatComposerGroupClassName}>
+						<div className={cn("w-full min-w-0 pt-3 pb-1", aiChatComposerInlinePadding)}>
+							{pending.questions.map((question, index) => {
+								const name = questionFieldName(index);
+								const chosen = selections[name] ?? [];
+
+								return (
+									<QuestionnaireItem key={name} name={name} multiple={question.multiple}>
+										{/* The label lives INSIDE the title: the title renders a
+								    <legend>, which always paints at the top of its <fieldset>
+								    regardless of DOM order, so a sibling above it lands below. */}
+										<QuestionnaireTitle>
+											<span className="flex items-center gap-1.5 text-xs font-normal text-muted-foreground">
+												<MessageCircleQuestionMark className="size-3 shrink-0" aria-hidden="true" />
+												<span className="min-w-0 truncate">{question.header}</span>
+											</span>
+											{question.question}
+										</QuestionnaireTitle>
+										<QuestionnaireChoices>
+											{question.options.map((option) => (
+												<QuestionnaireChoice
+													key={option.label}
+													value={option.label}
+													checked={chosen.includes(option.label)}
+													onChange={() => chooseOption(name, option.label, question.multiple)}
+												>
+													{option.label}
+													{option.description ? (
+														<QuestionnaireChoiceDescription className="text-xs">
+															{option.description}
+														</QuestionnaireChoiceDescription>
+													) : null}
+												</QuestionnaireChoice>
+											))}
+											{/* Always visible, per the shadcn pattern — the free-text answer
+									    is the escape hatch, so the model never writes an "Other". */}
+											<QuestionnaireInput
+												ref={name === activeItem ? activeInputRef : undefined}
+												aria-label="Answer in your own words"
+												placeholder="Or type your own answer…"
+												value={customText[name] ?? ""}
+												onChange={(event) =>
+													writeCustom(name, event.target.value, question.multiple)
+												}
+											/>
+										</QuestionnaireChoices>
+									</QuestionnaireItem>
+								);
+							})}
+						</div>
+
+						<InputGroupAddon align="block-end" className={aiChatComposerFooterPadding}>
+							<div className="flex w-full items-center gap-1">
+								{isMultiQuestion ? <QuestionnaireProgress className="ps-1.5" /> : null}
+								<div className="ml-auto flex items-center gap-1">
+									{isMultiQuestion ? <QuestionnairePrevious variant="ghost" /> : null}
+									<QuestionnaireSkip
+										variant="ghost"
+										onClick={() => {
+											setSelections((current) => ({ ...current, [activeItem]: [] }));
+											setCustomText((current) => ({ ...current, [activeItem]: "" }));
+										}}
+									>
+										Skip
+									</QuestionnaireSkip>
+									<QuestionnaireNext />
+									<QuestionnaireSubmit disabled={disabled}>Send</QuestionnaireSubmit>
+								</div>
+							</div>
+						</InputGroupAddon>
+					</InputGroup>
+				</Questionnaire>
+			</m.div>
+		</LazyMotion>
+	);
+}
+
+function questionFieldName(index: number) {
+	return `question-${index}`;
+}
+
+// Left to the questionnaire root, which binds 1-9 to choice selection.
+function isDigit(key: string) {
+	return key.length === 1 && key >= "0" && key <= "9";
+}

--- a/src/features/workspaces/components/ai-chat/AiChatQuestionCard.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatQuestionCard.tsx
@@ -23,7 +23,7 @@ import {
 	aiChatComposerInlinePadding,
 } from "#/features/workspaces/components/ai-chat/ai-chat-layout";
 import type {
-	AiChatPendingQuestion,
+	AiChatQuestion,
 	AiChatQuestionAnswer,
 } from "#/features/workspaces/components/ai-chat/ai-chat-question";
 import { useTypeToFocusTextInput } from "#/hooks/use-type-to-focus-text-input";
@@ -41,11 +41,11 @@ import { cn } from "#/lib/utils";
  */
 export default function AiChatQuestionCard({
 	disabled,
-	pending,
+	questions,
 	onAnswer,
 }: {
 	disabled: boolean;
-	pending: AiChatPendingQuestion;
+	questions: AiChatQuestion[];
 	onAnswer: (answers: AiChatQuestionAnswer[]) => void;
 }) {
 	const [selections, setSelections] = useState<Record<string, string[]>>({});
@@ -57,7 +57,7 @@ export default function AiChatQuestionCard({
 
 	// Choices belong here as well as in the markup — the root tracks answered
 	// vs unanswered state from this list, not from what happens to be rendered.
-	const items = pending.questions.map((question, index) => ({
+	const items = questions.map((question, index) => ({
 		name: questionFieldName(index),
 		choices: question.options.map((option) => ({ value: option.label })),
 		// Never `required`: the stepper would block Next on an unanswered
@@ -96,7 +96,7 @@ export default function AiChatQuestionCard({
 	};
 
 	const collectAnswers = (): AiChatQuestionAnswer[] =>
-		pending.questions.map((question, index) => {
+		questions.map((question, index) => {
 			const name = questionFieldName(index);
 			const custom = customText[name]?.trim() ?? "";
 			const values = [...(selections[name] ?? []), ...(custom ? [custom] : [])];
@@ -111,7 +111,7 @@ export default function AiChatQuestionCard({
 			};
 		});
 
-	const isMultiQuestion = pending.questions.length > 1;
+	const isMultiQuestion = questions.length > 1;
 
 	// Typing anywhere lands in the active question's free-text field, exactly as
 	// it does in the composer. Digits are left alone — the root binds them to
@@ -153,7 +153,7 @@ export default function AiChatQuestionCard({
 				>
 					<InputGroup className={aiChatComposerGroupClassName}>
 						<div className={cn("w-full min-w-0 pt-3 pb-1", aiChatComposerInlinePadding)}>
-							{pending.questions.map((question, index) => {
+							{questions.map((question, index) => {
 								const name = questionFieldName(index);
 								const chosen = selections[name] ?? [];
 

--- a/src/features/workspaces/components/ai-chat/AiChatThreadView.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatThreadView.tsx
@@ -15,6 +15,12 @@ import type {
 	AiChatSendMessage,
 } from "#/features/workspaces/components/ai-chat/types";
 import { canDrainQueuedMessage } from "#/features/workspaces/components/ai-chat/ai-chat-queue-drain";
+import AiChatQuestionCard from "#/features/workspaces/components/ai-chat/AiChatQuestionCard";
+import {
+	formatQuestionAnswerText,
+	getPendingQuestion,
+	type AiChatQuestionAnswer,
+} from "#/features/workspaces/components/ai-chat/ai-chat-question";
 import { AiChatLiveActivityProvider } from "#/features/workspaces/components/ai-chat/ai-chat-live-activity";
 import { useWorkspaceAiChat } from "#/features/workspaces/components/ai-chat/useWorkspaceAiChat";
 import { useWorkspaceAiAllowance } from "#/features/workspaces/ai/use-workspace-ai-allowance";
@@ -105,6 +111,7 @@ export default function AiChatThreadView({
 	const pauseQueue = useWorkspaceAiQueueStore((state) => state.pause);
 	const resumeQueue = useWorkspaceAiQueueStore((state) => state.resume);
 	const { isBlocked } = useWorkspaceAiAllowance(modelId);
+	const pendingQuestion = getPendingQuestion(messages);
 
 	const lastMessage = messages.at(-1);
 	const lastMessageMetadata = lastMessage?.metadata as { errorMessage?: string } | undefined;
@@ -204,6 +211,10 @@ export default function AiChatThreadView({
 			// Held during an edit: a drained turn would land after the message being
 			// edited, and the edit's truncate-and-rerun would then destroy it.
 			editing !== null ||
+			// Held while a question is up: the turn ended cleanly, so canSend is
+			// true and the queue would otherwise fire straight past the question
+			// the user is still looking at.
+			pendingQuestion !== null ||
 			!canDrainQueuedMessage({
 				canSend,
 				errorKind: assistantError?.kind,
@@ -237,11 +248,28 @@ export default function AiChatThreadView({
 		assistantError?.kind,
 		editing,
 		isBlocked,
+		pendingQuestion,
 		queueHead,
 		queuePaused,
 		takeQueueHead,
 		threadId,
 	]);
+	const answerQuestion = (answers: AiChatQuestionAnswer[]) => {
+		if (!pendingQuestion) {
+			return;
+		}
+
+		const chatMessage: AiChatSendMessage = {
+			id: generateId(),
+			role: "user",
+			parts: [{ type: "text", text: formatQuestionAnswerText(answers) }],
+			metadata: { questionAnswer: answers },
+		};
+
+		setScrollAnchorMessageId(chatMessage.id);
+		sendChatMessage(chatMessage);
+		setSentMessageAnimationId(chatMessage.id);
+	};
 	const stopGeneration = () => {
 		stop();
 	};
@@ -276,20 +304,30 @@ export default function AiChatThreadView({
 
 			<div className="px-3 pb-3">
 				<div className={aiChatComposerRailClassName}>
-					<AiChatPromptInput
-						activeThreadId={threadId}
-						canSend={canSend}
-						context={context}
-						isEditing={Boolean(editing)}
-						modelId={modelId}
-						status={inputStatus}
-						onCancelEdit={cancelEditing}
-						onModelChange={onModelChange}
-						onSubmit={(message) => (editing ? submitEditedMessage(message) : sendMessage(message))}
-						onStop={handleUserStop}
-						onInterrupt={stopGeneration}
-						onSendNow={handleSendNow}
-					/>
+					{pendingQuestion ? (
+						<AiChatQuestionCard
+							disabled={!canSend}
+							pending={pendingQuestion}
+							onAnswer={answerQuestion}
+						/>
+					) : (
+						<AiChatPromptInput
+							activeThreadId={threadId}
+							canSend={canSend}
+							context={context}
+							isEditing={Boolean(editing)}
+							modelId={modelId}
+							status={inputStatus}
+							onCancelEdit={cancelEditing}
+							onModelChange={onModelChange}
+							onSubmit={(message) =>
+								editing ? submitEditedMessage(message) : sendMessage(message)
+							}
+							onStop={handleUserStop}
+							onInterrupt={stopGeneration}
+							onSendNow={handleSendNow}
+						/>
+					)}
 				</div>
 			</div>
 		</div>

--- a/src/features/workspaces/components/ai-chat/AiChatThreadView.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatThreadView.tsx
@@ -18,7 +18,7 @@ import { canDrainQueuedMessage } from "#/features/workspaces/components/ai-chat/
 import AiChatQuestionCard from "#/features/workspaces/components/ai-chat/AiChatQuestionCard";
 import {
 	formatQuestionAnswerText,
-	getPendingQuestion,
+	getPendingQuestions,
 	type AiChatQuestionAnswer,
 } from "#/features/workspaces/components/ai-chat/ai-chat-question";
 import { AiChatLiveActivityProvider } from "#/features/workspaces/components/ai-chat/ai-chat-live-activity";
@@ -111,7 +111,7 @@ export default function AiChatThreadView({
 	const pauseQueue = useWorkspaceAiQueueStore((state) => state.pause);
 	const resumeQueue = useWorkspaceAiQueueStore((state) => state.resume);
 	const { isBlocked } = useWorkspaceAiAllowance(modelId);
-	const pendingQuestion = getPendingQuestion(messages);
+	const pendingQuestions = getPendingQuestions(messages);
 
 	const lastMessage = messages.at(-1);
 	const lastMessageMetadata = lastMessage?.metadata as { errorMessage?: string } | undefined;
@@ -214,7 +214,7 @@ export default function AiChatThreadView({
 			// Held while a question is up: the turn ended cleanly, so canSend is
 			// true and the queue would otherwise fire straight past the question
 			// the user is still looking at.
-			pendingQuestion !== null ||
+			pendingQuestions !== null ||
 			!canDrainQueuedMessage({
 				canSend,
 				errorKind: assistantError?.kind,
@@ -248,14 +248,14 @@ export default function AiChatThreadView({
 		assistantError?.kind,
 		editing,
 		isBlocked,
-		pendingQuestion,
+		pendingQuestions,
 		queueHead,
 		queuePaused,
 		takeQueueHead,
 		threadId,
 	]);
 	const answerQuestion = (answers: AiChatQuestionAnswer[]) => {
-		if (!pendingQuestion) {
+		if (!pendingQuestions) {
 			return;
 		}
 
@@ -304,10 +304,10 @@ export default function AiChatThreadView({
 
 			<div className="px-3 pb-3">
 				<div className={aiChatComposerRailClassName}>
-					{pendingQuestion ? (
+					{pendingQuestions ? (
 						<AiChatQuestionCard
 							disabled={!canSend}
-							pending={pendingQuestion}
+							questions={pendingQuestions}
 							onAnswer={answerQuestion}
 						/>
 					) : (

--- a/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
+++ b/src/features/workspaces/components/ai-chat/AiChatToolActivityRow.tsx
@@ -1,4 +1,13 @@
-import { BookOpen, ChevronDown, FileText, Globe2, PencilLine, Search, Wrench } from "lucide-react";
+import {
+	BookOpen,
+	ChevronDown,
+	FileText,
+	Globe2,
+	MessageCircleQuestionMark,
+	PencilLine,
+	Search,
+	Wrench,
+} from "lucide-react";
 import { LazyMotion, domAnimation, m, useReducedMotion } from "motion/react";
 import type { ReactNode } from "react";
 
@@ -441,6 +450,8 @@ export function ToolActivityIcon({ icon }: { icon: AiToolActivityIconKind }) {
 			return <FileText className="size-3.5" aria-hidden="true" />;
 		case "guidance":
 			return <BookOpen className="size-3.5" aria-hidden="true" />;
+		case "question":
+			return <MessageCircleQuestionMark className="size-3.5" aria-hidden="true" />;
 		case "search":
 			return <Search className="size-3.5" aria-hidden="true" />;
 		case "web":

--- a/src/features/workspaces/components/ai-chat/ai-chat-layout.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-layout.ts
@@ -1,3 +1,15 @@
 export const aiChatComposerRailClassName = "mx-auto w-full max-w-3xl";
+// The composer's shell and its internal paddings. Anything that takes the
+// composer's slot — today the question card — is built from these same values,
+// so it reads as the composer changing its contents rather than a different
+// surface appearing in its place. (The question card cannot literally render
+// inside the composer: both are <form> elements and nesting forms is invalid.)
+export const aiChatComposerGroupClassName =
+	"h-auto flex-col border-border/70 bg-muted/30 shadow-none dark:bg-muted/30";
+export const aiChatComposerInlinePadding = "px-3.5";
+// gap-0: every header row self-pads (pt on its content), so the always-mounted
+// zero-height reveal wrappers add no phantom flex gaps to an idle composer.
+export const aiChatComposerHeaderPadding = "gap-0 px-3.5 pb-1";
+export const aiChatComposerFooterPadding = "pl-2 pr-3.5 pt-1 pb-2";
 export const aiChatMessageRailClassName = "mx-auto w-full max-w-3xl";
 export const aiChatMessageScrollerContentClassName = "gap-5 px-4 pt-12 pb-5";

--- a/src/features/workspaces/components/ai-chat/ai-chat-question.test.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-question.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	formatQuestionAnswerText,
+	getPendingQuestions,
+	getQuestionAnswerMetadata,
+} from "#/features/workspaces/components/ai-chat/ai-chat-question";
+import type { AiChatMessage } from "#/features/workspaces/components/ai-chat/types";
+
+function askUserPart(header: string, state = "output-available") {
+	return {
+		type: "tool-ask_user",
+		toolCallId: `call-${header}`,
+		state,
+		input: {
+			questions: [
+				{
+					header,
+					question: `What about ${header}?`,
+					options: [
+						{ label: "Yes", description: "Go ahead." },
+						{ label: "No", description: "Do not." },
+					],
+					multiple: false,
+				},
+			],
+		},
+		output: { asked: [] },
+	};
+}
+
+function assistant(parts: unknown[]): AiChatMessage {
+	return { id: "m1", role: "assistant", parts } as unknown as AiChatMessage;
+}
+
+const userMessage = { id: "m2", role: "user", parts: [] } as unknown as AiChatMessage;
+
+describe("getPendingQuestions", () => {
+	it("surfaces a completed question on the last assistant message", () => {
+		const questions = getPendingQuestions([assistant([askUserPart("Format")])]);
+
+		expect(questions).toHaveLength(1);
+		expect(questions?.[0]?.header).toBe("Format");
+	});
+
+	it("collects every call — the model can ask twice in one step", () => {
+		const questions = getPendingQuestions([
+			assistant([askUserPart("Format"), askUserPart("Depth")]),
+		]);
+
+		expect(questions?.map((question) => question.header)).toEqual(["Format", "Depth"]);
+	});
+
+	// Anything sent after the question settles it, which is what makes the UI's
+	// idea of "still pending" the same fact the model reads.
+	it("settles once any message follows", () => {
+		expect(getPendingQuestions([assistant([askUserPart("Format")]), userMessage])).toBeNull();
+	});
+
+	it("ignores a call that never reached an output", () => {
+		expect(getPendingQuestions([assistant([askUserPart("Format", "output-error")])])).toBeNull();
+	});
+});
+
+describe("getQuestionAnswerMetadata", () => {
+	const answers = [{ header: "Format", question: "Which?", values: ["Yes"], skipped: false }];
+
+	it("reads back answers it wrote", () => {
+		const message = { id: "m", role: "user", parts: [], metadata: { questionAnswer: answers } };
+
+		expect(getQuestionAnswerMetadata(message as unknown as AiChatMessage)).toEqual(answers);
+	});
+
+	// Metadata lands in jsonb unvalidated, so a row written before a field
+	// changed must fall back to plain text rather than reach the renderer.
+	it("rejects a malformed entry instead of handing it to the renderer", () => {
+		const message = {
+			id: "m",
+			role: "user",
+			parts: [],
+			metadata: { questionAnswer: [{ header: "Format" }] },
+		};
+
+		expect(getQuestionAnswerMetadata(message as unknown as AiChatMessage)).toBeNull();
+	});
+
+	it("returns null when there is no question metadata", () => {
+		const message = { id: "m", role: "user", parts: [], metadata: { modelId: "gemini" } };
+
+		expect(getQuestionAnswerMetadata(message as unknown as AiChatMessage)).toBeNull();
+	});
+});
+
+describe("formatQuestionAnswerText", () => {
+	// The model never sees the question again except through this text.
+	it("names the question alongside the answer", () => {
+		expect(
+			formatQuestionAnswerText([
+				{ header: "Format", question: "Which?", values: ["Summary", "Quiz"], skipped: false },
+			]),
+		).toBe("Format: Summary, Quiz");
+	});
+
+	it("hands the decision back when everything was skipped", () => {
+		expect(
+			formatQuestionAnswerText([
+				{ header: "Format", question: "Which?", values: [], skipped: true },
+			]),
+		).toContain("best judgement");
+	});
+
+	it("keeps the answered questions when only some were skipped", () => {
+		expect(
+			formatQuestionAnswerText([
+				{ header: "Format", question: "Which?", values: ["Summary"], skipped: false },
+				{ header: "Depth", question: "How deep?", values: [], skipped: true },
+			]),
+		).toBe("Format: Summary\nDepth: (skipped — your call)");
+	});
+});

--- a/src/features/workspaces/components/ai-chat/ai-chat-question.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-question.ts
@@ -1,5 +1,5 @@
 import { isToolUIPart } from "ai";
-import type { z } from "zod";
+import { z } from "zod";
 
 import { ASK_USER_TOOL_NAME, askUserInputSchema } from "#/features/workspaces/ai/question-tools";
 import type { AiChatMessage } from "#/features/workspaces/components/ai-chat/types";
@@ -7,58 +7,67 @@ import { getToolPartName } from "#/features/workspaces/components/ai-chat/ai-cha
 
 export type AiChatQuestion = z.output<typeof askUserInputSchema>["questions"][number];
 
-export interface AiChatPendingQuestion {
-	toolCallId: string;
-	questions: AiChatQuestion[];
-}
+/**
+ * One question's answer: the labels chosen, or a skip. Schema-first because it
+ * round-trips through the message's jsonb metadata, where nothing else checks
+ * its shape — see getQuestionAnswerMetadata.
+ */
+const questionAnswerSchema = z.object({
+	header: z.string(),
+	question: z.string(),
+	values: z.array(z.string()),
+	skipped: z.boolean(),
+});
+const questionAnswersSchema = z.array(questionAnswerSchema);
 
-/** One question's answer: the labels chosen, or a skip. */
-export interface AiChatQuestionAnswer {
-	header: string;
-	question: string;
-	values: string[];
-	skipped: boolean;
-}
+export type AiChatQuestionAnswer = z.output<typeof questionAnswerSchema>;
 
 /**
- * The question awaiting an answer, if any. A question is pending only while its
+ * The questions awaiting an answer, if any. They are pending only while their
  * assistant message is the last in the thread — anything sent after it (an
- * answer, or the user ignoring it and typing) settles it, exactly as the model
- * sees it.
+ * answer, or the user ignoring it and typing) settles them, exactly as the
+ * model sees it.
+ *
+ * Every completed call contributes: the model can emit parallel tool calls in
+ * one step, and stopping at the first would drop the rest with no trace.
  */
-export function getPendingQuestion(messages: AiChatMessage[]): AiChatPendingQuestion | null {
+export function getPendingQuestions(messages: AiChatMessage[]): AiChatQuestion[] | null {
 	const last = messages.at(-1);
 
 	if (last?.role !== "assistant") {
 		return null;
 	}
 
-	for (const part of last.parts) {
-		if (!isToolUIPart(part) || getToolPartName(part) !== ASK_USER_TOOL_NAME) {
-			continue;
-		}
-
+	const questions = last.parts.flatMap((part): AiChatQuestion[] => {
 		// Only a completed call carries a question worth showing. An errored one
 		// (an interrupted turn, via settledParts) has nothing to ask — and having
-		// reached an output, its input is known to satisfy the schema below.
-		if (part.state !== "output-available") {
-			continue;
+		// reached an output, its input is known to satisfy the schema.
+		if (
+			!isToolUIPart(part) ||
+			getToolPartName(part) !== ASK_USER_TOOL_NAME ||
+			part.state !== "output-available"
+		) {
+			return [];
 		}
 
 		const parsed = askUserInputSchema.safeParse(part.input);
+		return parsed.success ? [...parsed.data.questions] : [];
+	});
 
-		if (parsed.success) {
-			return { toolCallId: part.toolCallId, questions: [...parsed.data.questions] };
-		}
-	}
-
-	return null;
+	return questions.length > 0 ? questions : null;
 }
 
+/**
+ * Answers ride the user message's metadata, which is persisted verbatim into
+ * jsonb — `validateUIMessages` runs without a metadataSchema and its result is
+ * discarded. Nothing else vouches for the shape, so old rows written before a
+ * field changed would otherwise reach the renderer and throw mid-transcript.
+ */
 export function getQuestionAnswerMetadata(message: AiChatMessage): AiChatQuestionAnswer[] | null {
-	const metadata = message.metadata as { questionAnswer?: AiChatQuestionAnswer[] } | undefined;
+	const metadata = message.metadata as { questionAnswer?: unknown } | undefined;
+	const parsed = questionAnswersSchema.safeParse(metadata?.questionAnswer);
 
-	return Array.isArray(metadata?.questionAnswer) ? metadata.questionAnswer : null;
+	return parsed.success && parsed.data.length > 0 ? parsed.data : null;
 }
 
 /**

--- a/src/features/workspaces/components/ai-chat/ai-chat-question.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-question.ts
@@ -1,0 +1,81 @@
+import { isToolUIPart } from "ai";
+import type { z } from "zod";
+
+import { ASK_USER_TOOL_NAME, askUserInputSchema } from "#/features/workspaces/ai/question-tools";
+import type { AiChatMessage } from "#/features/workspaces/components/ai-chat/types";
+import { getToolPartName } from "#/features/workspaces/components/ai-chat/ai-chat-display-state";
+
+export type AiChatQuestion = z.output<typeof askUserInputSchema>["questions"][number];
+
+export interface AiChatPendingQuestion {
+	toolCallId: string;
+	questions: AiChatQuestion[];
+}
+
+/** One question's answer: the labels chosen, or a skip. */
+export interface AiChatQuestionAnswer {
+	header: string;
+	question: string;
+	values: string[];
+	skipped: boolean;
+}
+
+/**
+ * The question awaiting an answer, if any. A question is pending only while its
+ * assistant message is the last in the thread — anything sent after it (an
+ * answer, or the user ignoring it and typing) settles it, exactly as the model
+ * sees it.
+ */
+export function getPendingQuestion(messages: AiChatMessage[]): AiChatPendingQuestion | null {
+	const last = messages.at(-1);
+
+	if (last?.role !== "assistant") {
+		return null;
+	}
+
+	for (const part of last.parts) {
+		if (!isToolUIPart(part) || getToolPartName(part) !== ASK_USER_TOOL_NAME) {
+			continue;
+		}
+
+		// Only a completed call carries a question worth showing. An errored one
+		// (an interrupted turn, via settledParts) has nothing to ask — and having
+		// reached an output, its input is known to satisfy the schema below.
+		if (part.state !== "output-available") {
+			continue;
+		}
+
+		const parsed = askUserInputSchema.safeParse(part.input);
+
+		if (parsed.success) {
+			return { toolCallId: part.toolCallId, questions: [...parsed.data.questions] };
+		}
+	}
+
+	return null;
+}
+
+export function getQuestionAnswerMetadata(message: AiChatMessage): AiChatQuestionAnswer[] | null {
+	const metadata = message.metadata as { questionAnswer?: AiChatQuestionAnswer[] } | undefined;
+
+	return Array.isArray(metadata?.questionAnswer) ? metadata.questionAnswer : null;
+}
+
+/**
+ * The text the model reads. It has to stand on its own: the answer arrives as
+ * an ordinary user message, with nothing tying it back to the question but the
+ * words in it.
+ */
+export function formatQuestionAnswerText(answers: AiChatQuestionAnswer[]): string {
+	if (answers.every((answer) => answer.skipped)) {
+		return "I'd rather not answer that — use your best judgement and keep going.";
+	}
+
+	return answers
+		.map((answer) =>
+			answer.skipped
+				? `${answer.header}: (skipped — your call)`
+				: `${answer.header}: ${answer.values.join(", ")}`,
+		)
+		.join("\n");
+}

--- a/src/features/workspaces/components/ai-chat/ai-chat-tool-summaries.ts
+++ b/src/features/workspaces/components/ai-chat/ai-chat-tool-summaries.ts
@@ -97,6 +97,8 @@ export function getRunningToolSummary(input: {
 	switch (input.toolName) {
 		case "activate_skill":
 			return summary.running("Using ", ...skillGuidanceName(toolInput));
+		case "ask_user":
+			return summary.running("Asking you something");
 		case "orchestrate":
 			// The model authors the label (schema: short plain-language title,
 			// streamed ahead of the code) — surface it verbatim.
@@ -163,6 +165,8 @@ export function getFinishedToolSummary(input: {
 	switch (input.toolName) {
 		case "activate_skill":
 			return summary.completed("Used ", ...skillGuidanceName(asRecord(input.toolInput)));
+		case "ask_user":
+			return summarizeAskUser(input.toolInput);
 		case "orchestrate":
 			return summarizeOrchestrate(input.output, input.toolInput);
 		case "workspace_create_items":
@@ -255,6 +259,19 @@ function summarizeFailedTool(
 		default:
 			return summary.failed(`${capitalize(formatToolNameFallback(toolName))} failed`);
 	}
+}
+
+function summarizeAskUser(toolInput: unknown): AiChatToolSummary {
+	const questions = getArray(asRecord(toolInput).questions);
+	const header = getString(asRecord(questions[0]).header);
+
+	if (questions.length > 1) {
+		return summary.completed(`Asked ${formatCount(questions.length, "question")}`);
+	}
+
+	return header
+		? summary.completed("Asked about ", ...name(header))
+		: summary.completed("Asked a question");
 }
 
 // The orchestrate tool reports failures as a successful output with

--- a/src/features/workspaces/components/ai-chat/types.ts
+++ b/src/features/workspaces/components/ai-chat/types.ts
@@ -11,6 +11,8 @@ export interface AiChatSendMessage {
 	id: string;
 	role: "user";
 	parts: AiChatMessagePart[];
+	/** Persisted verbatim; carries question-answer provenance for the transcript. */
+	metadata?: unknown;
 }
 
 export type AiChatSendMessageOptions = ChatRequestOptions;

--- a/src/features/workspaces/content/workspace-content-reader.test.ts
+++ b/src/features/workspaces/content/workspace-content-reader.test.ts
@@ -169,7 +169,15 @@ describe("WorkspaceContentReader", () => {
 	});
 
 	it("chunks a large document and continues by block range", async () => {
-		const html = Array.from({ length: 20_000 }, (_, index) => `<p>line ${index + 1}</p>`).join("");
+		// Blocks are wide rather than numerous: the chunker breaks on a 48k
+		// character budget, so a few hundred fat paragraphs cross it just as well
+		// as tens of thousands of thin ones — and parse two orders of magnitude
+		// faster. The thin version took longer than the suite's 5s timeout under
+		// parallel load.
+		const html = Array.from(
+			{ length: 200 },
+			(_, index) => `<p>line ${index + 1} ${"word ".repeat(200)}</p>`,
+		).join("");
 		const session = createDocumentSession({ html });
 		const read = createReader({
 			bucket: {} as R2Bucket,
@@ -179,7 +187,7 @@ describe("WorkspaceContentReader", () => {
 		const [first] = await read([{ mode: "start", path: "/Notes" }]);
 		expect(first).toMatchObject({
 			format: "html",
-			location: { kind: "blocks", startBlock: 1, totalBlocks: 20_000 },
+			location: { kind: "blocks", startBlock: 1, totalBlocks: 200 },
 			path: "/Notes",
 			ref: "refdoc01",
 			status: "ready",
@@ -193,7 +201,7 @@ describe("WorkspaceContentReader", () => {
 		) {
 			throw new Error("Expected a document chunk.");
 		}
-		expect(first.location.endBlock).toBeLessThan(20_000);
+		expect(first.location.endBlock).toBeLessThan(200);
 
 		const [second] = await read([
 			{

--- a/src/hooks/use-type-to-focus-text-input.ts
+++ b/src/hooks/use-type-to-focus-text-input.ts
@@ -7,10 +7,16 @@ type TypeToFocusElement = HTMLInputElement | HTMLTextAreaElement;
 
 export function useTypeToFocusTextInput({
 	enabled,
+	ignoreKey,
 	inputRef,
 	setValue,
 }: {
 	enabled: boolean;
+	/**
+	 * Keys this input must not swallow because something else on screen binds
+	 * them — the question card's number shortcuts, for one.
+	 */
+	ignoreKey?: (key: string) => boolean;
 	inputRef: RefObject<TypeToFocusElement | null>;
 	setValue: Dispatch<SetStateAction<string>>;
 }) {
@@ -22,7 +28,7 @@ export function useTypeToFocusTextInput({
 		}
 
 		const handleKeyDown = (event: KeyboardEvent) => {
-			if (!shouldRouteTypingToTextInput(event)) {
+			if (!shouldRouteTypingToTextInput(event) || ignoreKey?.(event.key)) {
 				return;
 			}
 
@@ -53,7 +59,7 @@ export function useTypeToFocusTextInput({
 
 		document.addEventListener("keydown", handleKeyDown);
 		return () => document.removeEventListener("keydown", handleKeyDown);
-	}, [enabled, inputRef, setValue]);
+	}, [enabled, ignoreKey, inputRef, setValue]);
 }
 
 function shouldRouteTypingToTextInput(event: KeyboardEvent) {


### PR DESCRIPTION
When the assistant hits a genuine fork — an ambiguous instruction, a preference it can't infer, a choice between directions with real trade-offs — it currently has to guess, and a wrong guess costs the user a whole turn to unwind. It can already ask in prose, but then the user has to type an answer to a question that was really multiple choice.

This adds an `ask_user` tool. The model offers up to four questions with 2–4 options each, the composer swaps for a question card, and the user clicks an answer.

## What I was asked for

Explore whether an ask-user-question tool makes sense here, using opencode v2's implementation and shadcn's new Questionnaire component as references, then build it.

## The design decision worth reviewing

**The tool does not block on the answer.** `execute` records what was asked and returns immediately; a `hasToolCall` stop condition ends the turn; the user's reply arrives as an ordinary user message on the next turn.

opencode v2 does the opposite — its question tool parks on an Effect `Deferred` until the client replies. That works because opencode is a persistent local server. Here it would park a Worker request on a human, hold the turn claim against the composer queue, and lose the question on refresh, so it'd need a Durable Object holding pending state plus a reconnect path.

The AI SDK's canonical HITL flow (`addToolResult` + `sendAutomaticallyWhen`) doesn't avoid this either: it also issues a *new* request rather than resuming the stream, so it buys no mid-turn continuation over what's here — and it would have to write the tool output into an assistant row that `onEnd` settles asynchronously behind `ctx.waitUntil` and a 5s race. A user answering a two-option question in under a second would patch a row that settle then overwrites.

Completing the call up front sidesteps all of it. Consequences worth knowing:

- **Reload works with no bookkeeping.** The question is a settled tool part in the transcript, and the transcript already persists.
- **The model keeps seeing the question.** `convertToModelMessages` drops tool parts that never reached an `output-*` state, so a never-resolved call would be erased from context — and a skipped question would leave no record, letting the model re-ask in a loop.
- **It renders as a finished tool row**, not a permanent spinner.
- **Pending state is derived, never stored.** A question is up while the last message is an assistant one carrying a completed `ask_user` part. It settles itself the moment anything follows, so the UI's notion of "still pending" is the same fact the model reads and the two can't drift.

The cost: the model drops its in-context plan at the question and re-orients from the transcript next turn. That's the one thing opencode's blocking version buys, and with a server that rebuilds full history from Postgres every turn anyway, it seemed a fair trade.

## The rest

**Answers travel as a normal user message.** The text is what the model reads and has to stand alone, since nothing else ties the reply back to the question. The picked options also ride along as metadata, and the transcript renders those as chips — so the user sees what they chose rather than prose they didn't write.

**Read access, and no Code Mode.** Asking mutates nothing, so view-only members get it too; a view-only user is better served by a model that asks than one that guesses. It's built outside the filtered set `orchestrate` is assembled from, so generated code can't call it — a program that "asks" mid-run would get the receipt back and run straight past the answer.

**The vendored Questionnaire is tuned, not overridden at the call site.** It has one consumer, so composer-scale sizing, the hover states and the shortcut-in-the-indicator treatment live in the component. Two specificity bugs are fixed there: `hover:bg-*` ties with `dark:bg-*`, so hovers without a dark counterpart were silently dead in dark mode, and the shortcut badge was rendering underneath the selection dot for the same reason.

## Testing

Driven by hand against a local dev server. Typecheck and lint pass. No unit tests — the logic that would benefit (`getPendingQuestion`, answer formatting) is small and pure, and I'd rather add tests once the interaction has settled than pin down details likely to move.

Worth a reviewer's eye on: whether the model actually reaches for the tool at the right moments, since the tool description is doing all the work and there's no system-prompt reinforcement. The AI SDK runs a step's tool calls in parallel, so a model that calls `ask_user` alongside a mutation gets the mutation executed regardless of the stop condition — that's true of every design considered here, including the blocking one, but it's unguarded today.

https://claude.ai/code/session_014R8TLXMjYCLwWkALXU1Y1b

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789607603&installation_model_id=425282&pr_number=807&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F807&signature=381778c01ab09dfa3dfff574c9b8a3d820a0d101056c73109b481e33d4c86fa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - AI chat can ask interactive questions with single- or multi-select choices, custom answers, progress tracking, navigation, skipping, and keyboard shortcuts.
  - Added a reusable questionnaire interface with accessible choices, inputs, validation states, and navigation controls.
  - Submitted answers appear in the conversation as labeled selections or skipped responses.
  - Added question activity indicators and clearer summaries for pending and completed questions.

- **Improvements**
  - Improved chat composer layout consistency.
  - Added more control over automatic text-input focus behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->