### PR TITLE
feat(workspaces): add personal workspace archiving

### DIFF
--- a/drizzle-postgres/0009_wild_blazing_skull.sql
+++ b/drizzle-postgres/0009_wild_blazing_skull.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "workspace_members" ADD COLUMN "archived_at" timestamp with time zone;

--- a/drizzle-postgres/meta/0009_snapshot.json
+++ b/drizzle-postgres/meta/0009_snapshot.json
@@ -1,0 +1,2899 @@
+{
+  "id": "974f230b-e9ea-4cb9-9cf3-7518ca5e9fbf",
+  "prevId": "257dc596-655c-4a13-9694-b84758983c64",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_attachments": {
+      "name": "ai_chat_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_chat_attachments_thread_id_idx": {
+          "name": "ai_chat_attachments_thread_id_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_attachments_thread_id_ai_chat_threads_id_fk": {
+          "name": "ai_chat_attachments_thread_id_ai_chat_threads_id_fk",
+          "tableFrom": "ai_chat_attachments",
+          "tableTo": "ai_chat_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_messages": {
+      "name": "ai_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "ai_chat_messages_seq_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_chat_messages_thread_seq_unique": {
+          "name": "ai_chat_messages_thread_seq_unique",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_messages_thread_id_ai_chat_threads_id_fk": {
+          "name": "ai_chat_messages_thread_id_ai_chat_threads_id_fk",
+          "tableFrom": "ai_chat_messages",
+          "tableTo": "ai_chat_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ai_chat_messages_thread_id_id_pk": {
+          "name": "ai_chat_messages_thread_id_id_pk",
+          "columns": [
+            "thread_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ai_chat_messages_role_check": {
+          "name": "ai_chat_messages_role_check",
+          "value": "\"ai_chat_messages\".\"role\" in ('user', 'assistant', 'system')"
+        },
+        "ai_chat_messages_status_check": {
+          "name": "ai_chat_messages_status_check",
+          "value": "\"ai_chat_messages\".\"status\" in ('complete', 'interrupted', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_threads": {
+      "name": "ai_chat_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_stream_id": {
+          "name": "active_stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_chat_threads_user_id_idx": {
+          "name": "ai_chat_threads_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_threads_workspace_id_idx": {
+          "name": "ai_chat_threads_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_threads_user_id_user_id_fk": {
+          "name": "ai_chat_threads_user_id_user_id_fk",
+          "tableFrom": "ai_chat_threads",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_chat_threads_workspace_id_workspaces_id_fk": {
+          "name": "ai_chat_threads_workspace_id_workspaces_id_fk",
+          "tableFrom": "ai_chat_threads",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_session_id_idx": {
+          "name": "oauth_access_token_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_refresh_id_idx": {
+          "name": "oauth_access_token_refresh_id_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_client_user_id_idx": {
+          "name": "oauth_client_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_client_id_idx": {
+          "name": "oauth_refresh_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_session_id_idx": {
+          "name": "oauth_refresh_token_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_user_id_idx": {
+          "name": "oauth_refresh_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit": {
+      "name": "rate_limit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rate_limit_key_unique": {
+          "name": "rate_limit_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_file_assets": {
+      "name": "workspace_file_assets",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_object_key": {
+          "name": "source_object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_object_key": {
+          "name": "preview_object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_size_bytes": {
+          "name": "preview_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_file_assets_item_id_workspace_items_id_fk": {
+          "name": "workspace_file_assets_item_id_workspace_items_id_fk",
+          "tableFrom": "workspace_file_assets",
+          "tableTo": "workspace_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_file_assets_source_object_key_unique": {
+          "name": "workspace_file_assets_source_object_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_object_key"
+          ]
+        },
+        "workspace_file_assets_preview_object_key_unique": {
+          "name": "workspace_file_assets_preview_object_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "preview_object_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invites": {
+      "name": "workspace_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_invites_token_unique": {
+          "name": "workspace_invites_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_invites_pending_link_per_role": {
+          "name": "workspace_invites_pending_link_per_role",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_invites\".\"type\" = 'link' and \"workspace_invites\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_invites_pending_email_per_workspace": {
+          "name": "workspace_invites_pending_email_per_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_invites\".\"type\" = 'email' and \"workspace_invites\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_invites_workspace_id_idx": {
+          "name": "workspace_invites_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_invites_created_by_user_id_idx": {
+          "name": "workspace_invites_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_invites_workspace_id_workspaces_id_fk": {
+          "name": "workspace_invites_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_invites",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_invites_created_by_user_id_user_id_fk": {
+          "name": "workspace_invites_created_by_user_id_user_id_fk",
+          "tableFrom": "workspace_invites",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspace_invites_role_check": {
+          "name": "workspace_invites_role_check",
+          "value": "\"workspace_invites\".\"role\" in ('owner', 'admin', 'editor', 'viewer')"
+        },
+        "workspace_invites_type_check": {
+          "name": "workspace_invites_type_check",
+          "value": "\"workspace_invites\".\"type\" in ('email', 'link')"
+        },
+        "workspace_invites_status_check": {
+          "name": "workspace_invites_status_check",
+          "value": "\"workspace_invites\".\"status\" in ('pending', 'accepted', 'revoked', 'expired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspace_item_contents": {
+      "name": "workspace_item_contents",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english_unaccent', \"workspace_item_contents\".\"search_text\")",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "workspace_item_contents_search_idx": {
+          "name": "workspace_item_contents_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_item_contents_item_id_workspace_items_id_fk": {
+          "name": "workspace_item_contents_item_id_workspace_items_id_fk",
+          "tableFrom": "workspace_item_contents",
+          "tableTo": "workspace_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_item_extractions": {
+      "name": "workspace_item_extractions",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_mode": {
+          "name": "provider_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_item_extractions_status_idx": {
+          "name": "workspace_item_extractions_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_item_extractions_item_fk": {
+          "name": "workspace_item_extractions_item_fk",
+          "tableFrom": "workspace_item_extractions",
+          "tableTo": "workspace_items",
+          "columnsFrom": [
+            "workspace_id",
+            "item_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspace_item_extractions_status_check": {
+          "name": "workspace_item_extractions_status_check",
+          "value": "\"workspace_item_extractions\".\"status\" in ('processing', 'ready', 'failed')"
+        },
+        "workspace_item_extractions_tier_check": {
+          "name": "workspace_item_extractions_tier_check",
+          "value": "\"workspace_item_extractions\".\"tier\" is null or \"workspace_item_extractions\".\"tier\" in ('fast', 'enhanced')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspace_item_pages": {
+      "name": "workspace_item_pages",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_number": {
+          "name": "page_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown_bytes": {
+          "name": "markdown_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english_unaccent', \"workspace_item_pages\".\"markdown\")",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "workspace_item_pages_search_idx": {
+          "name": "workspace_item_pages_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_item_pages_item_id_workspace_items_id_fk": {
+          "name": "workspace_item_pages_item_id_workspace_items_id_fk",
+          "tableFrom": "workspace_item_pages",
+          "tableTo": "workspace_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_item_pages_item_id_page_number_pk": {
+          "name": "workspace_item_pages_item_id_page_number_pk",
+          "columns": [
+            "item_id",
+            "page_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspace_item_pages_number_check": {
+          "name": "workspace_item_pages_number_check",
+          "value": "\"workspace_item_pages\".\"page_number\" > 0"
+        },
+        "workspace_item_pages_bytes_check": {
+          "name": "workspace_item_pages_bytes_check",
+          "value": "\"workspace_item_pages\".\"markdown_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspace_item_relations": {
+      "name": "workspace_item_relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_item_id": {
+          "name": "from_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_item_id": {
+          "name": "to_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_item_relations_unique": {
+          "name": "workspace_item_relations_unique",
+          "columns": [
+            {
+              "expression": "from_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_item_relations_from_idx": {
+          "name": "workspace_item_relations_from_idx",
+          "columns": [
+            {
+              "expression": "from_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_item_relations_to_idx": {
+          "name": "workspace_item_relations_to_idx",
+          "columns": [
+            {
+              "expression": "to_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_item_relations_from_fk": {
+          "name": "workspace_item_relations_from_fk",
+          "tableFrom": "workspace_item_relations",
+          "tableTo": "workspace_items",
+          "columnsFrom": [
+            "workspace_id",
+            "from_item_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_item_relations_to_fk": {
+          "name": "workspace_item_relations_to_fk",
+          "tableFrom": "workspace_item_relations",
+          "tableTo": "workspace_items",
+          "columnsFrom": [
+            "workspace_id",
+            "to_item_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspace_item_relations_kind_check": {
+          "name": "workspace_item_relations_kind_check",
+          "value": "\"workspace_item_relations\".\"kind\" in ('derived_from', 'references')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspace_item_user_states": {
+      "name": "workspace_item_user_states",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_item_user_states_item_id_idx": {
+          "name": "workspace_item_user_states_item_id_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_item_user_states_user_id_user_id_fk": {
+          "name": "workspace_item_user_states_user_id_user_id_fk",
+          "tableFrom": "workspace_item_user_states",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_item_user_states_item_id_workspace_items_id_fk": {
+          "name": "workspace_item_user_states_item_id_workspace_items_id_fk",
+          "tableFrom": "workspace_item_user_states",
+          "tableTo": "workspace_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_item_user_states_user_id_item_id_pk": {
+          "name": "workspace_item_user_states_user_id_item_id_pk",
+          "columns": [
+            "user_id",
+            "item_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_items": {
+      "name": "workspace_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_key": {
+          "name": "name_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_key": {
+          "name": "ref_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "substr(translate(encode(decode(md5(gen_random_uuid()::text), 'hex'), 'base64'), '+/', 'Aa'), 1, 8)"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_items_tree_idx": {
+          "name": "workspace_items_tree_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_items_type_idx": {
+          "name": "workspace_items_type_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_items_ref_key_unique": {
+          "name": "workspace_items_ref_key_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_items_root_name_unique": {
+          "name": "workspace_items_root_name_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_items\".\"parent_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_items_parent_name_unique": {
+          "name": "workspace_items_parent_name_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_items\".\"parent_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_items_workspace_id_workspaces_id_fk": {
+          "name": "workspace_items_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_items",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_items_parent_fk": {
+          "name": "workspace_items_parent_fk",
+          "tableFrom": "workspace_items",
+          "tableTo": "workspace_items",
+          "columnsFrom": [
+            "workspace_id",
+            "parent_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_items_workspace_id_id_unique": {
+          "name": "workspace_items_workspace_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_items_type_check": {
+          "name": "workspace_items_type_check",
+          "value": "\"workspace_items\".\"type\" in ('folder', 'document', 'flashcard', 'quiz', 'file')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspace_members": {
+      "name": "workspace_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_members_workspace_user_unique": {
+          "name": "workspace_members_workspace_user_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_members_user_id_idx": {
+          "name": "workspace_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_members_user_last_opened_at_idx": {
+          "name": "workspace_members_user_last_opened_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_opened_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_members_workspace_id_workspaces_id_fk": {
+          "name": "workspace_members_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_members_user_id_user_id_fk": {
+          "name": "workspace_members_user_id_user_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspace_members_role_check": {
+          "name": "workspace_members_role_check",
+          "value": "\"workspace_members\".\"role\" in ('owner', 'admin', 'editor', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspaces_owner_id_idx": {
+          "name": "workspaces_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspaces_archived_at_idx": {
+          "name": "workspaces_archived_at_idx",
+          "columns": [
+            {
+              "expression": "archived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspaces_owner_id_user_id_fk": {
+          "name": "workspaces_owner_id_user_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle-postgres/meta/_journal.json
+++ b/drizzle-postgres/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1786988445199,
       "tag": "0008_sparkling_black_crow",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1788460837327,
+      "tag": "0009_wild_blazing_skull",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -485,6 +485,7 @@ export const workspaceMembers = pgTable(
 			.references(() => user.id, { onDelete: "cascade" }),
 		role: text("role", { enum: WORKSPACE_ROLES }).default("viewer").notNull(),
 		lastOpenedAt: timestamp("last_opened_at", { withTimezone: true }),
+		archivedAt: timestamp("archived_at", { withTimezone: true }),
 		createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 		updatedAt: timestamp("updated_at", { withTimezone: true })
 			.defaultNow()

--- a/src/features/workspaces/components/WorkspaceCard.tsx
+++ b/src/features/workspaces/components/WorkspaceCard.tsx
@@ -1,7 +1,8 @@
 import { Link } from "@tanstack/react-router";
-import { Settings } from "lucide-react";
+import { Archive, ArchiveRestore, Settings } from "lucide-react";
 
 import { Card, CardHeader, CardTitle } from "#/components/ui/card";
+import { Tooltip, TooltipContent, TooltipTrigger } from "#/components/ui/tooltip";
 import WorkspaceSettingsDialog from "#/features/workspaces/components/WorkspaceSettingsDialog";
 import { WorkspaceToolbarIconButton } from "#/features/workspaces/components/WorkspaceToolbar";
 import { WorkspaceCardFooter } from "#/features/workspaces/components/workspace-card-footer";
@@ -9,6 +10,7 @@ import type { WorkspaceSummary } from "#/features/workspaces/contracts";
 import { getWorkspaceDisplay } from "#/features/workspaces/model/display";
 import { getWorkspaceThemeArt } from "#/features/workspaces/model/workspace-themes";
 import { getWorkspaceMemberCapabilities } from "#/features/workspaces/workspace-member-capabilities";
+import { useSetWorkspaceArchiveStatusMutation } from "#/features/workspaces/use-set-workspace-archive-status";
 import { cn } from "#/lib/utils";
 
 interface WorkspaceCardSearch {
@@ -26,6 +28,8 @@ export default function WorkspaceCard({ workspace, className, search }: Workspac
 	const { Icon, color } = getWorkspaceDisplay(workspace);
 	const themeArt = getWorkspaceThemeArt(workspace);
 	const capabilities = getWorkspaceMemberCapabilities(workspace.membershipRole);
+	const archiveMutation = useSetWorkspaceArchiveStatusMutation();
+	const isArchived = workspace.archivedForCurrentUserAt !== null;
 
 	return (
 		<Card
@@ -77,14 +81,40 @@ export default function WorkspaceCard({ workspace, className, search }: Workspac
 				</CardHeader>
 			</Link>
 
-			{capabilities.canMutateContent ? (
-				<div
-					className={cn(
-						"pointer-events-auto absolute top-2 right-2 z-10 opacity-100 transition-opacity sm:pointer-events-none sm:opacity-0",
-						"sm:group-hover/card:pointer-events-auto sm:group-hover/card:opacity-100",
-						"sm:group-focus-within/card:pointer-events-auto sm:group-focus-within/card:opacity-100",
-					)}
-				>
+			<div
+				className={cn(
+					"pointer-events-auto absolute top-2 right-2 z-10 flex gap-1 opacity-100 transition-opacity sm:pointer-events-none sm:opacity-0",
+					"sm:group-hover/card:pointer-events-auto sm:group-hover/card:opacity-100",
+					"sm:group-focus-within/card:pointer-events-auto sm:group-focus-within/card:opacity-100",
+				)}
+			>
+				<Tooltip>
+					<TooltipTrigger
+						render={
+							<WorkspaceToolbarIconButton
+								aria-label={`${isArchived ? "Restore" : "Archive"} ${workspace.name}`}
+								disabled={archiveMutation.isPending}
+								className={cn(
+									themeArt &&
+										"border-border/80 bg-card/95 backdrop-blur-md hover:border-foreground/30 hover:bg-secondary dark:border-white/15 dark:bg-card/90 dark:hover:border-white/35",
+								)}
+								onClick={(event) => {
+									event.preventDefault();
+									event.stopPropagation();
+									archiveMutation.mutate({
+										workspaceId: workspace.id,
+										status: isArchived ? "active" : "archived",
+									});
+								}}
+							>
+								{isArchived ? <ArchiveRestore /> : <Archive />}
+							</WorkspaceToolbarIconButton>
+						}
+					/>
+					<TooltipContent>{isArchived ? "Restore workspace" : "Archive workspace"}</TooltipContent>
+				</Tooltip>
+
+				{capabilities.canMutateContent ? (
 					<WorkspaceSettingsDialog
 						capabilities={capabilities}
 						workspace={workspace}
@@ -106,8 +136,8 @@ export default function WorkspaceCard({ workspace, className, search }: Workspac
 							</WorkspaceToolbarIconButton>
 						}
 					/>
-				</div>
-			) : null}
+				) : null}
+			</div>
 		</Card>
 	);
 }

--- a/src/features/workspaces/components/WorkspaceHomePage.tsx
+++ b/src/features/workspaces/components/WorkspaceHomePage.tsx
@@ -61,12 +61,12 @@ export function WorkspaceHomePage() {
 	const hasWorkspaceSearch = workspaceSearch.trim().length > 0;
 	const hasWorkspaces = workspaces.length > 0;
 	const showWorkspaceHomeEmptyState =
-		!hasWorkspaces ||
-		(workspaceCollection === "active" && collectionWorkspaces.length === 0 && !hasWorkspaceSearch);
+		workspaceCollection === "active" && collectionWorkspaces.length === 0 && !hasWorkspaceSearch;
 	const showArchiveEmptyState =
-		workspaceCollection === "archived" && collectionWorkspaces.length === 0 && !hasWorkspaceSearch;
+		workspaceCollection === "archived" && collectionWorkspaces.length === 0;
 	const handleCreateWorkspace = () => createWorkspaceMutation.mutate({ id: crypto.randomUUID() });
 	const handleWorkspaceCollectionChange = (collection: WorkspaceCollection) => {
+		setWorkspaceSearch("");
 		void navigate({
 			to: "/home",
 			search: (previous) => ({

--- a/src/features/workspaces/components/WorkspaceHomePage.tsx
+++ b/src/features/workspaces/components/WorkspaceHomePage.tsx
@@ -1,5 +1,6 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Mail, Search, UsersRound, X } from "lucide-react";
+import { getRouteApi, useNavigate } from "@tanstack/react-router";
+import { Archive, Mail, Search, UsersRound, X } from "lucide-react";
 import type { Dispatch, SetStateAction } from "react";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
@@ -17,6 +18,7 @@ import {
 	DropdownMenuTrigger,
 } from "#/components/ui/dropdown-menu";
 import { Input } from "#/components/ui/input";
+import { Tooltip, TooltipContent, TooltipTrigger } from "#/components/ui/tooltip";
 import CreateWorkspaceCard from "#/features/workspaces/components/CreateWorkspaceCard";
 import WorkspaceCard from "#/features/workspaces/components/WorkspaceCard";
 import { WorkspaceGrid } from "#/features/workspaces/components/WorkspaceGrid";
@@ -34,36 +36,77 @@ import { useTypeToFocusTextInput } from "#/hooks/use-type-to-focus-text-input";
 import { rankNameSearch } from "#/lib/name-search";
 
 const workspaceHomeCommunityLinkOrder = ["Discord", "Twitter / X", "GitHub"];
+type WorkspaceCollection = "active" | "archived";
+const routeApi = getRouteApi("/_protected/home");
 
 export function WorkspaceHomePage() {
 	const { data: workspaces } = useSuspenseQuery(workspacesQueryOptions());
+	const { view } = routeApi.useSearch({
+		select: (search) => ({ view: search.view }),
+	});
+	const navigate = useNavigate();
 	const createWorkspaceMutation = useCreateWorkspaceMutation();
 	const persistedStoresHydrated = useWorkspacePersistedStoresHydrated();
 	const [workspaceSearch, setWorkspaceSearch] = useState("");
-	const filteredWorkspaces = filterWorkspaces(workspaces, workspaceSearch);
+	const workspaceCollection: WorkspaceCollection = view === "archived" ? "archived" : "active";
+	const activeWorkspaces = workspaces.filter(
+		(workspace) => workspace.archivedForCurrentUserAt === null,
+	);
+	const archivedWorkspaces = workspaces.filter(
+		(workspace) => workspace.archivedForCurrentUserAt !== null,
+	);
+	const collectionWorkspaces =
+		workspaceCollection === "active" ? activeWorkspaces : archivedWorkspaces;
+	const filteredWorkspaces = filterWorkspaces(collectionWorkspaces, workspaceSearch);
 	const hasWorkspaceSearch = workspaceSearch.trim().length > 0;
 	const hasWorkspaces = workspaces.length > 0;
+	const showWorkspaceHomeEmptyState =
+		!hasWorkspaces ||
+		(workspaceCollection === "active" && collectionWorkspaces.length === 0 && !hasWorkspaceSearch);
+	const showArchiveEmptyState =
+		workspaceCollection === "archived" && collectionWorkspaces.length === 0 && !hasWorkspaceSearch;
 	const handleCreateWorkspace = () => createWorkspaceMutation.mutate({ id: crypto.randomUUID() });
+	const handleWorkspaceCollectionChange = (collection: WorkspaceCollection) => {
+		void navigate({
+			to: "/home",
+			search: (previous) => ({
+				...previous,
+				view: collection === "archived" ? "archived" : undefined,
+			}),
+		});
+	};
 
 	return (
 		<AppShell
 			navbarControls={
 				hasWorkspaces ? (
 					<WorkspaceHomeNavbarControls
+						archivedCount={archivedWorkspaces.length}
 						searchValue={workspaceSearch}
+						workspaceCollection={workspaceCollection}
 						onSearchChange={setWorkspaceSearch}
+						onWorkspaceCollectionChange={handleWorkspaceCollectionChange}
 					/>
 				) : undefined
 			}
 			siteControls={<WorkspaceHomeCommunityMenu />}
 		>
 			<div className="pb-8">
-				{hasWorkspaces ? (
+				{showWorkspaceHomeEmptyState ? (
+					<WorkspaceHomeEmptyState
+						onCreate={handleCreateWorkspace}
+						pending={createWorkspaceMutation.isPending}
+					/>
+				) : showArchiveEmptyState ? (
+					<EmptyArchive />
+				) : (
 					<WorkspaceGrid>
-						<CreateWorkspaceCard
-							onCreate={handleCreateWorkspace}
-							pending={createWorkspaceMutation.isPending}
-						/>
+						{workspaceCollection === "active" ? (
+							<CreateWorkspaceCard
+								onCreate={handleCreateWorkspace}
+								pending={createWorkspaceMutation.isPending}
+							/>
+						) : null}
 						{filteredWorkspaces.map((workspace) => (
 							<WorkspaceCard
 								key={workspace.id}
@@ -75,23 +118,33 @@ export function WorkspaceHomePage() {
 							<NoWorkspaceSearchResultsCard search={workspaceSearch} />
 						) : null}
 					</WorkspaceGrid>
-				) : (
-					<WorkspaceHomeEmptyState
-						onCreate={handleCreateWorkspace}
-						pending={createWorkspaceMutation.isPending}
-					/>
 				)}
 			</div>
 		</AppShell>
 	);
 }
 
+function EmptyArchive() {
+	return (
+		<div className="flex flex-col items-center justify-center space-y-1 py-24 text-center">
+			<h2 className="font-medium">No archived workspaces</h2>
+			<p className="text-sm text-muted-foreground">Archived workspaces will appear here.</p>
+		</div>
+	);
+}
+
 function WorkspaceHomeNavbarControls({
+	archivedCount,
 	searchValue,
+	workspaceCollection,
 	onSearchChange,
+	onWorkspaceCollectionChange,
 }: {
+	archivedCount: number;
 	searchValue: string;
+	workspaceCollection: WorkspaceCollection;
 	onSearchChange: Dispatch<SetStateAction<string>>;
+	onWorkspaceCollectionChange: (collection: WorkspaceCollection) => void;
 }) {
 	const searchInputRef = useRef<HTMLInputElement>(null);
 	useTypeToFocusTextInput({
@@ -101,8 +154,8 @@ function WorkspaceHomeNavbarControls({
 	});
 
 	return (
-		<div className="hidden w-full min-w-0 items-center justify-center sm:flex">
-			<div className="relative w-full min-w-0 max-w-72">
+		<div className="flex w-full min-w-0 items-center justify-center gap-2">
+			<div className="relative hidden w-full min-w-0 max-w-72 sm:block">
 				<Search
 					aria-hidden="true"
 					className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground"
@@ -129,6 +182,40 @@ function WorkspaceHomeNavbarControls({
 					</button>
 				) : null}
 			</div>
+
+			<Tooltip>
+				<TooltipTrigger
+					render={
+						<Button
+							variant="ghost"
+							size="icon-sm"
+							className={
+								workspaceCollection === "archived"
+									? "bg-background/70 text-muted-foreground shadow-xs hover:text-foreground"
+									: "text-muted-foreground hover:text-foreground"
+							}
+							aria-label={
+								workspaceCollection === "archived"
+									? "Show active workspaces"
+									: "Show archived workspaces"
+							}
+							aria-pressed={workspaceCollection === "archived"}
+							onClick={() =>
+								onWorkspaceCollectionChange(
+									workspaceCollection === "active" ? "archived" : "active",
+								)
+							}
+						/>
+					}
+				>
+					<Archive />
+				</TooltipTrigger>
+				<TooltipContent>
+					{workspaceCollection === "archived"
+						? "Show active workspaces"
+						: `Show archived workspaces (${archivedCount})`}
+				</TooltipContent>
+			</Tooltip>
 		</div>
 	);
 }

--- a/src/features/workspaces/contracts.ts
+++ b/src/features/workspaces/contracts.ts
@@ -354,7 +354,7 @@ export const workspaceSummarySchema = z.object({
 	createdAt: z.string(),
 	updatedAt: z.string(),
 	lastOpenedAt: z.string().nullable(),
-	archivedAt: z.string().nullable(),
+	archivedForCurrentUserAt: z.string().nullable(),
 	membershipRole: workspaceMembershipRoleSchema,
 });
 
@@ -434,6 +434,11 @@ export const updateWorkspaceInputSchema = z.object({
 	theme: workspaceThemeSchema.nullable(),
 });
 
+export const setWorkspaceArchiveStatusInputSchema = z.object({
+	workspaceId: z.string().min(1),
+	status: z.enum(["active", "archived"]),
+});
+
 export const deleteWorkspaceInputSchema = z.object({
 	workspaceId: z.string().min(1),
 	confirmationName: z.string().trim().min(1),
@@ -467,6 +472,7 @@ export type DeleteWorkspaceItemsInput = z.infer<typeof deleteWorkspaceItemsInput
 export type UpdateWorkspaceItemColorInput = z.infer<typeof updateWorkspaceItemColorInputSchema>;
 export type CreateWorkspaceInput = z.infer<typeof createWorkspaceInputSchema>;
 export type UpdateWorkspaceInput = z.infer<typeof updateWorkspaceInputSchema>;
+export type SetWorkspaceArchiveStatusInput = z.infer<typeof setWorkspaceArchiveStatusInputSchema>;
 export type DeleteWorkspaceInput = z.infer<typeof deleteWorkspaceInputSchema>;
 export type WorkspaceMembershipRole = z.infer<typeof workspaceMembershipRoleSchema>;
 

--- a/src/features/workspaces/server/functions.ts
+++ b/src/features/workspaces/server/functions.ts
@@ -9,6 +9,7 @@ import {
 	deleteWorkspaceItemsInputSchema,
 	moveWorkspaceItemsInputSchema,
 	renameWorkspaceItemInputSchema,
+	setWorkspaceArchiveStatusInputSchema,
 	updateWorkspaceInputSchema,
 	updateWorkspaceItemColorInputSchema,
 } from "#/features/workspaces/contracts";
@@ -24,6 +25,7 @@ import {
 	createWorkspaceForCurrentUser,
 	deleteWorkspaceForCurrentUser,
 	recordWorkspaceOpenedForCurrentUser,
+	setWorkspaceArchiveStatusForCurrentUser,
 	updateWorkspaceForCurrentUser,
 } from "#/features/workspaces/server/mutations";
 import { getCurrentUserId } from "#/features/workspaces/server/permissions";
@@ -55,6 +57,10 @@ export const recordWorkspaceOpenedFn = createServerFn({ method: "POST" })
 export const updateWorkspaceFn = createServerFn({ method: "POST" })
 	.validator(updateWorkspaceInputSchema)
 	.handler(async ({ data }) => updateWorkspaceForCurrentUser(data));
+
+export const setWorkspaceArchiveStatusFn = createServerFn({ method: "POST" })
+	.validator(setWorkspaceArchiveStatusInputSchema)
+	.handler(async ({ data }) => setWorkspaceArchiveStatusForCurrentUser(data));
 
 export const deleteWorkspaceFn = createServerFn({ method: "POST" })
 	.validator(deleteWorkspaceInputSchema)

--- a/src/features/workspaces/server/mappers.ts
+++ b/src/features/workspaces/server/mappers.ts
@@ -11,17 +11,19 @@ import {
 import { DEFAULT_WORKSPACE_COLOR, DEFAULT_WORKSPACE_ICON } from "#/features/workspaces/defaults";
 
 type WorkspaceRow = InferSelectModel<typeof workspaces>;
-type WorkspaceSummaryRow = WorkspaceRow & {
+interface WorkspaceSummaryMembership {
+	archivedAt?: Date | null;
 	lastOpenedAt?: Date | null;
-};
+	role: WorkspaceMembershipRole;
+}
 
 function toIsoString(value: Date | null) {
 	return value ? value.toISOString() : null;
 }
 
 export function mapWorkspaceRow(
-	row: WorkspaceSummaryRow,
-	membershipRole: WorkspaceMembershipRole,
+	row: WorkspaceRow,
+	membership: WorkspaceSummaryMembership,
 ): WorkspaceSummary {
 	return {
 		id: row.id,
@@ -32,9 +34,9 @@ export function mapWorkspaceRow(
 		theme: parseWorkspaceTheme(row.theme),
 		createdAt: row.createdAt.toISOString(),
 		updatedAt: row.updatedAt.toISOString(),
-		lastOpenedAt: toIsoString(row.lastOpenedAt ?? null),
-		archivedAt: toIsoString(row.archivedAt),
-		membershipRole,
+		lastOpenedAt: toIsoString(membership.lastOpenedAt ?? null),
+		archivedForCurrentUserAt: toIsoString(membership.archivedAt ?? null),
+		membershipRole: membership.role,
 	};
 }
 

--- a/src/features/workspaces/server/mutations.test.ts
+++ b/src/features/workspaces/server/mutations.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { and, eq } from "drizzle-orm";
+
+import { workspaceMembers } from "#/db/schema";
 
 const mocks = vi.hoisted(() => ({
+	assertCanReadWorkspace: vi.fn(),
 	capturePostHogServerEvent: vi.fn(),
 	createDbContext: vi.fn(),
 	env: {},
@@ -27,14 +31,17 @@ vi.mock("#/features/workspaces/realtime/workspace-room-notifier", () => ({
 }));
 vi.mock("#/features/workspaces/server/permissions", () => ({
 	assertCanDeleteWorkspace: vi.fn(),
-	assertCanReadWorkspace: vi.fn(),
+	assertCanReadWorkspace: mocks.assertCanReadWorkspace,
 	getCurrentUserId: mocks.getCurrentUserId,
 }));
 vi.mock("#/integrations/posthog/server", () => ({
 	capturePostHogServerEvent: mocks.capturePostHogServerEvent,
 }));
 
-import { updateWorkspaceForCurrentUser } from "#/features/workspaces/server/mutations";
+import {
+	setWorkspaceArchiveStatusForCurrentUser,
+	updateWorkspaceForCurrentUser,
+} from "#/features/workspaces/server/mutations";
 
 describe("workspace settings mutations", () => {
 	beforeEach(() => {
@@ -93,5 +100,65 @@ describe("workspace settings mutations", () => {
 			revision: 8,
 		});
 		expect(result).toMatchObject({ id: workspace.id, membershipRole: "editor" });
+	});
+
+	it("archives only the current user's workspace membership", async () => {
+		const archivedAt = new Date("2026-09-03T18:00:00.000Z");
+		const workspace = {
+			archivedAt: null,
+			color: "blue",
+			createdAt: new Date("2026-08-01T00:00:00.000Z"),
+			description: null,
+			icon: "compass",
+			id: "workspace-1",
+			name: "Research",
+			ownerId: "owner-user",
+			revision: 7,
+			theme: "default",
+			updatedAt: new Date("2026-08-11T00:00:00.000Z"),
+		} as const;
+		const membership = {
+			archivedAt,
+			lastOpenedAt: new Date("2026-08-10T00:00:00.000Z"),
+			role: "viewer",
+		};
+		const membershipWhere = vi.fn(() => ({ returning: vi.fn(async () => [membership]) }));
+		const set = vi.fn(() => ({ where: membershipWhere }));
+		const transaction = {
+			select: vi.fn(() => ({
+				from: vi.fn(() => ({
+					where: vi.fn(() => ({ limit: vi.fn(async () => [workspace]) })),
+				})),
+			})),
+			update: vi.fn(() => ({ set })),
+		};
+		const dispose = vi.fn();
+		const db = {
+			transaction: vi.fn(async (run) => await run(transaction)),
+		};
+		mocks.createDbContext.mockResolvedValue({ db, dispose });
+
+		const result = await setWorkspaceArchiveStatusForCurrentUser({
+			workspaceId: workspace.id,
+			status: "archived",
+		});
+
+		expect(mocks.assertCanReadWorkspace).toHaveBeenCalledWith(db, {
+			workspaceId: workspace.id,
+			userId: "actor-user",
+		});
+		expect(set).toHaveBeenCalledWith({ archivedAt: expect.any(Date) });
+		expect(membershipWhere).toHaveBeenCalledWith(
+			and(
+				eq(workspaceMembers.workspaceId, workspace.id),
+				eq(workspaceMembers.userId, "actor-user"),
+			),
+		);
+		expect(result).toMatchObject({
+			archivedForCurrentUserAt: archivedAt.toISOString(),
+			id: workspace.id,
+			membershipRole: "viewer",
+		});
+		expect(dispose).toHaveBeenCalledOnce();
 	});
 });

--- a/src/features/workspaces/server/mutations.ts
+++ b/src/features/workspaces/server/mutations.ts
@@ -7,6 +7,7 @@ import { purgeWorkspaceResources } from "#/features/workspaces/durable-object-li
 import type {
 	CreateWorkspaceInput,
 	DeleteWorkspaceInput,
+	SetWorkspaceArchiveStatusInput,
 	UpdateWorkspaceInput,
 	WorkspaceSummary,
 } from "#/features/workspaces/contracts";
@@ -86,13 +87,7 @@ async function insertWorkspaceForUser(
 			return insertedWorkspace;
 		});
 
-		return mapWorkspaceRow(
-			{
-				...row,
-				lastOpenedAt: openedAt,
-			},
-			"owner",
-		);
+		return mapWorkspaceRow(row, { lastOpenedAt: openedAt, role: "owner" });
 	} finally {
 		await dbContext.dispose();
 	}
@@ -116,6 +111,7 @@ export async function recordWorkspaceOpenedForCurrentUser(
 					and(eq(workspaceMembers.workspaceId, workspaceId), eq(workspaceMembers.userId, userId)),
 				)
 				.returning({
+					archivedAt: workspaceMembers.archivedAt,
 					lastOpenedAt: workspaceMembers.lastOpenedAt,
 					role: workspaceMembers.role,
 				}),
@@ -130,13 +126,7 @@ export async function recordWorkspaceOpenedForCurrentUser(
 			return null;
 		}
 
-		return mapWorkspaceRow(
-			{
-				...workspace,
-				lastOpenedAt: membership.lastOpenedAt,
-			},
-			membership.role,
-		);
+		return mapWorkspaceRow(workspace, membership);
 	} finally {
 		await dbContext.dispose();
 	}
@@ -165,6 +155,7 @@ export async function updateWorkspaceForCurrentUser(
 
 		const [membership] = await transaction
 			.select({
+				archivedAt: workspaceMembers.archivedAt,
 				lastOpenedAt: workspaceMembers.lastOpenedAt,
 				role: workspaceMembers.role,
 			})
@@ -193,13 +184,53 @@ export async function updateWorkspaceForCurrentUser(
 		revision: update.revision,
 	});
 
-	const workspace = {
-		...update.updatedWorkspace,
-		lastOpenedAt: update.membership.lastOpenedAt,
-		membershipRole: update.membership.role,
-	};
+	return mapWorkspaceRow(update.updatedWorkspace, update.membership);
+}
 
-	return mapWorkspaceRow(workspace, workspace.membershipRole);
+export async function setWorkspaceArchiveStatusForCurrentUser(
+	input: SetWorkspaceArchiveStatusInput,
+): Promise<WorkspaceSummary> {
+	const userId = await getCurrentUserId();
+	const dbContext = await createDbContext();
+
+	try {
+		await assertCanReadWorkspace(dbContext.db, { workspaceId: input.workspaceId, userId });
+
+		return await dbContext.db.transaction(async (transaction) => {
+			const [membership] = await transaction
+				.update(workspaceMembers)
+				.set({ archivedAt: input.status === "archived" ? new Date() : null })
+				.where(
+					and(
+						eq(workspaceMembers.workspaceId, input.workspaceId),
+						eq(workspaceMembers.userId, userId),
+					),
+				)
+				.returning({
+					archivedAt: workspaceMembers.archivedAt,
+					lastOpenedAt: workspaceMembers.lastOpenedAt,
+					role: workspaceMembers.role,
+				});
+
+			if (!membership) {
+				throw new Error("Workspace membership was not found.");
+			}
+
+			const [workspace] = await transaction
+				.select()
+				.from(workspaces)
+				.where(and(eq(workspaces.id, input.workspaceId), isNull(workspaces.archivedAt)))
+				.limit(1);
+
+			if (!workspace) {
+				throw new Error("Workspace was not found.");
+			}
+
+			return mapWorkspaceRow(workspace, membership);
+		});
+	} finally {
+		await dbContext.dispose();
+	}
 }
 
 export async function deleteWorkspaceForCurrentUser(input: DeleteWorkspaceInput) {

--- a/src/features/workspaces/server/queries.ts
+++ b/src/features/workspaces/server/queries.ts
@@ -22,6 +22,7 @@ export async function listWorkspacesForUser(
 	const rows = await db
 		.select({
 			workspace: workspaces,
+			archivedAt: workspaceMembers.archivedAt,
 			lastOpenedAt: workspaceMembers.lastOpenedAt,
 			membershipRole: workspaceMembers.role,
 		})
@@ -34,13 +35,11 @@ export async function listWorkspacesForUser(
 		);
 
 	return rows.map((row) =>
-		mapWorkspaceRow(
-			{
-				...row.workspace,
-				lastOpenedAt: row.lastOpenedAt,
-			},
-			row.membershipRole,
-		),
+		mapWorkspaceRow(row.workspace, {
+			archivedAt: row.archivedAt,
+			lastOpenedAt: row.lastOpenedAt,
+			role: row.membershipRole,
+		}),
 	);
 }
 
@@ -80,6 +79,7 @@ async function getWorkspace(
 ): Promise<WorkspacePage["workspace"] | null> {
 	const [workspaceRow] = await db
 		.select({
+			archivedAt: workspaceMembers.archivedAt,
 			lastOpenedAt: workspaceMembers.lastOpenedAt,
 			membershipRole: workspaceMembers.role,
 			workspace: workspaces,
@@ -99,11 +99,9 @@ async function getWorkspace(
 		return null;
 	}
 
-	return mapWorkspaceRow(
-		{
-			...workspaceRow.workspace,
-			lastOpenedAt: workspaceRow.lastOpenedAt,
-		},
-		workspaceRow.membershipRole,
-	);
+	return mapWorkspaceRow(workspaceRow.workspace, {
+		archivedAt: workspaceRow.archivedAt,
+		lastOpenedAt: workspaceRow.lastOpenedAt,
+		role: workspaceRow.membershipRole,
+	});
 }

--- a/src/features/workspaces/use-create-workspace.ts
+++ b/src/features/workspaces/use-create-workspace.ts
@@ -52,7 +52,7 @@ export function useCreateWorkspaceMutation() {
 				createdAt: now,
 				updatedAt: now,
 				lastOpenedAt: now,
-				archivedAt: null,
+				archivedForCurrentUserAt: null,
 				membershipRole: "owner",
 			};
 
@@ -83,7 +83,7 @@ export function useCreateWorkspaceMutation() {
 		onError: (error, _variables, context) => {
 			// Navigate away from the phantom workspace first, then tear down its
 			// caches, so the user doesn't see a flash of skeleton before the redirect.
-			void navigate({ to: "/home" });
+			void navigate({ to: "/home", search: { view: undefined } });
 			restoreWorkspaceListCache(queryClient, context?.previousWorkspaces);
 
 			if (context?.id) {

--- a/src/features/workspaces/use-set-workspace-archive-status.ts
+++ b/src/features/workspaces/use-set-workspace-archive-status.ts
@@ -16,7 +16,7 @@ export function useSetWorkspaceArchiveStatusMutation() {
 		mutationFn: (input: SetWorkspaceArchiveStatusInput) =>
 			setWorkspaceArchiveStatus({ data: input }),
 		onMutate: async () => {
-			await queryClient.cancelQueries({ queryKey: workspacesQueryKey });
+			await queryClient.cancelQueries({ queryKey: workspacesQueryKey, exact: true });
 		},
 		onSuccess: (workspace, input) => {
 			updateWorkspaceInCaches(queryClient, workspace);

--- a/src/features/workspaces/use-set-workspace-archive-status.ts
+++ b/src/features/workspaces/use-set-workspace-archive-status.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useServerFn } from "@tanstack/react-start";
 import { toast } from "sonner";
 
+import { workspacesQueryKey } from "#/features/workspaces/cache-keys";
 import { updateWorkspaceInCaches } from "#/features/workspaces/cache-workspace";
 import type { SetWorkspaceArchiveStatusInput } from "#/features/workspaces/contracts";
 import { setWorkspaceArchiveStatusFn } from "#/features/workspaces/server/functions";
@@ -14,6 +15,9 @@ export function useSetWorkspaceArchiveStatusMutation() {
 	return useMutation({
 		mutationFn: (input: SetWorkspaceArchiveStatusInput) =>
 			setWorkspaceArchiveStatus({ data: input }),
+		onMutate: async () => {
+			await queryClient.cancelQueries({ queryKey: workspacesQueryKey });
+		},
 		onSuccess: (workspace, input) => {
 			updateWorkspaceInCaches(queryClient, workspace);
 			toast.success(input.status === "archived" ? "Workspace archived." : "Workspace restored.");

--- a/src/features/workspaces/use-set-workspace-archive-status.ts
+++ b/src/features/workspaces/use-set-workspace-archive-status.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useServerFn } from "@tanstack/react-start";
+import { toast } from "sonner";
+
+import { updateWorkspaceInCaches } from "#/features/workspaces/cache-workspace";
+import type { SetWorkspaceArchiveStatusInput } from "#/features/workspaces/contracts";
+import { setWorkspaceArchiveStatusFn } from "#/features/workspaces/server/functions";
+import { getErrorMessage } from "#/lib/error-message";
+
+export function useSetWorkspaceArchiveStatusMutation() {
+	const setWorkspaceArchiveStatus = useServerFn(setWorkspaceArchiveStatusFn);
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (input: SetWorkspaceArchiveStatusInput) =>
+			setWorkspaceArchiveStatus({ data: input }),
+		onSuccess: (workspace, input) => {
+			updateWorkspaceInCaches(queryClient, workspace);
+			toast.success(input.status === "archived" ? "Workspace archived." : "Workspace restored.");
+		},
+		onError: (error, input) => {
+			toast.error(
+				getErrorMessage(
+					error,
+					input.status === "archived"
+						? "Unable to archive workspace right now."
+						: "Unable to restore workspace right now.",
+				),
+			);
+		},
+	});
+}

--- a/src/routes/_protected/home.tsx
+++ b/src/routes/_protected/home.tsx
@@ -4,8 +4,12 @@ import { WorkspaceHomePage } from "#/features/workspaces/components/WorkspaceHom
 import { WorkspaceHomePageSkeleton } from "#/features/workspaces/components/WorkspaceHomePageSkeleton";
 import { workspacesQueryOptions } from "#/features/workspaces/query-options";
 
+interface WorkspaceHomeSearch {
+	view?: "archived";
+}
+
 export const Route = createFileRoute("/_protected/home")({
-	validateSearch: (search) => ({
+	validateSearch: (search): WorkspaceHomeSearch => ({
 		view: search.view === "archived" ? ("archived" as const) : undefined,
 	}),
 	loader: async ({ context }) => {

--- a/src/routes/_protected/home.tsx
+++ b/src/routes/_protected/home.tsx
@@ -5,6 +5,9 @@ import { WorkspaceHomePageSkeleton } from "#/features/workspaces/components/Work
 import { workspacesQueryOptions } from "#/features/workspaces/query-options";
 
 export const Route = createFileRoute("/_protected/home")({
+	validateSearch: (search) => ({
+		view: search.view === "archived" ? ("archived" as const) : undefined,
+	}),
 	loader: async ({ context }) => {
 		await context.queryClient.ensureQueryData(workspacesQueryOptions());
 	},


### PR DESCRIPTION
Old course workspaces clutter the active home view, but users still need a safe way to retain and revisit them. This adds personal archiving so each member can hide a workspace without affecting collaborators or deleting data.

## What was requested

- Let people archive old workspaces while keeping access to them.
- Put the archive view in the top-bar control area alongside search.
- Keep the empty state compact and provide clear archive/restore tooltips.

## Changes

- Store archive state on each workspace membership and expose it explicitly as `archivedForCurrentUserAt`.
- Add archive and restore controls to workspace cards for every member role.
- Add the route-backed `/home?view=archived` collection view with a muted top-bar filter button.
- Keep the archive filter reachable on mobile while hiding only the search input.
- Update caches only after successful mutations, avoiding unsafe optimistic rollbacks.
- Add a focused test proving the update is scoped by both workspace and current user.

## Testing

- `pnpm exec vp check` on the 12 changed TypeScript files
- `pnpm exec vp test --run src/features/workspaces/server/mutations.test.ts`
- `pnpm db:check`
- `git diff --check origin/main...HEAD`
- Manually verified archive, archived-view navigation, restore, URL persistence, and tooltips at `localhost:3000`

## Review Notes

Migration `0009_wild_blazing_skull` adds the nullable membership archive timestamp. Workspace-level `archivedAt` remains the separate deletion lifecycle field.

A full production build was not run; focused checks and the local end-to-end flow cover this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ThinkEx-OSS/codesmith/thinkex/pr/831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791054605&installation_model_id=425282&pr_number=831&repository=ThinkEx-OSS%2Fthinkex&return_to=https%3A%2F%2Fgithub.com%2FThinkEx-OSS%2Fthinkex%2Fpull%2F831&signature=c9150b2cd4b1c6981b1490030a591071a15bb36848ec433fd8ac2dc33930d3d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ThinkEx-OSS/thinkex/pull/831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-user workspace archiving and restoration.
  * Added an Active/Archived workspace view toggle with archived counts.
  * Added an empty-state message when no archived workspaces are available.
  * Added archive and restore controls to workspace cards, with success and error notifications.
* **Bug Fixes**
  * Workspace view navigation now preserves only valid archive-view selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->